### PR TITLE
skip bisect testing on python2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Install extract dependencies on py2.6
         if: ${{ contains(matrix.opt-deps, 'extract') && matrix.python-version == '2.6' }}
         run: |
-          pip install 'dpkt==1.9.2'
+          pip install -vvv 'dpkt==1.9.2'
       - name: Install extract dependencies on py2.7+
         if: ${{ contains(matrix.opt-deps, 'extract') && matrix.python-version != '2.6' }}
         run: |
@@ -223,7 +223,7 @@ jobs:
           pip install --upgrade pip
           pip install -r build-requirements-analysis.txt
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -vvv -r requirements.txt
       - name: Display installed python package versions
         run: pip list
       - name: Prepare Codeclimate environment
@@ -281,7 +281,10 @@ jobs:
           pylint --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" tlsfuzzer > pylint_report.txt || :
           diff-quality --violations=pylint --fail-under=90 pylint_report.txt
       - name: Verify that intermediate commits are testable
-        if: ${{ github.event.pull_request }}
+        # for some reason this takes a lot of time on Python 2.6, on the other
+        # hand, it's highly unlikely that anybody will bisect code on
+        # 2.6, so let's just skip it there
+        if: ${{ github.event.pull_request && matrix.python-version != '2.6' }}
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Disable bisect tests on python 2.6

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
Python2.6 tests on github actions are slow (30min vs 5min for other
versions), and most of the time is spent in the bisect run, so
disable it to improve the github workflow.

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/751)
<!-- Reviewable:end -->
