### PR TITLE
Provide an option to disable record splitting

### DIFF
--- a/scripts/test-dhe-key-share-random.py
+++ b/scripts/test-dhe-key-share-random.py
@@ -42,6 +42,7 @@ def help_msg():
     print("                (excluding \"sanity\" tests)")
     print(" --repeat num   repeat every test num times to collect the values")
     print("                32 by default")
+    print(" -z             disable 1/n-1 record split for TLS1.0")
     print(" --help         this message")
 
 
@@ -52,9 +53,10 @@ def main():
     num_limit = None
     run_exclude = set()
     repeats = 32
+    record_split = True
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:n:", ["help", "repeat="])
+    opts, args = getopt.getopt(argv, "h:p:e:n:z", ["help", "repeat="])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -64,6 +66,8 @@ def main():
             run_exclude.add(arg)
         elif opt == '-n':
             num_limit = int(arg)
+        elif opt == '-z':
+            record_split = False
         elif opt == '--help':
             help_msg()
             sys.exit(0)
@@ -145,7 +149,7 @@ def main():
             node = node.add_child(ApplicationDataGenerator(
                 bytearray(b"GET / HTTP/1.0\n\n")))
             node = node.add_child(ExpectApplicationData())
-            if prot < (3, 2):
+            if prot < (3, 2) and record_split:
                 # 1/n-1 record splitting
                 node = node.add_child(ExpectApplicationData())
             node = node.add_child(AlertGenerator(AlertLevel.warning,

--- a/scripts/test-dhe-no-shared-secret-padding.py
+++ b/scripts/test-dhe-no-shared-secret-padding.py
@@ -43,6 +43,7 @@ def help_msg():
     print(" --min-zeros m  minimal number of zeros that have to be cut from")
     print("                shared secret for test case to be valid,")
     print("                1 by default")
+    print(" -z             disable 1/n-1 record split for TLS1.0")
     print(" --help         this message")
 
 
@@ -53,9 +54,10 @@ def main():
     num_limit = None
     run_exclude = set()
     min_zeros = 1
+    record_split = True
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:n:", ["help", "min-zeros="])
+    opts, args = getopt.getopt(argv, "h:p:e:n:z", ["help", "min-zeros="])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -65,6 +67,8 @@ def main():
             run_exclude.add(arg)
         elif opt == '-n':
             num_limit = int(arg)
+        elif opt == '-z':
+            record_split = False
         elif opt == '--help':
             help_msg()
             sys.exit(0)
@@ -143,7 +147,7 @@ def main():
             node = node.add_child(ApplicationDataGenerator(
                 bytearray(b"GET / HTTP/1.0\n\n")))
             node = node.add_child(ExpectApplicationData())
-            if prot < (3, 2):
+            if prot < (3, 2) and record_split:
                 # 1/n-1 record splitting
                 node = node.add_child(ExpectApplicationData())
             node = node.add_child(AlertGenerator(AlertLevel.warning,

--- a/scripts/test-ecdhe-padded-shared-secret.py
+++ b/scripts/test-ecdhe-padded-shared-secret.py
@@ -44,6 +44,7 @@ def help_msg():
     print(" --min-zeros m  minimal number of zeros that have to be cut from")
     print("                shared secret for test case to be valid,")
     print("                1 by default")
+    print(" -z             disable 1/n-1 record split for TLS1.0")
     print(" --help         this message")
 
 
@@ -54,9 +55,10 @@ def main():
     num_limit = None
     run_exclude = set()
     min_zeros = 1
+    record_split = True
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:n:", ["help", "min-zeros="])
+    opts, args = getopt.getopt(argv, "h:p:e:n:z", ["help", "min-zeros="])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -66,6 +68,8 @@ def main():
             run_exclude.add(arg)
         elif opt == '-n':
             num_limit = int(arg)
+        elif opt == '-z':
+            record_split = False
         elif opt == '--help':
             help_msg()
             sys.exit(0)
@@ -164,7 +168,7 @@ def main():
                 node = node.add_child(ApplicationDataGenerator(
                     bytearray(b"GET / HTTP/1.0\n\n")))
                 node = node.add_child(ExpectApplicationData())
-                if prot < (3, 2):
+                if prot < (3, 2) and record_split:
                     # 1/n-1 record splitting
                     node = node.add_child(ExpectApplicationData())
                 node = node.add_child(AlertGenerator(AlertLevel.warning,

--- a/scripts/test-ecdhe-rsa-key-share-random.py
+++ b/scripts/test-ecdhe-rsa-key-share-random.py
@@ -44,6 +44,7 @@ def help_msg():
     print("                (excluding \"sanity\" tests)")
     print(" --repeat num   repeat every test num times to collect the values")
     print("                32 by default")
+    print(" -z             disable 1/n-1 record split for TLS1.0")
     print(" --help         this message")
 
 
@@ -54,9 +55,10 @@ def main():
     num_limit = None
     run_exclude = set()
     repeats = 32
+    record_split = True
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:n:", ["help", "repeat="])
+    opts, args = getopt.getopt(argv, "h:p:e:n:z", ["help", "repeat="])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -69,6 +71,8 @@ def main():
         elif opt == '--help':
             help_msg()
             sys.exit(0)
+        elif opt == '-z':
+            record_split = False
         elif opt == '--repeat':
             repeats = int(arg)
         else:
@@ -170,7 +174,7 @@ def main():
                 node = node.add_child(ApplicationDataGenerator(
                     bytearray(b"GET / HTTP/1.0\n\n")))
                 node = node.add_child(ExpectApplicationData())
-                if prot < (3, 2):
+                if prot < (3, 2) and record_split:
                     # 1/n-1 record splitting
                     node = node.add_child(ExpectApplicationData())
                 node = node.add_child(AlertGenerator(AlertLevel.warning,

--- a/scripts/test-serverhello-random.py
+++ b/scripts/test-serverhello-random.py
@@ -42,6 +42,7 @@ def help_msg():
     print("                (excluding \"sanity\" tests)")
     print(" --repeat num   repeat every test num times to collect the values")
     print("                32 by default")
+    print(" -z             disable 1/n-1 record split for TLS1.0")
     print(" --help         this message")
 
 
@@ -52,9 +53,10 @@ def main():
     num_limit = None
     run_exclude = set()
     repeats = 32
+    record_split = True
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:n:", ["help", "repeat="])
+    opts, args = getopt.getopt(argv, "h:p:e:n:z", ["help", "repeat="])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -64,6 +66,8 @@ def main():
             run_exclude.add(arg)
         elif opt == '-n':
             num_limit = int(arg)
+        elif opt == '-z':
+            record_split = False
         elif opt == '--help':
             help_msg()
             sys.exit(0)
@@ -140,7 +144,7 @@ def main():
             node = node.add_child(ApplicationDataGenerator(
                 bytearray(b"GET / HTTP/1.0\n\n")))
             node = node.add_child(ExpectApplicationData())
-            if prot < (3, 2):
+            if prot < (3, 2) and record_split:
                 # 1/n-1 record splitting
                 node = node.add_child(ExpectApplicationData())
             node = node.add_child(AlertGenerator(AlertLevel.warning,


### PR DESCRIPTION
### Description
Some tests mandate record splitting although their primary test case is unrelated to it. This enables an implementation to use that test case even if it does not have record splitting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/588)
<!-- Reviewable:end -->
