### PR TITLE
test-fuzzed-padding.py: add -d for DH key exchange

### DIFF
--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -167,6 +167,8 @@
          {"name" : "test-fuzzed-finished.py"},
          {"name" : "test-fuzzed-MAC.py"},
          {"name" : "test-fuzzed-padding.py"},
+         {"name" : "test-fuzzed-padding.py",
+          "arguments" : ["-d"]},
          {"name" : "test-fuzzed-plaintext.py",
           "arguments" : ["-n", "80", "--random", "200"],
           "comment" : "--random to speed up initial test case creation"},

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -161,6 +161,8 @@
          {"name" : "test-fuzzed-finished.py"},
          {"name" : "test-fuzzed-MAC.py"},
          {"name" : "test-fuzzed-padding.py"},
+         {"name" : "test-fuzzed-padding.py",
+          "arguments" : ["-d"]},
          {"name" : "test-fuzzed-plaintext.py"},
          {"name" : "test-fuzzed-plaintext.py",
           "arguments" : ["-d"]},


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Add -d switch for test-fuzzed-padding.py which enables DH key exchange instead of RSA
### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
#563 
### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [x] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/589)
<!-- Reviewable:end -->
