### PR TITLE
fix py2/py3 compat with Unicode inputs

### DIFF
--- a/scripts/test-tls13-post-handshake-auth.py
+++ b/scripts/test-tls13-post-handshake-auth.py
@@ -32,6 +32,7 @@ from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, AutoEmptyExtension
 from tlslite.x509certchain import X509CertChain
 from tlslite.x509 import X509
 from tlslite.utils.keyfactory import parsePEMKey
+from tlslite.utils.compat import compatAscii2Bytes
 
 
 version = 3
@@ -116,7 +117,7 @@ def main():
         elif opt == '--cert-required':
             cert_required = True
         elif opt == '--query':
-            pha_query = arg
+            pha_query = compatAscii2Bytes(arg)
         elif opt == '--min-tickets':
             min_tickets = int(arg)
         elif opt == '-k':

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -313,7 +313,8 @@
          {"name" : "test-tls13-post-handshake-auth.py",
           "arguments" : ["-k", "tests/clientX509Key.pem",
                          "-c", "tests/clientX509Cert.pem",
-                         "--pha-as-reply"]
+                         "--pha-as-reply",
+                         "--query", "GET /secret HTTP/1.0\r\n\r\n"]
           },
          {"name" : "test-tls13-record-layer-limits.py"},
          {"name" : "test-tls13-record-padding.py"},


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
make the `--query` option work in python3

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
fix issue from https://gitlab.com/gnutls/gnutls/issues/868#note_277046798

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/635)
<!-- Reviewable:end -->
