### PR TITLE
test-rsa-sigs-on-certificate-verify - remove duplicate opt parsing

### DIFF
--- a/scripts/test-rsa-sigs-on-certificate-verify.py
+++ b/scripts/test-rsa-sigs-on-certificate-verify.py
@@ -70,17 +70,6 @@ def main():
                 text_cert = str(text_cert, 'utf-8')
             cert = X509()
             cert.parse(text_cert)
-        elif opt == '-k':
-            text_key = open(arg, 'rb').read()
-            if sys.version_info[0] >= 3:
-                text_key = str(text_key, 'utf-8')
-            private_key = parsePEMKey(text_key, private=True)
-        elif opt == '-c':
-            text_cert = open(arg, 'rb').read()
-            if sys.version_info[0] >= 3:
-                text_cert = str(text_cert, 'utf-8')
-            cert = X509()
-            cert.parse(text_cert)
         elif opt == '-h':
             host = arg
         elif opt == '-p':


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
remove duplicated parsers for `-k` and `-c` options

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

removal of dead code

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [X] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [X] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [X] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [X] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
  - n/a
- [X] new and modified scripts were ran against popular TLS implementations:
  - n/a
- [X] required version of tlslite-ng updated in requirements.txt and README.md
  - n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/393)
<!-- Reviewable:end -->
