### PR TITLE
Corrected PEP 8: E305 expected 2 blank lines after class or function

### DIFF
--- a/scripts/test-SSLv3-padding.py
+++ b/scripts/test-SSLv3-padding.py
@@ -11,17 +11,16 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        fuzz_padding, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    fuzz_padding, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription
 from tlslite.utils.compat import compatAscii2Bytes
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 5
 
@@ -113,7 +112,7 @@ def main():
     node = node.add_child(ExpectClose())
 
     conversations["sanity"] = \
-            conversation
+        conversation
 
     # zero-fill SSLv3 padding
     conversation = Connect(host, port)
@@ -150,7 +149,7 @@ def main():
     node = node.add_child(ExpectClose())
 
     conversations["zero-filled padding in SSLv3"] = \
-            conversation
+        conversation
 
     # max size SSLv3 padding
     conversation = Connect(host, port)
@@ -172,7 +171,7 @@ def main():
     # make sure that padding has full block to work with
     assert (len(text) + hmac_tag_length) % block_size == 0
     node = node.add_child(fuzz_padding(ApplicationDataGenerator(text),
-                                       min_length=128//8))
+                                       min_length=128 // 8))
     node = node.add_child(ExpectApplicationData())
     # BEAST 1/n-1 splitting
     node = node.add_child(ExpectApplicationData())
@@ -184,7 +183,7 @@ def main():
     node = node.add_child(ExpectClose())
 
     conversations["max acceptable padding in SSLv3"] = \
-            conversation
+        conversation
 
     # too much padding in SSLv3
     conversation = Connect(host, port)
@@ -208,13 +207,13 @@ def main():
     node = node.add_child(fuzz_padding(ApplicationDataGenerator(text),
                                        # make the padding longer than the block
                                        # size of the cipher
-                                       min_length=(128//8)+1))
+                                       min_length=(128 // 8) + 1))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.bad_record_mac))
     node.add_child(ExpectClose())
 
     conversations["excessive padding in SSLv3 (valid in TLS 1.0)"] = \
-            conversation
+        conversation
 
     # max size SSLv3 padding
     conversation = Connect(host, port)
@@ -237,7 +236,7 @@ def main():
                 b"a" * (4096 - 9) + b"\r\n"
     text += b"X-ba3: " + b"a" * (4096 - 37) + b"\r\n"
     text += b"\r\n"
-    assert len(text) == 2**14, len(text)
+    assert len(text) == 2 ** 14, len(text)
     # as SSLv3 specifies that padding must be minimal length, that means
     # there is just one valid length of padding, no need to force it
     node = node.add_child(ApplicationDataGenerator(text))
@@ -252,8 +251,7 @@ def main():
     node = node.add_child(ExpectClose())
 
     conversations["max Application Data in SSLv3"] = \
-            conversation
-
+        conversation
 
     # run the conversation
     good = 0
@@ -272,7 +270,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -302,12 +300,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -326,14 +324,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -342,6 +340,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-TLSv1_2-rejected-without-TLSv1_2.py
+++ b/scripts/test-TLSv1_2-rejected-without-TLSv1_2.py
@@ -12,17 +12,16 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, \
+    ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 4
 
@@ -93,12 +92,12 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions={ExtensionType.
-                                                   renegotiation_info:None}))
+                                               renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(version=(3, 3),
                                             extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
-    #node = node.add_child(ExpectServerKeyExchange())
+    # node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
     node = node.add_child(ChangeCipherSpecGenerator())
@@ -122,12 +121,12 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                version=(3, 2),
                                                extensions={ExtensionType.
-                                                   renegotiation_info:None}))
+                                               renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(version=(3, 2),
                                             extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
-    #node = node.add_child(ExpectServerKeyExchange())
+    # node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
     node = node.add_child(ChangeCipherSpecGenerator())
@@ -152,13 +151,13 @@ def main():
         node = node.add_child(ClientHelloGenerator(ciphers,
                                                    version=(3, 2),
                                                    extensions={ExtensionType.
-                                                       renegotiation_info:None}))
+                                                   renegotiation_info: None}))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.handshake_failure))
         node.add_child(ExpectClose())
 
-        conversations[CipherSuite.ietfNames[cipher] + " in TLSv1.1"] =\
-                conversation
+        conversations[CipherSuite.ietfNames[cipher] + " in TLSv1.1"] = \
+            conversation
 
     # run the conversation
     good = 0
@@ -177,7 +176,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -207,12 +206,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -231,14 +230,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -247,6 +246,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-aes-gcm-nonces.py
+++ b/scripts/test-aes-gcm-nonces.py
@@ -11,18 +11,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        CollectNonces
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    CollectNonces
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.utils.cryptomath import bytesToNumber
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -106,13 +107,12 @@ def main():
     node.next_sibling = ExpectClose()
     conversations["sanity"] = conversation
 
-
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -137,8 +137,8 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -157,7 +157,6 @@ def main():
 
     conversations["aes-256-gcm cipher"] = conversation
 
-
     good = 0
     bad = 0
     xfail = 0
@@ -174,7 +173,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -204,12 +203,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -255,14 +254,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests) + 2))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests) + 2))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -271,6 +270,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-aesccm.py
+++ b/scripts/test-aesccm.py
@@ -11,17 +11,17 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_encrypted_message, PlaintextMessageGenerator, SetMaxRecordSize
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_encrypted_message, PlaintextMessageGenerator, SetMaxRecordSize
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ContentType, GroupName, ExtensionType
+    ContentType, GroupName, ExtensionType
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import SIG_ALL
 from tlsfuzzer.utils.lists import natural_sort_keys
 
@@ -97,7 +97,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -146,7 +146,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -180,7 +180,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -221,7 +221,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -263,7 +263,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -301,12 +301,12 @@ def main():
     # plaintext just under the maximum permissible
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ext = {}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -331,9 +331,9 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     data = bytearray(b"GET / HTTP/1.0\r\n" +
-                     b"X-test: " + b"A" * (2**14 - 28) +
+                     b"X-test: " + b"A" * (2 ** 14 - 28) +
                      b"\r\n\r\n")
-    assert len(data) == 2**14
+    assert len(data) == 2 ** 14
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
@@ -350,12 +350,12 @@ def main():
     # plaintext over the maximum permissible
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ext = {}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -380,9 +380,9 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     data = bytearray(b"GET / HTTP/1.0\r\n" +
-                     b"X-test: " + b"A" * (2**14 - 28) +
+                     b"X-test: " + b"A" * (2 ** 14 - 28) +
                      b"\r\n\r\n")
-    assert len(data) == 2**14
+    assert len(data) == 2 ** 14
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
@@ -398,12 +398,12 @@ def main():
 
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ext = {}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -428,9 +428,9 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     data = bytearray(b"GET / HTTP/1.0\r\n" +
-                     b"X-test: " + b"A" * (2**14 - 28 + 1) +
+                     b"X-test: " + b"A" * (2 ** 14 - 28 + 1) +
                      b"\r\n\r\n")
-    assert len(data) == 2**14 + 1
+    assert len(data) == 2 ** 14 + 1
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       [AlertDescription.decompression_failure,
@@ -440,12 +440,12 @@ def main():
 
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ext = {}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -470,9 +470,9 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     data = bytearray(b"GET / HTTP/1.0\r\n" +
-                     b"X-test: " + b"A" * (2**14 - 28 + 1) +
+                     b"X-test: " + b"A" * (2 ** 14 - 28 + 1) +
                      b"\r\n\r\n")
-    assert len(data) == 2**14 + 1
+    assert len(data) == 2 ** 14 + 1
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       [AlertDescription.decompression_failure,
@@ -482,12 +482,12 @@ def main():
 
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ext = {}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -512,9 +512,9 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     data = bytearray(b"GET / HTTP/1.0\r\n" +
-                     b"X-test: " + b"A" * (2**14 + 1024 - 28) +
+                     b"X-test: " + b"A" * (2 ** 14 + 1024 - 28) +
                      b"\r\n\r\n")
-    assert len(data) == 2**14 + 1024
+    assert len(data) == 2 ** 14 + 1024
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       [AlertDescription.decompression_failure,
@@ -524,12 +524,12 @@ def main():
 
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ext = {}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -554,9 +554,9 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     data = bytearray(b"GET / HTTP/1.0\r\n" +
-                     b"X-test: " + b"A" * (2**14 + 1024 - 28) +
+                     b"X-test: " + b"A" * (2 ** 14 + 1024 - 28) +
                      b"\r\n\r\n")
-    assert len(data) == 2**14 + 1024
+    assert len(data) == 2 ** 14 + 1024
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       [AlertDescription.decompression_failure,
@@ -566,12 +566,12 @@ def main():
 
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ext = {}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -596,9 +596,9 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     data = bytearray(b"GET / HTTP/1.0\r\n" +
-                     b"X-test: " + b"A" * (2**14 + 1024 - 28 + 1) +
+                     b"X-test: " + b"A" * (2 ** 14 + 1024 - 28 + 1) +
                      b"\r\n\r\n")
-    assert len(data) == 2**14 + 1024 + 1
+    assert len(data) == 2 ** 14 + 1024 + 1
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.record_overflow))
@@ -607,12 +607,12 @@ def main():
 
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ext = {}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -637,9 +637,9 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     data = bytearray(b"GET / HTTP/1.0\r\n" +
-                     b"X-test: " + b"A" * (2**14 + 1024 - 28 + 1) +
+                     b"X-test: " + b"A" * (2 ** 14 + 1024 - 28 + 1) +
                      b"\r\n\r\n")
-    assert len(data) == 2**14 + 1024 + 1
+    assert len(data) == 2 ** 14 + 1024 + 1
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.record_overflow))
@@ -649,14 +649,14 @@ def main():
     # fuzz the tag (last 16 bytes or last 8 bytes in case of _8 ciphers)
     for n in [17, 9]:
         for val in [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80]:
-            for pos in range(-1, -n, -1): 
+            for pos in range(-1, -n, -1):
                 conversation = Connect(host, port)
                 node = conversation
                 ext = {}
                 if dhe:
                     groups = [GroupName.secp256r1,
                               GroupName.ffdhe2048]
-                    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+                    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                         .create(groups)
                     ext[ExtensionType.signature_algorithms] = \
                         SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -687,12 +687,12 @@ def main():
                 node = node.add_child(ExpectFinished())
                 msg = ApplicationDataGenerator(
                     bytearray(b"GET / HTTP/1.0\r\n\r\n"))
-                node = node.add_child(fuzz_encrypted_message(msg, xors={pos:val}))
+                node = node.add_child(fuzz_encrypted_message(msg, xors={pos: val}))
                 node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                                   AlertDescription.bad_record_mac))
                 node.add_child(ExpectClose())
-                conversations["fuzz tag with {0} on pos {1} - using cipher with {2} byte tag".format(val, pos, n-1)] \
-                        = conversation
+                conversations["fuzz tag with {0} on pos {1} - using cipher with {2} byte tag".format(val, pos, n - 1)] \
+                    = conversation
 
     # too small message handling
     for val in range(16):
@@ -702,7 +702,7 @@ def main():
         if dhe:
             groups = [GroupName.secp256r1,
                       GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -728,13 +728,13 @@ def main():
         node = node.add_child(ExpectFinished())
         # any byte value will do, a1 chosen at random
         msg = PlaintextMessageGenerator(ContentType.application_data,
-                                        bytearray([0xa1]*val))
+                                        bytearray([0xa1] * val))
         node = node.add_child(msg)
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.bad_record_mac))
         node.add_child(ExpectClose())
         conversations["{0} bytes long ciphertext".format(val)] \
-                = conversation
+            = conversation
 
     # too small message handling against _8 ciphers
     for val in range(8):
@@ -744,7 +744,7 @@ def main():
         if dhe:
             groups = [GroupName.secp256r1,
                       GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -770,13 +770,13 @@ def main():
         node = node.add_child(ExpectFinished())
         # any byte value will do, a1 chosen at random
         msg = PlaintextMessageGenerator(ContentType.application_data,
-                                        bytearray([0xa1]*val))
+                                        bytearray([0xa1] * val))
         node = node.add_child(msg)
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.bad_record_mac))
         node.add_child(ExpectClose())
         conversations["{0} bytes long ciphertext against _8 ciphers".format(val)] \
-                = conversation
+            = conversation
 
     # run the conversation
     good = 0
@@ -795,7 +795,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -825,12 +825,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -848,14 +848,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -864,6 +864,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-alpn-negotiation.py
+++ b/scripts/test-alpn-negotiation.py
@@ -10,23 +10,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_message, ResetHandshakeHashes, Close, ResetRenegotiationInfo
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_message, ResetHandshakeHashes, Close, ResetRenegotiationInfo
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType, SignatureScheme
+    GroupName, ExtensionType, SignatureScheme
 from tlslite.extensions import ALPNExtension, TLSExtension, \
-        SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
 from tlsfuzzer.utils.ordered_dict import OrderedDict
-
 
 version = 4
 
@@ -55,7 +54,7 @@ def help_msg():
 def add_dhe_extensions(extensions):
     groups = [GroupName.secp256r1,
               GroupName.ffdhe2048]
-    extensions[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    extensions[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     extensions[ExtensionType.signature_algorithms] = \
         SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -111,7 +110,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(
@@ -378,7 +377,7 @@ def main():
     node = conversation
 
     ext = {ExtensionType.alpn: ALPNExtension().create([bytearray(b'http/1.1')]),
-           ExtensionType.renegotiation_info:None}
+           ExtensionType.renegotiation_info: None}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -401,7 +400,7 @@ def main():
     # 2nd handshake
     node = node.add_child(ResetHandshakeHashes())
     ext = {ExtensionType.alpn: ALPNExtension().create([bytearray(b'http/2')]),
-           ExtensionType.renegotiation_info:None}
+           ExtensionType.renegotiation_info: None}
     if dhe:
         add_dhe_extensions(ext)
     node = node.add_child(ClientHelloGenerator(ciphers, session_id=bytearray(0), extensions=ext))
@@ -429,7 +428,7 @@ def main():
     node = conversation
 
     ext = {ExtensionType.alpn: ALPNExtension().create([bytearray(b'http/1.1')]),
-           ExtensionType.renegotiation_info:None}
+           ExtensionType.renegotiation_info: None}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -452,7 +451,7 @@ def main():
     # 2nd handshake
     node = node.add_child(ResetHandshakeHashes())
     ext = {ExtensionType.alpn: ALPNExtension().create([bytearray(b'http/1.1')]),
-           ExtensionType.renegotiation_info:None}
+           ExtensionType.renegotiation_info: None}
     if dhe:
         add_dhe_extensions(ext)
     node = node.add_child(ClientHelloGenerator(ciphers, session_id=bytearray(0), extensions=ext))
@@ -478,7 +477,7 @@ def main():
     # renegotiation 2nd handshake alpn
     conversation = Connect(host, port)
     node = conversation
-    ext = {ExtensionType.renegotiation_info:None}
+    ext = {ExtensionType.renegotiation_info: None}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -500,7 +499,7 @@ def main():
     # 2nd handshake
     node = node.add_child(ResetHandshakeHashes())
     ext = {ExtensionType.alpn: ALPNExtension().create([bytearray(b'http/1.1')]),
-           ExtensionType.renegotiation_info:None}
+           ExtensionType.renegotiation_info: None}
     if dhe:
         add_dhe_extensions(ext)
     node = node.add_child(ClientHelloGenerator(ciphers, session_id=bytearray(0), extensions=ext))
@@ -527,7 +526,7 @@ def main():
     conversation = Connect(host, port)
     node = conversation
     ext = {ExtensionType.alpn: ALPNExtension().create([bytearray(b'http/1.1')]),
-           ExtensionType.renegotiation_info:None}
+           ExtensionType.renegotiation_info: None}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -560,11 +559,11 @@ def main():
     node = node.add_child(ResetHandshakeHashes())
     node = node.add_child(ResetRenegotiationInfo())
     ext = {ExtensionType.alpn: ALPNExtension().create([bytearray(b'http/1.1')]),
-           ExtensionType.renegotiation_info:None}
+           ExtensionType.renegotiation_info: None}
     if dhe:
         add_dhe_extensions(ext)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-    ext = {ExtensionType.renegotiation_info:None,
+    ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.alpn: ALPNExtension().create([bytearray(b'http/1.1')])}
     node = node.add_child(ExpectServerHello(extensions=ext, resume=True))
     node = node.add_child(ExpectChangeCipherSpec())
@@ -583,7 +582,7 @@ def main():
     conversation = Connect(host, port)
     node = conversation
     ext = {ExtensionType.alpn: ALPNExtension().create([bytearray(b'http/1.1')]),
-           ExtensionType.renegotiation_info:None}
+           ExtensionType.renegotiation_info: None}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -616,11 +615,11 @@ def main():
     node = node.add_child(ResetHandshakeHashes())
     node = node.add_child(ResetRenegotiationInfo())
     ext = {ExtensionType.alpn: ALPNExtension().create([bytearray(b'h2')]),
-           ExtensionType.renegotiation_info:None}
+           ExtensionType.renegotiation_info: None}
     if dhe:
         add_dhe_extensions(ext)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-    ext = {ExtensionType.renegotiation_info:None,
+    ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.alpn: ALPNExtension().create([bytearray(b'h2')])}
     node = node.add_child(ExpectServerHello(extensions=ext, resume=True))
     node = node.add_child(ExpectChangeCipherSpec())
@@ -638,7 +637,7 @@ def main():
     # resumption with alpn
     conversation = Connect(host, port)
     node = conversation
-    ext = {ExtensionType.renegotiation_info:None}
+    ext = {ExtensionType.renegotiation_info: None}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -670,11 +669,11 @@ def main():
     node = node.add_child(ResetHandshakeHashes())
     node = node.add_child(ResetRenegotiationInfo())
     ext = {ExtensionType.alpn: ALPNExtension().create([bytearray(b'http/1.1')]),
-           ExtensionType.renegotiation_info:None}
+           ExtensionType.renegotiation_info: None}
     if dhe:
         add_dhe_extensions(ext)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-    ext = {ExtensionType.renegotiation_info:None,
+    ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.alpn: ALPNExtension().create([bytearray(b'http/1.1')])}
     node = node.add_child(ExpectServerHello(extensions=ext, resume=True))
     node = node.add_child(ExpectChangeCipherSpec())
@@ -712,7 +711,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(
@@ -762,7 +761,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -792,12 +791,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -817,14 +816,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -833,6 +832,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-atypical-padding.py
+++ b/scripts/test-atypical-padding.py
@@ -11,22 +11,21 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        fuzz_padding, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    fuzz_padding, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData, \
+    ExpectServerKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL, AutoEmptyExtension
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType
+    GroupName, ExtensionType
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlslite.utils.compat import compatAscii2Bytes
-
 
 version = 5
 
@@ -58,13 +57,12 @@ def help_msg():
 def add_dhe_extensions(extensions):
     groups = [GroupName.secp256r1,
               GroupName.ffdhe2048]
-    extensions[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    extensions[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     extensions[ExtensionType.signature_algorithms] = \
         SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
     extensions[ExtensionType.signature_algorithms_cert] = \
         SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
-
 
 
 def main():
@@ -217,8 +215,8 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-    extensions = {ExtensionType.encrypt_then_mac:None,
-                  ExtensionType.renegotiation_info:None}
+    extensions = {ExtensionType.encrypt_then_mac: None,
+                  ExtensionType.renegotiation_info: None}
     node = node.add_child(ExpectServerHello(extensions=extensions))
     node = node.add_child(ExpectCertificate())
     if dhe:
@@ -278,7 +276,7 @@ def main():
     node = node.add_child(ExpectClose())
 
     conversations["256 bytes of padding"] = \
-            conversation
+        conversation
 
     # maximum size of padding with SHA256
     conversation = Connect(host, port)
@@ -320,7 +318,7 @@ def main():
     node = node.add_child(ExpectClose())
 
     conversations["256 bytes of padding with SHA256"] = \
-            conversation
+        conversation
 
     # ... and SHA384
     conversation = Connect(host, port)
@@ -328,7 +326,7 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1,
               GroupName.ffdhe2048]
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ext[ExtensionType.signature_algorithms] = \
         SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -359,7 +357,7 @@ def main():
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["256 bytes of padding with SHA384"] = \
-            conversation
+        conversation
 
     # longest possible padding with max size Application data
     conversation = Connect(host, port)
@@ -391,11 +389,11 @@ def main():
                 b"a" * (4096 - 9) + b"\r\n"
     text += b"X-ba3: " + b"a" * (4096 - 37) + b"\r\n"
     text += b"\r\n"
-    assert len(text) == 2**14, len(text)
+    assert len(text) == 2 ** 14, len(text)
     node = node.add_child(fuzz_padding(ApplicationDataGenerator(text),
                                        min_length=252))
     if echo:
-        node = node.add_child(ExpectApplicationData(size=2**14))
+        node = node.add_child(ExpectApplicationData(size=2 ** 14))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
@@ -405,7 +403,7 @@ def main():
     node = node.add_child(ExpectClose())
 
     conversations["2^14 bytes of AppData with 253 bytes of padding (SHA1)"] = \
-            conversation
+        conversation
 
     # longest possible padding with max size Application data (and EtM)
     conversation = Connect(host, port)
@@ -420,8 +418,8 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-    extensions = {ExtensionType.encrypt_then_mac:None,
-                  ExtensionType.renegotiation_info:None}
+    extensions = {ExtensionType.encrypt_then_mac: None,
+                  ExtensionType.renegotiation_info: None}
     node = node.add_child(ExpectServerHello(extensions=extensions))
     node = node.add_child(ExpectCertificate())
     if dhe:
@@ -438,11 +436,11 @@ def main():
                 b"a" * (4096 - 9) + b"\r\n"
     text += b"X-ba3: " + b"a" * (4096 - 37) + b"\r\n"
     text += b"\r\n"
-    assert len(text) == 2**14, len(text)
+    assert len(text) == 2 ** 14, len(text)
     node = node.add_child(fuzz_padding(ApplicationDataGenerator(text),
                                        min_length=255))
     if echo:
-        node = node.add_child(ExpectApplicationData(size=2**14))
+        node = node.add_child(ExpectApplicationData(size=2 ** 14))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
@@ -453,7 +451,7 @@ def main():
 
     conversations["2^14 bytes of AppData with 256 bytes of padding (SHA1 "
                   "+ Encrypt then MAC)"] = \
-            conversation
+        conversation
 
     # longest possible padding with max size Application data with SHA256
     conversation = Connect(host, port)
@@ -485,11 +483,11 @@ def main():
                 b"a" * (4096 - 9) + b"\r\n"
     text += b"X-ba3: " + b"a" * (4096 - 37) + b"\r\n"
     text += b"\r\n"
-    assert len(text) == 2**14, len(text)
+    assert len(text) == 2 ** 14, len(text)
     node = node.add_child(fuzz_padding(ApplicationDataGenerator(text),
                                        min_length=255))
     if echo:
-        node = node.add_child(ExpectApplicationData(size=2**14))
+        node = node.add_child(ExpectApplicationData(size=2 ** 14))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
@@ -499,7 +497,7 @@ def main():
     node = node.add_child(ExpectClose())
 
     conversations["2^14 bytes of AppData with 256 bytes of padding (SHA256)"] = \
-            conversation
+        conversation
 
     conversation = Connect(host, port)
     node = conversation
@@ -523,18 +521,18 @@ def main():
                 b"a" * (4096 - 9) + b"\r\n"
     text += b"X-ba3: " + b"a" * (4096 - 37) + b"\r\n"
     text += b"\r\n"
-    assert len(text) == 2**14, len(text)
+    assert len(text) == 2 ** 14, len(text)
     node = node.add_child(fuzz_padding(ApplicationDataGenerator(text),
                                        min_length=255))
     if echo:
-        node = node.add_child(ExpectApplicationData(size=2**14))
+        node = node.add_child(ExpectApplicationData(size=2 ** 14))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["2^14 bytes of AppData with 256 bytes of padding (SHA384)"] = \
-            conversation
+        conversation
 
     # run the conversation
     good = 0
@@ -553,7 +551,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -583,12 +581,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -608,14 +606,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -624,6 +622,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-bleichenbacher-workaround.py
+++ b/scripts/test-bleichenbacher-workaround.py
@@ -10,20 +10,21 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        TCPBufferingEnable, TCPBufferingDisable, TCPBufferingFlush
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    TCPBufferingEnable, TCPBufferingDisable, TCPBufferingFlush
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData, ExpectNoMessage
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData, ExpectNoMessage
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.utils.dns_utils import is_valid_hostname
 from tlslite.extensions import SNIExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -69,13 +70,13 @@ def main():
     timeout = 1.0
     alert = AlertDescription.bad_record_mac
     level = AlertLevel.fatal
-    srv_extensions = {ExtensionType.renegotiation_info:None}
+    srv_extensions = {ExtensionType.renegotiation_info: None}
     no_sni = False
 
     argv = sys.argv[1:]
     opts, args = getopt.getopt(argv, "h:p:e:x:X:t:n:a:l:", ["help",
-                                                        "no-safe-renego",
-                                                        "no-sni"])
+                                                            "no-safe-renego",
+                                                            "no-sni"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -113,10 +114,10 @@ def main():
     else:
         run_only = None
 
-    cln_extensions = {ExtensionType.renegotiation_info:None}
+    cln_extensions = {ExtensionType.renegotiation_info: None}
     if is_valid_hostname(host) and not no_sni:
         cln_extensions[ExtensionType.server_name] = \
-                SNIExtension().create(bytearray(host, 'ascii'))
+            SNIExtension().create(bytearray(host, 'ascii'))
 
     conversations = {}
 
@@ -186,7 +187,7 @@ def main():
                                         AlertDescription.handshake_failure)
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={2:1}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={2: 1}))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ExpectChangeCipherSpec())
@@ -199,7 +200,8 @@ def main():
         node.next_sibling = ExpectClose()
         node = node.add_child(ExpectClose())
 
-        conversations["static non-zero byte in random padding - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations[
+            "static non-zero byte in random padding - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
 
         # set 2nd byte of padding to 3 (invalid value)
         conversation = Connect(host, port)
@@ -215,7 +217,7 @@ def main():
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={1:3}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={1: 3}))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -240,7 +242,7 @@ def main():
                                         AlertDescription.handshake_failure)
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={1:3}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={1: 3}))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -249,7 +251,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["set PKCS#1 padding type to 3 - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations[
+            "set PKCS#1 padding type to 3 - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
 
         # set 2nd byte of padding to 1 (signing)
         conversation = Connect(host, port)
@@ -265,7 +268,7 @@ def main():
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={1:1}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={1: 1}))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -290,7 +293,7 @@ def main():
                                         AlertDescription.handshake_failure)
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={1:1}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={1: 1}))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -299,7 +302,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["set PKCS#1 padding type to 1 - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations[
+            "set PKCS#1 padding type to 1 - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
 
         # test early zero in random data
         conversation = Connect(host, port)
@@ -315,7 +319,7 @@ def main():
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={4:0}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={4: 0}))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -340,7 +344,7 @@ def main():
                                         AlertDescription.handshake_failure)
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={4:0}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={4: 0}))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -349,7 +353,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["zero byte in random padding - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations[
+            "zero byte in random padding - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
 
         # check if early padding separator is detected
         conversation = Connect(host, port)
@@ -365,7 +370,7 @@ def main():
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-2:0}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-2: 0}))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -375,7 +380,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["zero byte in last byte of random padding - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations[
+            "zero byte in last byte of random padding - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
 
         # check if early padding separator is detected
         conversation = Connect(host, port)
@@ -390,7 +396,7 @@ def main():
                                         AlertDescription.handshake_failure)
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-2:0}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-2: 0}))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -399,7 +405,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["zero byte in last byte of random padding - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations["zero byte in last byte of random padding - with wait - {0}".format(
+            CipherSuite.ietfNames[cipher])] = conversation
 
         # check if separator without any random padding is detected
         conversation = Connect(host, port)
@@ -415,7 +422,7 @@ def main():
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={2:0}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={2: 0}))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -425,7 +432,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["zero byte in first byte of random padding - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations[
+            "zero byte in first byte of random padding - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
 
         # check if separator without any random padding is detected
         conversation = Connect(host, port)
@@ -440,7 +448,7 @@ def main():
                                         AlertDescription.handshake_failure)
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={2:0}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={2: 0}))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -449,7 +457,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["zero byte in first byte of random padding - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations["zero byte in first byte of random padding - with wait - {0}".format(
+            CipherSuite.ietfNames[cipher])] = conversation
 
         # check if invalid first byte of encoded value is correctly detecte
         conversation = Connect(host, port)
@@ -465,7 +474,7 @@ def main():
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={0:1}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={0: 1}))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -490,7 +499,7 @@ def main():
                                         AlertDescription.handshake_failure)
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={0:1}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={0: 1}))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -499,7 +508,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["invalid version number in padding - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations[
+            "invalid version number in padding - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
 
         # check if no null separator in padding is detected
         conversation = Connect(host, port)
@@ -515,7 +525,7 @@ def main():
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1:1}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1: 1}))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -540,7 +550,7 @@ def main():
                                         AlertDescription.handshake_failure)
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1:1}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1: 1}))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -549,7 +559,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["no null separator in padding - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations[
+            "no null separator in padding - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
 
         # check if no null separator in padding is detected
         # but with PMS set to non-zero
@@ -566,8 +577,8 @@ def main():
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1:1},
-                                                         premaster_secret=bytearray([1]*48)))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1: 1},
+                                                         premaster_secret=bytearray([1] * 48)))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -593,8 +604,8 @@ def main():
                                         AlertDescription.handshake_failure)
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1:1},
-                                                         premaster_secret=bytearray([1]*48)))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1: 1},
+                                                         premaster_secret=bytearray([1] * 48)))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -603,7 +614,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["no null separator in encrypted value - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations["no null separator in encrypted value - with wait - {0}".format(
+            CipherSuite.ietfNames[cipher])] = conversation
 
         # check if too short PMS is detected
         conversation = Connect(host, port)
@@ -653,7 +665,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["two byte long PMS (TLS version only) - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations["two byte long PMS (TLS version only) - with wait - {0}".format(
+            CipherSuite.ietfNames[cipher])] = conversation
 
         # check if no encrypted payload is detected
         conversation = Connect(host, port)
@@ -671,7 +684,7 @@ def main():
         node = node.add_child(TCPBufferingEnable())
         # the TLS version is always set, so we mask the real padding separator
         # and set the last byte of PMS to 0
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1:1},
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1: 1},
                                                          premaster_secret=bytearray([1, 1, 0])))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
@@ -699,7 +712,7 @@ def main():
         node = node.add_child(ExpectServerHelloDone())
         # the TLS version is always set, so we mask the real padding separator
         # and set the last byte of PMS to 0
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1:1},
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1: 1},
                                                          premaster_secret=bytearray([1, 1, 0])))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
@@ -727,7 +740,7 @@ def main():
         node = node.add_child(TCPBufferingEnable())
         # the TLS version is always set, so we mask the real padding separator
         # and set the last byte of PMS to 0
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1:1},
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1: 1},
                                                          premaster_secret=bytearray([1, 1, 0, 3])))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
@@ -755,7 +768,7 @@ def main():
         node = node.add_child(ExpectServerHelloDone())
         # the TLS version is always set, so we mask the real padding separator
         # and set the last byte of PMS to 0
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1:1},
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={-1: 1},
                                                          premaster_secret=bytearray([1, 1, 0, 3])))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
@@ -781,7 +794,7 @@ def main():
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
-        node = node.add_child(ClientKeyExchangeGenerator(premaster_secret=bytearray([1]*47)))
+        node = node.add_child(ClientKeyExchangeGenerator(premaster_secret=bytearray([1] * 47)))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -791,7 +804,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["too short (47-byte) pre master secret - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations[
+            "too short (47-byte) pre master secret - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
 
         # check if too short PMS is detected
         conversation = Connect(host, port)
@@ -806,7 +820,7 @@ def main():
                                         AlertDescription.handshake_failure)
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
-        node = node.add_child(ClientKeyExchangeGenerator(premaster_secret=bytearray([1]*47)))
+        node = node.add_child(ClientKeyExchangeGenerator(premaster_secret=bytearray([1] * 47)))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -815,7 +829,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["too short (47-byte) pre master secret - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations["too short (47-byte) pre master secret - with wait - {0}".format(
+            CipherSuite.ietfNames[cipher])] = conversation
 
         # check if too short PMS is detected
         conversation = Connect(host, port)
@@ -831,7 +846,7 @@ def main():
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
-        node = node.add_child(ClientKeyExchangeGenerator(premaster_secret=bytearray([1]*4)))
+        node = node.add_child(ClientKeyExchangeGenerator(premaster_secret=bytearray([1] * 4)))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -841,7 +856,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["very short (4-byte) pre master secret - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations[
+            "very short (4-byte) pre master secret - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
 
         # check if too short PMS is detected
         conversation = Connect(host, port)
@@ -856,7 +872,7 @@ def main():
                                         AlertDescription.handshake_failure)
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
-        node = node.add_child(ClientKeyExchangeGenerator(premaster_secret=bytearray([1]*4)))
+        node = node.add_child(ClientKeyExchangeGenerator(premaster_secret=bytearray([1] * 4)))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -865,8 +881,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["very short (4-byte) pre master secret - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
-
+        conversations["very short (4-byte) pre master secret - with wait - {0}".format(
+            CipherSuite.ietfNames[cipher])] = conversation
 
         # check if too long PMS is detected
         conversation = Connect(host, port)
@@ -882,7 +898,7 @@ def main():
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
-        node = node.add_child(ClientKeyExchangeGenerator(premaster_secret=bytearray([1]*49)))
+        node = node.add_child(ClientKeyExchangeGenerator(premaster_secret=bytearray([1] * 49)))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -907,7 +923,7 @@ def main():
                                         AlertDescription.handshake_failure)
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
-        node = node.add_child(ClientKeyExchangeGenerator(premaster_secret=bytearray([1]*49)))
+        node = node.add_child(ClientKeyExchangeGenerator(premaster_secret=bytearray([1] * 49)))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -916,7 +932,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["too long (49-byte) pre master secret - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations["too long (49-byte) pre master secret - with wait - {0}".format(
+            CipherSuite.ietfNames[cipher])] = conversation
 
         # check if wrong TLS version number is rejected
         conversation = Connect(host, port)
@@ -942,7 +959,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["wrong TLS version (2, 2) in pre master secret - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations[
+            "wrong TLS version (2, 2) in pre master secret - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
 
         # check if wrong TLS version number is rejected
         conversation = Connect(host, port)
@@ -966,7 +984,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["wrong TLS version (2, 2) in pre master secret - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations["wrong TLS version (2, 2) in pre master secret - with wait - {0}".format(
+            CipherSuite.ietfNames[cipher])] = conversation
 
         # check if wrong TLS version number is rejected
         conversation = Connect(host, port)
@@ -992,7 +1011,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["wrong TLS version (0, 0) in pre master secret - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations[
+            "wrong TLS version (0, 0) in pre master secret - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
 
         # check if wrong TLS version number is rejected
         conversation = Connect(host, port)
@@ -1016,7 +1036,8 @@ def main():
                                           alert))
         node.add_child(ExpectClose())
 
-        conversations["wrong TLS version (0, 0) in pre master secret - with wait - {0}".format(CipherSuite.ietfNames[cipher])] = conversation
+        conversations["wrong TLS version (0, 0) in pre master secret - with wait - {0}".format(
+            CipherSuite.ietfNames[cipher])] = conversation
 
         # check if too short PKCS padding is detected
         conversation = Connect(host, port)
@@ -1035,7 +1056,7 @@ def main():
         # move the start of the padding forward, essentially encrypting two 0 bytes
         # at the beginning of the padding, but since those are transformed into a number
         # their existence is lost and it just like the padding was too small
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={1:0, 2:2}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={1: 0, 2: 2}))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -1063,7 +1084,7 @@ def main():
         # move the start of the padding forward, essentially encrypting two 0 bytes
         # at the beginning of the padding, but since those are transformed into a number
         # their existence is lost and it just like the padding was too small
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={1:0, 2:2}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={1: 0, 2: 2}))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -1091,7 +1112,7 @@ def main():
         # move the start of the padding backward, essentially encrypting no 0 bytes
         # at the beginning of the padding, but since those are transformed into a number
         # its lack is lost and it just like the padding was too big
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={0:2}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={0: 2}))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n")))
@@ -1119,7 +1140,7 @@ def main():
         # move the start of the padding backward, essentially encrypting no 0 bytes
         # at the beginning of the padding, but since those are transformed into a number
         # its lack is lost and it just like the padding was too big
-        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={0:2}))
+        node = node.add_child(ClientKeyExchangeGenerator(padding_subs={0: 2}))
         node = node.add_child(ExpectNoMessage(timeout))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(ExpectNoMessage(timeout))
@@ -1174,12 +1195,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -1195,14 +1216,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -1211,6 +1232,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-certificate-malformed.py
+++ b/scripts/test-certificate-malformed.py
@@ -11,29 +11,29 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        AlertGenerator, pad_handshake, TCPBufferingEnable, \
-        TCPBufferingDisable, TCPBufferingFlush, truncate_handshake, \
-        fuzz_message
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    AlertGenerator, pad_handshake, TCPBufferingEnable, \
+    TCPBufferingDisable, TCPBufferingFlush, truncate_handshake, \
+    fuzz_message
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsCertExtension
 from tlslite.constants import CipherSuite, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, AlertLevel, \
-        AlertDescription, ContentType
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, AlertLevel, \
+    AlertDescription, ContentType
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 from tlsfuzzer.helpers import RSA_SIG_ALL
 from tlsfuzzer.utils.lists import natural_sort_keys
 
-
 version = 3
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -55,7 +55,6 @@ def help_msg():
     print(" -k file.pem    file with private key for client")
     print(" -c file.pem    file with certificate for client")
     print(" --help         this message")
-
 
 
 def main():
@@ -120,13 +119,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert:
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -153,13 +152,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert:
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -185,13 +184,13 @@ def main():
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                    'sha224', 'sha1', 'md5']]),
-               ExtensionType.signature_algorithms_cert:
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                   'sha224', 'sha1', 'md5']]),
+            ExtensionType.signature_algorithms_cert:
+                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
         node = node.add_child(ExpectCertificate())
@@ -217,13 +216,13 @@ def main():
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                    'sha224', 'sha1', 'md5']]),
-               ExtensionType.signature_algorithms_cert:
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                   'sha224', 'sha1', 'md5']]),
+            ExtensionType.signature_algorithms_cert:
+                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
         node = node.add_child(ExpectCertificate())
@@ -242,8 +241,8 @@ def main():
         # If the lenght seems fine for that cert(they are parsed one by one), but
         # the payload is wrong, it will fail with bad_certificate.
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                         (AlertDescription.decode_error,
-                                          AlertDescription.bad_certificate)))
+                                          (AlertDescription.decode_error,
+                                           AlertDescription.bad_certificate)))
         node = node.add_child(ExpectClose())
 
         conversations["fuzz first certificate length with {0}".format(i)] = conversation
@@ -254,13 +253,13 @@ def main():
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                    'sha224', 'sha1', 'md5']]),
-               ExtensionType.signature_algorithms_cert:
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                   'sha224', 'sha1', 'md5']]),
+            ExtensionType.signature_algorithms_cert:
+                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
         node = node.add_child(ExpectCertificate())
@@ -268,7 +267,7 @@ def main():
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
         node = node.add_child(fuzz_message(CertificateGenerator(None),
-                                           xors={-1:i}))
+                                           xors={-1: i}))
         node = node.add_child(ClientKeyExchangeGenerator())
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
@@ -279,20 +278,20 @@ def main():
         node = node.add_child(ExpectClose())
 
         conversations["fuzz empty certificates length - {0}"
-                      .format(i)] = conversation
+            .format(i)] = conversation
 
     # sanity check for no client certificate
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert:
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -301,7 +300,7 @@ def main():
     node = node.add_child(TCPBufferingEnable())
     msg = CertificateGenerator()
     msg = pad_handshake(msg, 3)
-    msg = fuzz_message(msg, substitutions={-4:3})
+    msg = fuzz_message(msg, substitutions={-4: 3})
     node = node.add_child(msg)
     node = node.add_child(ClientKeyExchangeGenerator())
     node = node.add_child(ChangeCipherSpecGenerator())
@@ -310,7 +309,7 @@ def main():
     node = node.add_child(TCPBufferingFlush())
     # if the implementation is proper, it will reject the message
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                    AlertDescription.decode_error))
+                                      AlertDescription.decode_error))
     node = node.add_child(ExpectClose())
     conversations["sanity - empty client cert"] = conversation
 
@@ -323,13 +322,13 @@ def main():
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                    'sha224', 'sha1', 'md5']]),
-               ExtensionType.signature_algorithms_cert:
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                   'sha224', 'sha1', 'md5']]),
+            ExtensionType.signature_algorithms_cert:
+                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
         node = node.add_child(ExpectCertificate())
@@ -364,24 +363,24 @@ def main():
             # If the lenght seems fine for that cert(they are parsed one by one), but
             # the payload is wrong, it will fail with bad_certificate.
             node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                             (AlertDescription.decode_error,
-	                                      AlertDescription.bad_certificate)))
+                                              (AlertDescription.decode_error,
+                                               AlertDescription.bad_certificate)))
         node = node.add_child(ExpectClose())
 
         conversations["fuzz empty certificate - overall {2}, certs {0}, cert {1}"
-                      .format(i, j, k + 3)] = conversation
+            .format(i, j, k + 3)] = conversation
 
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ext = {ExtensionType.signature_algorithms:
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert:
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -409,11 +408,11 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = {ExtensionType.signature_algorithms:
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384',
-                                                    'sha256', 'sha224',
-                                                    'sha1', 'md5']])}
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384',
+                                                   'sha256', 'sha224',
+                                                   'sha1', 'md5']])}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
         node = node.add_child(ExpectCertificate())
@@ -434,7 +433,7 @@ def main():
         node = node.add_child(ExpectClose())
 
         conversations["fuzz second certificate(empty) length - {0}"
-                      .format(i)] = conversation
+            .format(i)] = conversation
 
     # Correct cert followed by 2 empty certs. Fuzz the length of the middle(2nd) cert
     for i in range(1, 0x100):
@@ -443,11 +442,11 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = {ExtensionType.signature_algorithms:
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384',
-                                                    'sha256', 'sha224',
-                                                    'sha1', 'md5']])}
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384',
+                                                   'sha256', 'sha224',
+                                                   'sha1', 'md5']])}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
         node = node.add_child(ExpectCertificate())
@@ -468,12 +467,12 @@ def main():
         # If the lenght seems fine for that cert(they are parsed one by one), but
         # the payload is wrong, it will fail with bad_certificate.
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                         (AlertDescription.decode_error,
-                                          AlertDescription.bad_certificate)))
+                                          (AlertDescription.decode_error,
+                                           AlertDescription.bad_certificate)))
         node = node.add_child(ExpectClose())
 
         conversations["fuzz middle certificate(empty) length - {0}"
-                      .format(i)] = conversation
+            .format(i)] = conversation
 
     # run the conversation
     good = 0
@@ -492,7 +491,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -522,12 +521,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -544,14 +543,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)

--- a/scripts/test-certificate-request.py
+++ b/scripts/test-certificate-request.py
@@ -12,26 +12,25 @@ from itertools import chain
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import sig_algs_to_ids, RSA_SIG_ALL, \
-        client_cert_types_to_ids
+    client_cert_types_to_ids
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsCertExtension
 from tlslite.constants import CipherSuite, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, SignatureScheme, \
-        ClientCertificateType
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, SignatureScheme, \
+    ClientCertificateType
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
-
 
 version = 7
 
@@ -156,10 +155,10 @@ def main():
             (HashAlgorithm.sha224, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa),
             (HashAlgorithm.md5, SignatureAlgorithm.rsa)]
-    ext = {ExtensionType.signature_algorithms :
-            SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -198,10 +197,10 @@ def main():
                 (HashAlgorithm.sha224, SignatureAlgorithm.rsa),
                 (HashAlgorithm.sha1, SignatureAlgorithm.rsa),
                 (HashAlgorithm.md5, SignatureAlgorithm.rsa)]
-        ext = {ExtensionType.signature_algorithms :
-                SignatureAlgorithmsExtension().create(sigs),
-               ExtensionType.signature_algorithms_cert :
-                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+                   SignatureAlgorithmsExtension().create(sigs),
+               ExtensionType.signature_algorithms_cert:
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
         node = node.add_child(ExpectCertificate())
@@ -240,10 +239,10 @@ def main():
             (HashAlgorithm.sha224, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa),
             (HashAlgorithm.md5, SignatureAlgorithm.rsa)]
-    ext = {ExtensionType.signature_algorithms :
-            SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -281,10 +280,10 @@ def main():
             (HashAlgorithm.sha224, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa),
             (HashAlgorithm.md5, SignatureAlgorithm.rsa)]
-    ext = {ExtensionType.signature_algorithms :
-            SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -322,7 +321,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -352,12 +351,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -377,14 +376,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -393,6 +392,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-certificate-verify-malformed-sig.py
+++ b/scripts/test-certificate-verify-malformed-sig.py
@@ -11,25 +11,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        AlertGenerator, TCPBufferingEnable, TCPBufferingDisable, \
-        TCPBufferingFlush
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    AlertGenerator, TCPBufferingEnable, TCPBufferingDisable, \
+    TCPBufferingFlush
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData, ExpectServerKeyExchange
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension, SupportedGroupsExtension
+    SignatureAlgorithmsCertExtension, SupportedGroupsExtension
 from tlslite.constants import CipherSuite, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, GroupName
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, GroupName
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 version = 5
 
@@ -130,15 +129,15 @@ def main():
         else:
             ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                        CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                    'sha224', 'sha1', 'md5']]),
-               ExtensionType.signature_algorithms_cert :
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                   'sha224', 'sha1', 'md5']]),
+            ExtensionType.signature_algorithms_cert:
+                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         if dhe:
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create([GroupName.secp256r1, GroupName.ffdhe2048])
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
@@ -171,12 +170,12 @@ def main():
 
     # try valid signatures but with wrong identifiers on TLS level
     for name, signature, envelope in [
-            ("SHA-1 signature in SHA-256 envelope", HashAlgorithm.sha1,
-             HashAlgorithm.sha256),
-            ("SHA-256 signature in SHA-1 envelope", HashAlgorithm.sha256,
-             HashAlgorithm.sha1),
-            ("SHA-384 signature in SHA-256 envelope", HashAlgorithm.sha384,
-             HashAlgorithm.sha256)]:
+        ("SHA-1 signature in SHA-256 envelope", HashAlgorithm.sha1,
+         HashAlgorithm.sha256),
+        ("SHA-256 signature in SHA-1 envelope", HashAlgorithm.sha256,
+         HashAlgorithm.sha1),
+        ("SHA-384 signature in SHA-256 envelope", HashAlgorithm.sha384,
+         HashAlgorithm.sha256)]:
         conversation = Connect(host, port)
         node = conversation
         if dhe:
@@ -186,15 +185,15 @@ def main():
         else:
             ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                        CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                    'sha224', 'sha1', 'md5']]),
-               ExtensionType.signature_algorithms_cert :
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                   'sha224', 'sha1', 'md5']]),
+            ExtensionType.signature_algorithms_cert:
+                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         if dhe:
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create([GroupName.secp256r1, GroupName.ffdhe2048])
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
@@ -236,15 +235,15 @@ def main():
     else:
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     if dhe:
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([GroupName.secp256r1, GroupName.ffdhe2048])
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
@@ -289,7 +288,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -324,12 +323,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -352,14 +351,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -368,6 +367,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-certificate-verify-malformed.py
+++ b/scripts/test-certificate-verify-malformed.py
@@ -11,21 +11,21 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        AlertGenerator, pad_handshake, TCPBufferingEnable, \
-        TCPBufferingDisable, TCPBufferingFlush, truncate_handshake, \
-        fuzz_message
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    AlertGenerator, pad_handshake, TCPBufferingEnable, \
+    TCPBufferingDisable, TCPBufferingFlush, truncate_handshake, \
+    fuzz_message
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsCertExtension
 from tlslite.constants import CipherSuite, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, AlertLevel, \
-        AlertDescription, ContentType
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, AlertLevel, \
+    AlertDescription, ContentType
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
@@ -55,7 +55,6 @@ def help_msg():
     print(" -k file.pem    file with private key for client")
     print(" -c file.pem    file with certificate for client")
     print(" --help         this message")
-
 
 
 def main():
@@ -120,13 +119,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -153,13 +152,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -185,13 +184,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -219,13 +218,13 @@ def main():
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                    'sha224', 'sha1', 'md5']]),
-               ExtensionType.signature_algorithms_cert :
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                   'sha224', 'sha1', 'md5']]),
+            ExtensionType.signature_algorithms_cert:
+                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
         node = node.add_child(ExpectCertificate())
@@ -245,7 +244,7 @@ def main():
         node = node.add_child(ExpectClose())
 
         conversations["{0} byte sig in CertificateVerify"
-                      .format(i)] = conversation
+            .format(i)] = conversation
 
     # empty CertificateVerify
     for i in range(1, 5):
@@ -253,13 +252,13 @@ def main():
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                    'sha224', 'sha1', 'md5']]),
-               ExtensionType.signature_algorithms_cert :
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                   'sha224', 'sha1', 'md5']]),
+            ExtensionType.signature_algorithms_cert:
+                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
         node = node.add_child(ExpectCertificate())
@@ -281,7 +280,7 @@ def main():
         node = node.add_child(ExpectClose())
 
         conversations["CertificateVerify truncated to {0} bytes"
-                      .format(4 - i)] = conversation
+            .format(4 - i)] = conversation
 
     # fuzz length
     for i in range(1, 0x100):
@@ -289,13 +288,13 @@ def main():
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                    'sha224', 'sha1', 'md5']]),
-               ExtensionType.signature_algorithms_cert :
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                   'sha224', 'sha1', 'md5']]),
+            ExtensionType.signature_algorithms_cert:
+                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
         node = node.add_child(ExpectCertificate())
@@ -333,13 +332,12 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
     sampled_tests = sample(regular_tests, min(num_limit, len(regular_tests)))
     ordered_tests = chain(sanity_tests, sampled_tests, sanity_tests)
-
 
     for c_name, c_test in ordered_tests:
         if run_only and c_name not in run_only or c_name in run_exclude:
@@ -364,12 +362,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -386,14 +384,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -402,6 +400,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-certificate-verify.py
+++ b/scripts/test-certificate-verify.py
@@ -11,24 +11,23 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData, ExpectServerKeyExchange
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension, SupportedGroupsExtension
+    SignatureAlgorithmsCertExtension, SupportedGroupsExtension
 from tlslite.constants import CipherSuite, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, GroupName
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, GroupName
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 version = 8
 
@@ -120,17 +119,17 @@ def main():
     # sanity check for Client Certificates
     conversation = Connect(host, port)
     node = conversation
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
@@ -164,17 +163,17 @@ def main():
     # force MD5 signature on CertificateVerify
     conversation = Connect(host, port)
     node = conversation
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
@@ -214,17 +213,17 @@ def main():
     # expected value
     conversation = Connect(host, port)
     node = conversation
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
@@ -261,17 +260,17 @@ def main():
     # make invalid signature in CertificateVerify (TLSv1.1 style)
     conversation = Connect(host, port)
     node = conversation
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
@@ -303,7 +302,7 @@ def main():
     node.next_sibling.add_child(ExpectClose())
 
     conversations["TLSv1.1 signature in TLSv1.2 Certificate Verify"] = \
-            conversation
+        conversation
 
     # run the conversation
     good = 0
@@ -322,7 +321,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -352,12 +351,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -375,14 +374,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -391,6 +390,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-chacha20.py
+++ b/scripts/test-chacha20.py
@@ -11,21 +11,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_encrypted_message, PlaintextMessageGenerator, SetMaxRecordSize
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_encrypted_message, PlaintextMessageGenerator, SetMaxRecordSize
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ContentType, ExtensionType, GroupName
+    ContentType, ExtensionType, GroupName
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import SIG_ALL
-
 
 version = 3
 
@@ -99,7 +98,7 @@ def main():
         exts = None
     else:
         exts = {}
-        exts[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        exts[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([GroupName.secp256r1, GroupName.ffdhe2048,
                      GroupName.x25519])
         exts[ExtensionType.signature_algorithms_cert] = \
@@ -203,7 +202,7 @@ def main():
     # plaintext just under the maximum permissible
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
                CipherSuite.TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -219,9 +218,9 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     data = bytearray(b"GET / HTTP/1.0\r\n" +
-                     b"X-test: " + b"A" * (2**14 - 28) +
+                     b"X-test: " + b"A" * (2 ** 14 - 28) +
                      b"\r\n\r\n")
-    assert len(data) == 2**14
+    assert len(data) == 2 ** 14
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
@@ -238,7 +237,7 @@ def main():
     # plaintext over the maximum permissible
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
                CipherSuite.TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -254,9 +253,9 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     data = bytearray(b"GET / HTTP/1.0\r\n" +
-                     b"X-test: " + b"A" * (2**14 - 28 + 1) +
+                     b"X-test: " + b"A" * (2 ** 14 - 28 + 1) +
                      b"\r\n\r\n")
-    assert len(data) == 2**14 + 1
+    assert len(data) == 2 ** 14 + 1
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       [AlertDescription.decompression_failure,
@@ -266,7 +265,7 @@ def main():
 
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
                CipherSuite.TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -282,9 +281,9 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     data = bytearray(b"GET / HTTP/1.0\r\n" +
-                     b"X-test: " + b"A" * (2**14 + 1024 - 28) +
+                     b"X-test: " + b"A" * (2 ** 14 + 1024 - 28) +
                      b"\r\n\r\n")
-    assert len(data) == 2**14 + 1024
+    assert len(data) == 2 ** 14 + 1024
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       [AlertDescription.decompression_failure,
@@ -294,7 +293,7 @@ def main():
 
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
                CipherSuite.TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -310,15 +309,14 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     data = bytearray(b"GET / HTTP/1.0\r\n" +
-                     b"X-test: " + b"A" * (2**14 + 1024 - 28 + 1) +
+                     b"X-test: " + b"A" * (2 ** 14 + 1024 - 28 + 1) +
                      b"\r\n\r\n")
-    assert len(data) == 2**14 + 1024 + 1
+    assert len(data) == 2 ** 14 + 1024 + 1
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.record_overflow))
     node.add_child(ExpectClose())
     conversations["too big plaintext - above TLSCompressed max"] = conversation
-
 
     # fuzz the tag (16 last bytes)
     for val in [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80]:
@@ -340,13 +338,13 @@ def main():
             node = node.add_child(ExpectChangeCipherSpec())
             node = node.add_child(ExpectFinished())
             msg = ApplicationDataGenerator(
-                    bytearray(b"GET / HTTP/1.0\r\n\r\n"))
-            node = node.add_child(fuzz_encrypted_message(msg, xors={pos:val}))
+                bytearray(b"GET / HTTP/1.0\r\n\r\n"))
+            node = node.add_child(fuzz_encrypted_message(msg, xors={pos: val}))
             node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                               AlertDescription.bad_record_mac))
             node.add_child(ExpectClose())
             conversations["fuzz tag with {0} on pos {1}".format(val, pos)] \
-                    = conversation
+                = conversation
 
     # too small message handling
     for val in range(16):
@@ -368,13 +366,13 @@ def main():
         node = node.add_child(ExpectFinished())
         # any byte value will do, a1 chosen at random
         msg = PlaintextMessageGenerator(ContentType.application_data,
-                                        bytearray([0xa1]*val))
+                                        bytearray([0xa1] * val))
         node = node.add_child(msg)
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.bad_record_mac))
         node.add_child(ExpectClose())
         conversations["{0} bytes long ciphertext".format(val)] \
-                = conversation
+            = conversation
 
     # run the conversation
     good = 0
@@ -420,12 +418,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -441,14 +439,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -457,6 +455,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-client-compatibility.py
+++ b/scripts/test-client-compatibility.py
@@ -5786,12 +5786,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")

--- a/scripts/test-client-hello-max-size.py
+++ b/scripts/test-client-hello-max-size.py
@@ -11,21 +11,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, SignatureScheme, GroupName
+    ExtensionType, SignatureScheme, GroupName
 from tlslite.extensions import ALPNExtension, TLSExtension, \
-        SupportedGroupsExtension, SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension
+    SupportedGroupsExtension, SignatureAlgorithmsExtension, \
+    SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 version = 4
 
@@ -49,6 +48,7 @@ def help_msg():
     print("                usage: [-x probe-name] [-X exception], order is compulsory!")
     print(" -d             negotiate (EC)DHE instead of RSA key exchange")
     print(" --help         this message")
+
 
 def main():
     host = "localhost"
@@ -107,7 +107,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(sigalgs)
@@ -191,7 +191,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(sigalgs)
@@ -237,7 +237,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -267,12 +267,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -291,14 +291,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -307,6 +307,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-clienthello-md5.py
+++ b/scripts/test-clienthello-md5.py
@@ -15,19 +15,19 @@ from itertools import chain
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerKeyExchange, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData
+    ExpectServerKeyExchange, \
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsCertExtension
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType
+    HashAlgorithm, SignatureAlgorithm, ExtensionType
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
@@ -35,6 +35,7 @@ from tlsfuzzer.helpers import RSA_SIG_ALL
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -130,11 +131,11 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (HashAlgorithm.md5, SignatureAlgorithm.rsa)]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (HashAlgorithm.md5, SignatureAlgorithm.rsa)]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     if workaround:
         node = node.add_child(ExpectServerHello(version=(3, 3)))
@@ -166,10 +167,10 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([(21, 69)]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create([(21, 69)]),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     if workaround:
         node = node.add_child(ExpectServerHello(version=(3, 3)))
@@ -213,7 +214,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -243,12 +244,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -269,14 +270,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -285,6 +286,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-conversation.py
+++ b/scripts/test-conversation.py
@@ -10,21 +10,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
-
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType
+    GroupName, ExtensionType
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import SIG_ALL
-
 
 version = 6
 
@@ -121,7 +119,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -199,12 +197,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -224,14 +222,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -240,6 +238,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-cve-2016-2107.py
+++ b/scripts/test-cve-2016-2107.py
@@ -11,19 +11,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_plaintext
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_plaintext
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -89,8 +90,8 @@ def main():
     # any CBC will do, but the rest of code expects a 128 block cipher
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -116,8 +117,8 @@ def main():
     # 160 bit HMAC
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -127,14 +128,13 @@ def main():
     node = node.add_child(ExpectFinished())
     # we are encrypting 4 blocks, with 3 blocks (48 bytes) being data, MAC and padding
     node = node.add_child(
-                          fuzz_plaintext(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\n\n"))
-                                       ,
-                                       substitutions=dict((i, 0x31) for i in range(-1, -49, -1))))
+        fuzz_plaintext(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\n\n"))
+                       ,
+                       substitutions=dict((i, 0x31) for i in range(-1, -49, -1))))
     node = node.add_child(ExpectAlert(AlertLevel.fatal, AlertDescription.bad_record_mac))
     node = node.add_child(ExpectClose())
 
     conversations["CVE-2016-2107"] = conversation
-
 
     good = 0
     bad = 0
@@ -152,7 +152,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -182,12 +182,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -203,14 +203,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -219,6 +219,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-cve-2016-6309.py
+++ b/scripts/test-cve-2016-6309.py
@@ -13,17 +13,19 @@ from itertools import chain
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, AlertGenerator, fuzz_message, \
-        ApplicationDataGenerator, Close
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, AlertGenerator, fuzz_message, \
+    ApplicationDataGenerator, Close
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData, ExpectNoMessage
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData, ExpectNoMessage
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.extensions import PaddingExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
+
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -46,7 +48,6 @@ def help_msg():
 
 
 def main():
-
     host = "localhost"
     port = 4433
     num_limit = None
@@ -139,7 +140,7 @@ def main():
     # lowest size substitution, that causes OpenSSL 1.1.0 and 1.1.0a
     # to crash (SIGABRT)
     node = node.add_child(fuzz_message(ClientHelloGenerator(ciphers),
-                                       substitutions={2:0x55, 3:0x55}))
+                                       substitutions={2: 0x55, 3: 0x55}))
     # wait for the timeout set in Connect to occur
     node = node.add_child(ExpectNoMessage(timeout=6))
     node.add_child(Close())
@@ -162,7 +163,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -192,12 +193,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -213,14 +214,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -229,6 +230,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-cve-2016-7054.py
+++ b/scripts/test-cve-2016-7054.py
@@ -12,17 +12,18 @@ import re
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        fuzz_encrypted_message, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    fuzz_encrypted_message, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -86,11 +87,11 @@ def main():
     # The payload has to be long enough to trigger heap overflow
     # Create max. length application data:
     #   2**14 (max. record size) - 28 ("GET / HTTP/1.0\r\nX-test: " + ending)
-    data_length = 2**14 - 28
+    data_length = 2 ** 14 - 28
 
     # 16 bytes: POLY1305 tag 128 bit
     # Tampering one bit suffices to damage the mac
-    fuzzes = [(x, 2**y) for x in range(-16, 0) for y in range(8)]
+    fuzzes = [(x, 2 ** y) for x in range(-16, 0) for y in range(8)]
     for pos, val in fuzzes:
         conversation = Connect(host, port)
         node = conversation
@@ -109,7 +110,7 @@ def main():
             ApplicationDataGenerator(
                 b"GET / HTTP/1.0\r\n" + b'X-test: ' + data_length * b'A' +
                 b'\r\n\r\n'),
-            xors={pos:val}))
+            xors={pos: val}))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.bad_record_mac))
         node = node.add_child(ExpectClose())
@@ -130,8 +131,8 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     node = node.add_child(ApplicationDataGenerator(
-            b"GET / HTTP/1.0\r\n" + b'X-test: ' + data_length * b'A' +
-            b'\r\n\r\n'))
+        b"GET / HTTP/1.0\r\n" + b'X-test: ' + data_length * b'A' +
+        b'\r\n\r\n'))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
@@ -144,7 +145,6 @@ def main():
     node.next_sibling = ExpectClose()
     conversations["sanity"] = \
         conversation
-
 
     # run the conversation
     good = 0
@@ -191,12 +191,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -212,14 +212,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -228,6 +228,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-dhe-key-share-random.py
+++ b/scripts/test-dhe-key-share-random.py
@@ -12,19 +12,18 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        CopyVariables
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    CopyVariables
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import uniqueness_check
-
 
 version = 3
 
@@ -101,11 +100,11 @@ def main():
     collected_session_ids = []
     variables_check = \
         {'ServerHello.random':
-         collected_randoms,
+             collected_randoms,
          'ServerKeyExchange.key_share':
-         collected_key_shares,
+             collected_key_shares,
          'ServerHello.session_id':
-         collected_session_ids}
+             collected_session_ids}
 
     conversations = {}
 
@@ -114,9 +113,9 @@ def main():
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions={ExtensionType.
-                                                   renegotiation_info:None}))
+                                               renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(CopyVariables(variables_check))
@@ -175,7 +174,7 @@ def main():
             conversations["Protocol {0}{1}".format(
                 prot,
                 " in SSLv2 compatible ClientHello" if ssl2 else "")] = \
-                    conversation
+                conversation
 
     # run the conversation
     good = 0
@@ -194,7 +193,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -225,25 +224,25 @@ def main():
                     xpassed.append(c_name)
                     print("XPASS-expected failure but test passed\n")
                 else:
-                    if expected_failures[c_name] is not None and  \
-                        expected_failures[c_name] not in str(exception):
-                            bad += 1
-                            failed.append(c_name)
-                            print("Expected error message: {0}\n"
-                                .format(expected_failures[c_name]))
+                    if expected_failures[c_name] is not None and \
+                            expected_failures[c_name] not in str(exception):
+                        bad += 1
+                        failed.append(c_name)
+                        print("Expected error message: {0}\n"
+                              .format(expected_failures[c_name]))
                     else:
                         xfail += 1
                         print("OK-expected failure\n")
             else:
-                    if res:
-                        good += 1
-                        print("OK\n")
-                    else:
-                        bad += 1
-                        failed.append(c_name)
+                if res:
+                    good += 1
+                    print("OK\n")
+                else:
+                    bad += 1
+                    failed.append(c_name)
 
     failed_tests = uniqueness_check(variables_check, good + bad + xfail +
-                                                     xpass)
+                                    xpass)
     if failed_tests:
         print("\n".join(failed_tests))
     else:
@@ -258,14 +257,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -274,6 +273,7 @@ def main():
 
     if bad > 0 or failed_tests:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-dhe-no-shared-secret-padding.py
+++ b/scripts/test-dhe-no-shared-secret-padding.py
@@ -12,19 +12,18 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        CopyVariables
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    CopyVariables
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.utils.cryptomath import numBytes
-
 
 version = 3
 
@@ -101,9 +100,9 @@ def main():
     collected_dh_primes = []
     variables_check = \
         {'premaster_secret':
-         collected_premaster_secrets,
+             collected_premaster_secrets,
          'ServerKeyExchange.dh_p':
-         collected_dh_primes}
+             collected_dh_primes}
 
     conversations = {}
 
@@ -112,9 +111,9 @@ def main():
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(CopyVariables(variables_check))
@@ -173,7 +172,7 @@ def main():
             conversations["Protocol {0}{1}".format(
                 prot,
                 " in SSLv2 compatible ClientHello" if ssl2 else "")] = \
-                    conversation
+                conversation
 
     # run the conversation
     good = 0
@@ -192,7 +191,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -232,12 +231,12 @@ def main():
                     xpassed.append(c_name)
                     print("XPASS-expected failure but test passed\n")
                 else:
-                    if expected_failures[c_name] is not None and  \
-                        expected_failures[c_name] not in str(exception):
-                            bad += 1
-                            failed.append(c_name)
-                            print("Expected error message: {0}\n"
-                                .format(expected_failures[c_name]))
+                    if expected_failures[c_name] is not None and \
+                            expected_failures[c_name] not in str(exception):
+                        bad += 1
+                        failed.append(c_name)
+                        print("Expected error message: {0}\n"
+                              .format(expected_failures[c_name]))
                     else:
                         xfail += 1
                         print("OK-expected failure\n")
@@ -250,7 +249,7 @@ def main():
                         print("Got prime {0} bytes long and a premaster_secret "
                               "{1} bytes long"
                               .format(numBytes(collected_dh_primes[-1]),
-                                  len(collected_premaster_secrets[-1])))
+                                      len(collected_premaster_secrets[-1])))
                         break_loop = True
                     print("OK\n")
                 else:
@@ -259,7 +258,6 @@ def main():
                     break
             if break_loop:
                 break
-
 
     print('')
 
@@ -270,14 +268,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -286,6 +284,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-dhe-rsa-key-exchange-signatures.py
+++ b/scripts/test-dhe-rsa-key-exchange-signatures.py
@@ -13,21 +13,22 @@ from itertools import chain
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsCertExtension
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, HashAlgorithm, SignatureAlgorithm
+    ExtensionType, HashAlgorithm, SignatureAlgorithm
 from tlsfuzzer.helpers import RSA_SIG_ALL
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 4
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -98,16 +99,16 @@ def main():
                CipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA256]
     sig_algs = [(getattr(HashAlgorithm, hash_alg), SignatureAlgorithm.rsa)
                 for hash_alg in ("sha1", "sha224", "sha256", "sha384",
-                                "sha512")]
-    ext = {ExtensionType.renegotiation_info : None,
-           ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(sig_algs),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                                 "sha512")]
+    ext = {ExtensionType.renegotiation_info: None,
+           ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sig_algs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3),
                                             extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange(valid_sig_algs=sig_algs))
     node = node.add_child(ExpectServerHelloDone())
@@ -137,15 +138,15 @@ def main():
             node = conversation
             ciphers = [cipher]
             sig_algs = [(getattr(HashAlgorithm, hash_alg), SignatureAlgorithm.rsa)]
-            ext = {ExtensionType.renegotiation_info : None,
-                   ExtensionType.signature_algorithms :
-                   SignatureAlgorithmsExtension().create(sig_algs),
-                   ExtensionType.signature_algorithms_cert :
-                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+            ext = {ExtensionType.renegotiation_info: None,
+                   ExtensionType.signature_algorithms:
+                       SignatureAlgorithmsExtension().create(sig_algs),
+                   ExtensionType.signature_algorithms_cert:
+                       SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
             node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
             node = node.add_child(ExpectServerHello(version=(3, 3),
                                                     extensions={ExtensionType.
-                                                             renegotiation_info:None}))
+                                                    renegotiation_info: None}))
             node = node.add_child(ExpectCertificate())
             node = node.add_child(ExpectServerKeyExchange(valid_sig_algs=sig_algs))
             node = node.add_child(ExpectServerHelloDone())
@@ -182,7 +183,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -213,35 +214,35 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
         else:
             if res:
-                good+=1
+                good += 1
                 print("OK\n")
             else:
-                bad+=1
+                bad += 1
                 failed.append(c_name)
 
     print("Test end")
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -250,6 +251,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-dhe-rsa-key-exchange-with-bad-messages.py
+++ b/scripts/test-dhe-rsa-key-exchange-with-bad-messages.py
@@ -13,22 +13,21 @@ from itertools import chain
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        truncate_handshake, TCPBufferingEnable, TCPBufferingDisable, \
-        TCPBufferingFlush, pad_handshake
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    truncate_handshake, TCPBufferingEnable, TCPBufferingDisable, \
+    TCPBufferingFlush, pad_handshake
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 version = 3
 
@@ -54,7 +53,6 @@ def help_msg():
     print("                with publicly invalid client key shares,")
     print("                47 (illegal_parameter) by default")
     print(" --help         this message")
-
 
 
 def main():
@@ -98,7 +96,6 @@ def main():
     else:
         run_only = None
 
-
     conversations = {}
 
     conversation = Connect(host, port)
@@ -113,7 +110,7 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
@@ -134,8 +131,8 @@ def main():
     conversations["sanity"] = conversation
 
     # invalid dh_Yc value
-    #for i in [2*1024, 4*1024, 8*1024, 16*1024]:
-    for i in [8*1024]:
+    # for i in [2*1024, 4*1024, 8*1024, 16*1024]:
+    for i in [8 * 1024]:
         conversation = Connect(host, port)
         node = conversation
         ext = {}
@@ -148,12 +145,12 @@ def main():
         node = node.add_child(ClientHelloGenerator(ciphers,
                                                    extensions=ext))
         node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                         renegotiation_info:None}))
+                                                renegotiation_info: None}))
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerKeyExchange())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
-        node = node.add_child(ClientKeyExchangeGenerator(dh_Yc=2**(i)))
+        node = node.add_child(ClientKeyExchangeGenerator(dh_Yc=2 ** (i)))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(TCPBufferingDisable())
@@ -177,7 +174,7 @@ def main():
         node = node.add_child(ClientHelloGenerator(ciphers,
                                                    extensions=ext))
         node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                         renegotiation_info:None}))
+                                                renegotiation_info: None}))
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerKeyExchange())
         node = node.add_child(ExpectServerHelloDone())
@@ -206,7 +203,7 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
@@ -235,7 +232,7 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
@@ -264,7 +261,7 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
@@ -294,13 +291,13 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(TCPBufferingEnable())
     node = node.add_child(pad_handshake(ClientKeyExchangeGenerator(),
-                                             1))
+                                        1))
     node = node.add_child(ChangeCipherSpecGenerator())
     node = node.add_child(FinishedGenerator())
     node = node.add_child(TCPBufferingDisable())
@@ -328,7 +325,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -358,12 +355,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -384,14 +381,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -400,6 +397,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-dhe-rsa-key-exchange.py
+++ b/scripts/test-dhe-rsa-key-exchange.py
@@ -13,18 +13,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -44,6 +45,7 @@ def help_msg():
     print(" -n num         run 'num' or all(if 0) tests instead of default(all)")
     print("                (excluding \"sanity\" tests)")
     print(" --help         this message")
+
 
 def main():
     """Test if server supports the DHE_RSA key exchange"""
@@ -90,9 +92,9 @@ def main():
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions={ExtensionType.
-                                                   renegotiation_info:None}))
+                                               renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
@@ -128,7 +130,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -158,12 +160,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -179,14 +181,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -195,6 +197,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-downgrade-protection.py
+++ b/scripts/test-downgrade-protection.py
@@ -10,23 +10,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, \
-        protocol_name_to_tuple
-
+    protocol_name_to_tuple
 
 version = 3
 
@@ -61,12 +60,12 @@ def main():
     run_exclude = set()
     expected_failures = {}
     last_exp_tmp = None
-    srv_max_prot=None
+    srv_max_prot = None
     dhe = False
 
     argv = sys.argv[1:]
     opts, args = getopt.getopt(argv, "h:p:e:x:X:n:d", ["help",
-                                                  "server-max-protocol="])
+                                                       "server-max-protocol="])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -132,7 +131,7 @@ def main():
         node = node.add_child(ExpectFinished())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(
-        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+            bytearray(b"GET / HTTP/1.0\r\n\r\n")))
         # This message is optional and may show up 0 to many times
         cycle = ExpectNewSessionTicket()
         node = node.add_child(cycle)
@@ -140,7 +139,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                           AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -149,7 +148,7 @@ def main():
             ext = {}
             groups = [GroupName.secp256r1,
                       GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -191,7 +190,7 @@ def main():
             ext = {}
             groups = [GroupName.secp256r1,
                       GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -244,7 +243,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -274,12 +273,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -299,14 +298,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -315,6 +314,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-early-application-data.py
+++ b/scripts/test-early-application-data.py
@@ -10,18 +10,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -112,8 +113,8 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ApplicationDataGenerator(bytearray(b"hello server!\n")))
@@ -127,8 +128,8 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -143,8 +144,8 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -173,7 +174,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -203,12 +204,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -224,14 +225,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -240,6 +241,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-ecdhe-padded-shared-secret.py
+++ b/scripts/test-ecdhe-padded-shared-secret.py
@@ -12,20 +12,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        CopyVariables
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    CopyVariables
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, GroupName, ECPointFormat
+    ExtensionType, GroupName, ECPointFormat
 from tlslite.extensions import ECPointFormatsExtension, \
-        SupportedGroupsExtension
-
+    SupportedGroupsExtension
 
 version = 4
 
@@ -101,7 +100,7 @@ def main():
     collected_premaster_secrets = []
     variables_check = \
         {'premaster_secret':
-         collected_premaster_secrets}
+             collected_premaster_secrets}
 
     groups = [GroupName.x25519, GroupName.x448, GroupName.secp256r1,
               GroupName.secp384r1, GroupName.secp521r1]
@@ -117,7 +116,7 @@ def main():
             ExtensionType.supported_groups: groups_ext,
             ExtensionType.ec_point_formats: points_ext}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=exts))
-    exts = {ExtensionType.renegotiation_info:None,
+    exts = {ExtensionType.renegotiation_info: None,
             ExtensionType.ec_point_formats: None}
     node = node.add_child(ExpectServerHello(extensions=exts))
     node = node.add_child(ExpectCertificate())
@@ -196,7 +195,7 @@ def main():
                     "" if ssl2 or prot < (3, 1)
                     else " with {0} group".format(GroupName.toStr(group)),
                     " in SSLv2 compatible ClientHello" if ssl2 else "")] = \
-                        conversation
+                    conversation
 
     # run the conversation
     good = 0
@@ -215,7 +214,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -253,12 +252,12 @@ def main():
                     xpassed.append(c_name)
                     print("XPASS-expected failure but test passed\n")
                 else:
-                    if expected_failures[c_name] is not None and  \
-                        expected_failures[c_name] not in str(exception):
-                            bad += 1
-                            failed.append(c_name)
-                            print("Expected error message: {0}\n"
-                                .format(expected_failures[c_name]))
+                    if expected_failures[c_name] is not None and \
+                            expected_failures[c_name] not in str(exception):
+                        bad += 1
+                        failed.append(c_name)
+                        print("Expected error message: {0}\n"
+                              .format(expected_failures[c_name]))
                     else:
                         xfail += 1
                         print("OK-expected failure\n")
@@ -269,8 +268,8 @@ def main():
                     if collected_premaster_secrets[-1][:min_zeros] == \
                             bytearray(min_zeros):
                         print("Got premaster secret with {0} most significant "
-                            "bytes equal to zero."
-                            .format(min_zeros))
+                              "bytes equal to zero."
+                              .format(min_zeros))
                         break_loop = True
                     print("OK\n")
                 else:
@@ -289,14 +288,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -305,6 +304,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-ecdhe-rsa-key-exchange-with-bad-messages.py
+++ b/scripts/test-ecdhe-rsa-key-exchange-with-bad-messages.py
@@ -13,22 +13,23 @@ from itertools import chain
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_message, truncate_handshake, pad_handshake, \
-        TCPBufferingEnable, TCPBufferingDisable, TCPBufferingFlush
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_message, truncate_handshake, pad_handshake, \
+    TCPBufferingEnable, TCPBufferingDisable, TCPBufferingFlush
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, GroupName, ECPointFormat
+    ExtensionType, GroupName, ECPointFormat
 from tlslite.extensions import SupportedGroupsExtension, \
-        ECPointFormatsExtension
+    ECPointFormatsExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -95,9 +96,9 @@ def main():
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.supported_groups: SupportedGroupsExtension().
-           create([GroupName.secp256r1]),
+               create([GroupName.secp256r1]),
            ExtensionType.ec_point_formats: ECPointFormatsExtension().
-           create([ECPointFormat.uncompressed])}
+               create([ECPointFormat.uncompressed])}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
@@ -127,9 +128,9 @@ def main():
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.supported_groups: SupportedGroupsExtension().
-           create([GroupName.secp256r1]),
+               create([GroupName.secp256r1]),
            ExtensionType.ec_point_formats: ECPointFormatsExtension().
-           create([ECPointFormat.uncompressed])}
+               create([ECPointFormat.uncompressed])}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
@@ -159,9 +160,9 @@ def main():
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.supported_groups: SupportedGroupsExtension().
-           create([GroupName.secp256r1]),
+               create([GroupName.secp256r1]),
            ExtensionType.ec_point_formats: ECPointFormatsExtension().
-           create([ECPointFormat.uncompressed])}
+               create([ECPointFormat.uncompressed])}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
@@ -186,16 +187,15 @@ def main():
 
     conversations["invalid point (0, 0)"] = conversation
 
-
     # invalid ecdh_Yc value
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.supported_groups: SupportedGroupsExtension().
-           create([GroupName.secp256r1]),
+               create([GroupName.secp256r1]),
            ExtensionType.ec_point_formats: ECPointFormatsExtension().
-           create([ECPointFormat.uncompressed])}
+               create([ECPointFormat.uncompressed])}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
@@ -225,9 +225,9 @@ def main():
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.supported_groups: SupportedGroupsExtension().
-           create([GroupName.secp256r1]),
+               create([GroupName.secp256r1]),
            ExtensionType.ec_point_formats: ECPointFormatsExtension().
-           create([ECPointFormat.uncompressed])}
+               create([ECPointFormat.uncompressed])}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
@@ -240,7 +240,7 @@ def main():
     # uncompressed EC points need to be self consistent, by changing
     # one coordinate without changing the other we create an invalid point
     node = node.add_child(fuzz_message(ClientKeyExchangeGenerator(),
-                                       xors={-1:0xff}))
+                                       xors={-1: 0xff}))
     node = node.add_child(ChangeCipherSpecGenerator())
     node = node.add_child(FinishedGenerator())
     node = node.add_child(TCPBufferingDisable())
@@ -257,9 +257,9 @@ def main():
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.supported_groups: SupportedGroupsExtension().
-           create([GroupName.secp256r1]),
+               create([GroupName.secp256r1]),
            ExtensionType.ec_point_formats: ECPointFormatsExtension().
-           create([ECPointFormat.uncompressed])}
+               create([ECPointFormat.uncompressed])}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
@@ -289,9 +289,9 @@ def main():
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.supported_groups: SupportedGroupsExtension().
-           create([GroupName.secp256r1]),
+               create([GroupName.secp256r1]),
            ExtensionType.ec_point_formats: ECPointFormatsExtension().
-           create([ECPointFormat.uncompressed])}
+               create([ECPointFormat.uncompressed])}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
@@ -331,7 +331,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -361,12 +361,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -382,14 +382,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -398,6 +398,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-ecdhe-rsa-key-exchange.py
+++ b/scripts/test-ecdhe-rsa-key-exchange.py
@@ -13,21 +13,22 @@ from itertools import chain
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        Close
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    Close
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, GroupName, ECPointFormat
+    ExtensionType, GroupName, ECPointFormat
 from tlslite.extensions import SupportedGroupsExtension, \
-        ECPointFormatsExtension
+    ECPointFormatsExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [OPTIONS] [[probe-name] ...]")
@@ -94,9 +95,9 @@ def main():
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.supported_groups: SupportedGroupsExtension().
-           create([GroupName.secp256r1, GroupName.secp384r1]),
+               create([GroupName.secp256r1, GroupName.secp384r1]),
            ExtensionType.ec_point_formats: ECPointFormatsExtension().
-           create([ECPointFormat.uncompressed])}
+               create([ECPointFormat.uncompressed])}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
@@ -125,9 +126,9 @@ def main():
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
@@ -160,7 +161,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -190,35 +191,35 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
         else:
             if res:
-                good+=1
+                good += 1
                 print("OK")
             else:
-                bad+=1
+                bad += 1
                 failed.append(c_name)
 
     print("Test end")
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -227,6 +228,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-ecdhe-rsa-key-share-random.py
+++ b/scripts/test-ecdhe-rsa-key-share-random.py
@@ -12,21 +12,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        CopyVariables
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    CopyVariables
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, GroupName, ECPointFormat
+    ExtensionType, GroupName, ECPointFormat
 from tlslite.extensions import ECPointFormatsExtension, \
-        SupportedGroupsExtension
+    SupportedGroupsExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import uniqueness_check
-
 
 version = 3
 
@@ -103,11 +102,11 @@ def main():
     collected_session_ids = []
     variables_check = \
         {'ServerHello.random':
-         collected_randoms,
+             collected_randoms,
          'ServerKeyExchange.key_share':
-         collected_key_shares,
+             collected_key_shares,
          'ServerHello.session_id':
-         collected_session_ids}
+             collected_session_ids}
 
     groups = [GroupName.x25519, GroupName.x448, GroupName.secp256r1,
               GroupName.secp384r1, GroupName.secp521r1]
@@ -123,7 +122,7 @@ def main():
             ExtensionType.supported_groups: groups_ext,
             ExtensionType.ec_point_formats: points_ext}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=exts))
-    exts = {ExtensionType.renegotiation_info:None,
+    exts = {ExtensionType.renegotiation_info: None,
             ExtensionType.ec_point_formats: None}
     node = node.add_child(ExpectServerHello(extensions=exts))
     node = node.add_child(ExpectCertificate())
@@ -200,9 +199,9 @@ def main():
                 conversations["Protocol {0}{1}{2}".format(
                     prot,
                     "" if ssl2 or prot < (3, 1)
-                        else " with {0} group".format(GroupName.toStr(group)),
+                    else " with {0} group".format(GroupName.toStr(group)),
                     " in SSLv2 compatible ClientHello" if ssl2 else "")] = \
-                        conversation
+                    conversation
 
     # run the conversation
     good = 0
@@ -221,7 +220,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -252,22 +251,22 @@ def main():
                     xpassed.append(c_name)
                     print("XPASS-expected failure but test passed\n")
                 else:
-                    if expected_failures[c_name] is not None and  \
-                        expected_failures[c_name] not in str(exception):
-                            bad += 1
-                            failed.append(c_name)
-                            print("Expected error message: {0}\n"
-                                .format(expected_failures[c_name]))
+                    if expected_failures[c_name] is not None and \
+                            expected_failures[c_name] not in str(exception):
+                        bad += 1
+                        failed.append(c_name)
+                        print("Expected error message: {0}\n"
+                              .format(expected_failures[c_name]))
                     else:
                         xfail += 1
                         print("OK-expected failure\n")
             else:
-                    if res:
-                        good += 1
-                        print("OK\n")
-                    else:
-                        bad += 1
-                        failed.append(c_name)
+                if res:
+                    good += 1
+                    print("OK\n")
+                else:
+                    bad += 1
+                    failed.append(c_name)
 
     failed_tests = uniqueness_check(variables_check, good + bad)
     if failed_tests:
@@ -287,14 +286,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -303,6 +302,7 @@ def main():
 
     if bad > 0 or failed_tests:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-ecdsa-in-certificate-verify.py
+++ b/scripts/test-ecdsa-in-certificate-verify.py
@@ -11,27 +11,26 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        AlertGenerator, TCPBufferingEnable, TCPBufferingDisable, \
-        TCPBufferingFlush
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    AlertGenerator, TCPBufferingEnable, TCPBufferingDisable, \
+    TCPBufferingFlush
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData, ExpectServerKeyExchange
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension, SupportedGroupsExtension, \
-        ECPointFormatsExtension
+    SignatureAlgorithmsCertExtension, SupportedGroupsExtension, \
+    ECPointFormatsExtension
 from tlslite.constants import CipherSuite, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, GroupName, \
-        ECPointFormat, AlertLevel, AlertDescription
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, GroupName, \
+    ECPointFormat, AlertLevel, AlertDescription
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL, ECDSA_SIG_ALL
-
 
 version = 3
 
@@ -122,15 +121,15 @@ def main():
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(ECDSA_SIG_ALL + RSA_SIG_ALL),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(ECDSA_SIG_ALL + RSA_SIG_ALL),
-           ExtensionType.supported_groups :
-           SupportedGroupsExtension().create([
-               GroupName.secp256r1, GroupName.secp384r1, GroupName.secp521r1]),
-           ExtensionType.ec_point_formats :
-           ECPointFormatsExtension().create([ECPointFormat.uncompressed])}
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(ECDSA_SIG_ALL + RSA_SIG_ALL),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(ECDSA_SIG_ALL + RSA_SIG_ALL),
+           ExtensionType.supported_groups:
+               SupportedGroupsExtension().create([
+                   GroupName.secp256r1, GroupName.secp384r1, GroupName.secp521r1]),
+           ExtensionType.ec_point_formats:
+               ECPointFormatsExtension().create([ECPointFormat.uncompressed])}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -159,15 +158,15 @@ def main():
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(ECDSA_SIG_ALL + RSA_SIG_ALL),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(ECDSA_SIG_ALL + RSA_SIG_ALL),
-           ExtensionType.supported_groups :
-           SupportedGroupsExtension().create([
-               GroupName.secp256r1, GroupName.secp384r1, GroupName.secp521r1]),
-           ExtensionType.ec_point_formats :
-           ECPointFormatsExtension().create([ECPointFormat.uncompressed])}
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(ECDSA_SIG_ALL + RSA_SIG_ALL),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(ECDSA_SIG_ALL + RSA_SIG_ALL),
+           ExtensionType.supported_groups:
+               SupportedGroupsExtension().create([
+                   GroupName.secp256r1, GroupName.secp384r1, GroupName.secp521r1]),
+           ExtensionType.ec_point_formats:
+               ECPointFormatsExtension().create([ECPointFormat.uncompressed])}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -200,19 +199,19 @@ def main():
             ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                        CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-            ext = {ExtensionType.signature_algorithms :
-                   SignatureAlgorithmsExtension().create(ECDSA_SIG_ALL +
-                                                         RSA_SIG_ALL),
-                   ExtensionType.signature_algorithms_cert :
-                   SignatureAlgorithmsCertExtension().create(ECDSA_SIG_ALL +
+            ext = {ExtensionType.signature_algorithms:
+                       SignatureAlgorithmsExtension().create(ECDSA_SIG_ALL +
                                                              RSA_SIG_ALL),
-                   ExtensionType.supported_groups :
-                   SupportedGroupsExtension().create([
-                       GroupName.secp256r1, GroupName.secp384r1,
-                       GroupName.secp521r1]),
-                   ExtensionType.ec_point_formats :
-                   ECPointFormatsExtension().create([
-                       ECPointFormat.uncompressed])}
+                   ExtensionType.signature_algorithms_cert:
+                       SignatureAlgorithmsCertExtension().create(ECDSA_SIG_ALL +
+                                                                 RSA_SIG_ALL),
+                   ExtensionType.supported_groups:
+                       SupportedGroupsExtension().create([
+                           GroupName.secp256r1, GroupName.secp384r1,
+                           GroupName.secp521r1]),
+                   ExtensionType.ec_point_formats:
+                       ECPointFormatsExtension().create([
+                           ECPointFormat.uncompressed])}
             node = node.add_child(ClientHelloGenerator(ciphers,
                                                        extensions=ext))
             node = node.add_child(ExpectServerHello(version=(3, 3)))
@@ -244,7 +243,7 @@ def main():
                 node.next_sibling.add_child(ExpectClose())
 
                 conversations["make {0}+ecdsa signature in CertificateVerify"
-                              .format(h_alg)] = conversation
+                    .format(h_alg)] = conversation
             else:
                 node = node.add_child(TCPBufferingEnable())
                 node = node.add_child(CertificateVerifyGenerator(
@@ -261,7 +260,7 @@ def main():
                 node = node.add_child(ExpectClose())
                 conversations["make {0}+ecdsa signature, advertise it as "
                               "{1}+ecdsa in CertificateVerify"
-                              .format(h_alg, real_h_alg)] = conversation
+                    .format(h_alg, real_h_alg)] = conversation
 
     # run the conversation
     good = 0
@@ -307,12 +306,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -330,14 +329,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -345,6 +344,7 @@ def main():
         print("FAILED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-ecdsa-sig-flexibility.py
+++ b/scripts/test-ecdsa-sig-flexibility.py
@@ -10,20 +10,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SupportedGroupsExtension, SignatureAlgorithmsCertExtension
+    SupportedGroupsExtension, SignatureAlgorithmsCertExtension
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, GroupName
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, GroupName
 from tlsfuzzer.helpers import SIG_ALL
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 4
 
@@ -96,14 +95,14 @@ def main():
                (HashAlgorithm.sha384, SignatureAlgorithm.ecdsa),
                (HashAlgorithm.sha512, SignatureAlgorithm.ecdsa)]
     ext[ExtensionType.signature_algorithms] = \
-            SignatureAlgorithmsExtension().create(sigalgs)
+        SignatureAlgorithmsExtension().create(sigalgs)
     ext[ExtensionType.signature_algorithms_cert] = \
-            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        SignatureAlgorithmsCertExtension().create(SIG_ALL)
     curves = [GroupName.secp256r1,
               GroupName.secp384r1,
               GroupName.secp521r1]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(curves)
+        SupportedGroupsExtension().create(curves)
     ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
@@ -136,14 +135,14 @@ def main():
                (HashAlgorithm.sha224, SignatureAlgorithm.ecdsa),
                (HashAlgorithm.sha1, SignatureAlgorithm.ecdsa)]
     ext[ExtensionType.signature_algorithms] = \
-            SignatureAlgorithmsExtension().create(sigalgs)
+        SignatureAlgorithmsExtension().create(sigalgs)
     ext[ExtensionType.signature_algorithms_cert] = \
-            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        SignatureAlgorithmsCertExtension().create(SIG_ALL)
     curves = [GroupName.secp256r1,
               GroupName.secp384r1,
               GroupName.secp521r1]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(curves)
+        SupportedGroupsExtension().create(curves)
     ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
@@ -173,14 +172,14 @@ def main():
         ext = {}
         sigalgs = [(getattr(HashAlgorithm, h_alg), SignatureAlgorithm.ecdsa)]
         ext[ExtensionType.signature_algorithms] = \
-                SignatureAlgorithmsExtension().create(sigalgs)
+            SignatureAlgorithmsExtension().create(sigalgs)
         ext[ExtensionType.signature_algorithms_cert] = \
-                SignatureAlgorithmsCertExtension().create(SIG_ALL)
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
         curves = [GroupName.secp256r1,
                   GroupName.secp384r1,
                   GroupName.secp521r1]
         ext[ExtensionType.supported_groups] = \
-                SupportedGroupsExtension().create(curves)
+            SupportedGroupsExtension().create(curves)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
@@ -220,7 +219,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -250,12 +249,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -274,14 +273,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -290,6 +289,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-empty-extensions.py
+++ b/scripts/test-empty-extensions.py
@@ -11,18 +11,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, Close
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, Close
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -125,7 +126,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -155,12 +156,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -176,14 +177,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -192,6 +193,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-encrypt-then-mac-renegotiation.py
+++ b/scripts/test-encrypt-then-mac-renegotiation.py
@@ -11,23 +11,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, AlertGenerator, ResetHandshakeHashes, \
-        ApplicationDataGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, AlertGenerator, ResetHandshakeHashes, \
+    ApplicationDataGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData, \
+    ExpectServerKeyExchange
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension, SupportedGroupsExtension
+    SignatureAlgorithmsCertExtension, SupportedGroupsExtension
 from tlsfuzzer.helpers import AutoEmptyExtension
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, GroupName
+    ExtensionType, GroupName
 from tlsfuzzer.helpers import RSA_SIG_ALL
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port]")
@@ -111,8 +112,8 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-    extensions = {ExtensionType.encrypt_then_mac:None,
-                  ExtensionType.renegotiation_info:None}
+    extensions = {ExtensionType.encrypt_then_mac: None,
+                  ExtensionType.renegotiation_info: None}
     node = node.add_child(ExpectServerHello(extensions=extensions))
     node = node.add_child(ExpectCertificate())
     if dhe:
@@ -175,8 +176,8 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                session_id=bytearray(0),
                                                extensions=ext))
-    extensions = {ExtensionType.encrypt_then_mac:None,
-                  ExtensionType.renegotiation_info:None}
+    extensions = {ExtensionType.encrypt_then_mac: None,
+                  ExtensionType.renegotiation_info: None}
     node = node.add_child(ExpectServerHello(extensions=extensions))
     node = node.add_child(ExpectCertificate())
     if dhe:
@@ -214,7 +215,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -244,12 +245,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -265,14 +266,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -281,6 +282,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-encrypt-then-mac.py
+++ b/scripts/test-encrypt-then-mac.py
@@ -10,21 +10,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData, \
+    ExpectServerKeyExchange
 from tlsfuzzer.helpers import AutoEmptyExtension
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType
+    GroupName, ExtensionType
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 version = 3
 
@@ -98,7 +97,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -136,7 +135,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -187,7 +186,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -217,12 +216,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -241,14 +240,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)

--- a/scripts/test-export-ciphers-rejected.py
+++ b/scripts/test-export-ciphers-rejected.py
@@ -10,19 +10,18 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, ExpectServerKeyExchange
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, GroupName, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import protocol_name_to_tuple, RSA_SIG_ALL
-
 
 version = 6
 
@@ -99,7 +98,7 @@ def main():
     node = conversation
     ext = {}
     groups = [GroupName.ffdhe2048]
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ext[ExtensionType.signature_algorithms] = \
         SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -162,7 +161,7 @@ def main():
             node = conversation
             ext = {}
             groups = [GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -198,12 +197,12 @@ def main():
                 node = node.add_child(ExpectApplicationData())
                 record_split = node
                 node.next_sibling = ExpectAlert(AlertLevel.warning,
-                                              AlertDescription.close_notify)
+                                                AlertDescription.close_notify)
                 node.next_sibling.next_sibling = ExpectClose()
                 node = record_split.add_child(record_split.next_sibling)
                 node.add_child(ExpectClose())
             conversations["{0} with AES_128 in {1}".format(name, prot_name)] \
-                    = conversation
+                = conversation
 
             # alone
             conversation = Connect(host, port, version=(3, 0))
@@ -217,7 +216,6 @@ def main():
                              AlertDescription.protocol_version)))
             node = node.add_child(ExpectClose())
             conversations["{0} in {1}".format(name, prot_name)] = conversation
-
 
     # run the conversation
     good = 0
@@ -236,7 +234,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -266,12 +264,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -289,14 +287,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -305,6 +303,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-extended-master-secret-extension-with-client-cert.py
+++ b/scripts/test-extended-master-secret-extension-with-client-cert.py
@@ -12,26 +12,27 @@ from itertools import chain
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        AlertGenerator, Close, ResetHandshakeHashes, ResetRenegotiationInfo
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    AlertGenerator, Close, ResetHandshakeHashes, ResetRenegotiationInfo
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData, ExpectServerKeyExchange
 from tlsfuzzer.helpers import sig_algs_to_ids, RSA_SIG_ALL, AutoEmptyExtension
 
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension, SupportedGroupsExtension
+    SignatureAlgorithmsCertExtension, SupportedGroupsExtension
 from tlslite.constants import CipherSuite, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, AlertLevel, GroupName
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, AlertLevel, GroupName
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -125,13 +126,13 @@ def main():
     # sanity check for Client Certificates
     conversation = Connect(hostname, port)
     node = conversation
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     if dhe:
         groups = [GroupName.secp256r1, GroupName.ffdhe2048]
@@ -144,8 +145,8 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-    ext = {ExtensionType.renegotiation_info:None,
-           ExtensionType.extended_master_secret:None}
+    ext = {ExtensionType.renegotiation_info: None,
+           ExtensionType.extended_master_secret: None}
     node = node.add_child(ExpectServerHello(version=(3, 3), extensions=ext))
     node = node.add_child(ExpectCertificate())
     if dhe:
@@ -171,13 +172,13 @@ def main():
         # sanity check for Client Certificates
         conversation = Connect(hostname, port)
         node = conversation
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                    'sha224', 'sha1', 'md5']]),
-               ExtensionType.signature_algorithms_cert :
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                   'sha224', 'sha1', 'md5']]),
+            ExtensionType.signature_algorithms_cert:
+                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
         if dhe:
             groups = [GroupName.secp256r1, GroupName.ffdhe2048]
@@ -190,8 +191,8 @@ def main():
             ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                        CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-        ext = {ExtensionType.renegotiation_info:None,
-               ExtensionType.extended_master_secret:None}
+        ext = {ExtensionType.renegotiation_info: None,
+               ExtensionType.extended_master_secret: None}
         node = node.add_child(ExpectServerHello(version=(3, 3), extensions=ext))
         node = node.add_child(ExpectCertificate())
         if dhe:
@@ -217,13 +218,13 @@ def main():
         # resume session with client certificates
         conversation = Connect(hostname, port)
         node = conversation
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                    'sha224', 'sha1', 'md5']]),
-               ExtensionType.signature_algorithms_cert :
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                   'sha224', 'sha1', 'md5']]),
+            ExtensionType.signature_algorithms_cert:
+                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
         if dhe:
             groups = [GroupName.secp256r1, GroupName.ffdhe2048]
@@ -236,8 +237,8 @@ def main():
             ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                        CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-        ext = {ExtensionType.renegotiation_info:None,
-               ExtensionType.extended_master_secret:None}
+        ext = {ExtensionType.renegotiation_info: None,
+               ExtensionType.extended_master_secret: None}
         node = node.add_child(ExpectServerHello(version=(3, 3), extensions=ext))
         node = node.add_child(ExpectCertificate())
         if dhe:
@@ -265,13 +266,13 @@ def main():
         node = node.add_child(ResetHandshakeHashes())
         node = node.add_child(ResetRenegotiationInfo())
 
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create([
-                 (getattr(HashAlgorithm, x),
-                  SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                    'sha224', 'sha1', 'md5']]),
-               ExtensionType.signature_algorithms_cert :
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+        ext = {ExtensionType.signature_algorithms:
+            SignatureAlgorithmsExtension().create([
+                (getattr(HashAlgorithm, x),
+                 SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                   'sha224', 'sha1', 'md5']]),
+            ExtensionType.signature_algorithms_cert:
+                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
         ext[ExtensionType.renegotiation_info] = None
         if dhe:
@@ -285,11 +286,11 @@ def main():
             ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                        CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-        ext = {ExtensionType.renegotiation_info:None,
-               ExtensionType.extended_master_secret:None}
+        ext = {ExtensionType.renegotiation_info: None,
+               ExtensionType.extended_master_secret: None}
         node = node.add_child(ExpectServerHello(version=(3, 3),
-                              extensions=ext,
-                              resume=True))
+                                                extensions=ext,
+                                                resume=True))
         node = node.add_child(ExpectChangeCipherSpec())
         node = node.add_child(ExpectFinished())
         node = node.add_child(ChangeCipherSpecGenerator())
@@ -322,7 +323,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -352,12 +353,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -376,14 +377,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -392,6 +393,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-extended-master-secret-extension.py
+++ b/scripts/test-extended-master-secret-extension.py
@@ -10,24 +10,23 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, Close, \
-        ResetHandshakeHashes, ResetRenegotiationInfo
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, Close, \
+    ResetHandshakeHashes, ResetRenegotiationInfo
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData, \
+    ExpectServerKeyExchange
 from tlsfuzzer.helpers import AutoEmptyExtension
 
 from tlslite.extensions import TLSExtension
 from tlslite.extensions import SupportedGroupsExtension
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsCertExtension
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, GroupName
+    ExtensionType, GroupName
 from tlsfuzzer.helpers import RSA_SIG_ALL
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 4
 
@@ -117,7 +116,7 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -157,7 +156,7 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -200,7 +199,7 @@ def main():
                                                extensions=ext))
     node = node.add_child(ExpectServerHello(
         version=(3, 2),
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -241,8 +240,8 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None}))
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -270,17 +269,17 @@ def main():
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        extensions={ExtensionType.renegotiation_info:None,
+        extensions={ExtensionType.renegotiation_info: None,
                     ExtensionType.extended_master_secret: AutoEmptyExtension(),
-                    ExtensionType.supported_groups:SupportedGroupsExtension().
-                    create([GroupName.secp256r1]),
+                    ExtensionType.supported_groups: SupportedGroupsExtension().
+                        create([GroupName.secp256r1]),
                     ExtensionType.signature_algorithms:
-                    SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
+                        SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
                     ExtensionType.signature_algorithms_cert:
-                    SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}))
+                        SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None}))
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
@@ -307,15 +306,15 @@ def main():
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        extensions={ExtensionType.renegotiation_info:None,
+        extensions={ExtensionType.renegotiation_info: None,
                     ExtensionType.extended_master_secret: AutoEmptyExtension(),
                     ExtensionType.signature_algorithms:
-                    SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
+                        SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
                     ExtensionType.signature_algorithms_cert:
-                    SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}))
+                        SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None}))
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
@@ -342,11 +341,11 @@ def main():
     node = conversation
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.extended_master_secret: \
-                TLSExtension(extType=ExtensionType.extended_master_secret) \
-                .create(bytearray(b'\x00'))}
+               TLSExtension(extType=ExtensionType.extended_master_secret) \
+                   .create(bytearray(b'\x00'))}
     if dhe:
         groups = [GroupName.secp256r1, GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -382,8 +381,8 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None}))
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -426,8 +425,8 @@ def main():
                                                extensions=ext))
     node = node.add_child(ExpectServerHello(
         version=(3, 2),
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None}))
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -467,7 +466,7 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -502,8 +501,8 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None}))
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -527,8 +526,8 @@ def main():
     node = node.add_child(ResetRenegotiationInfo())
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None},
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None},
         resume=True))
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
@@ -566,8 +565,8 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None}))
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -591,8 +590,8 @@ def main():
     node = node.add_child(ResetRenegotiationInfo())
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None},
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None},
         resume=True))
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
@@ -629,8 +628,8 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None}))
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -688,7 +687,7 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -722,8 +721,8 @@ def main():
             SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None},
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None},
         resume=False))
     node = node.add_child(ExpectCertificate())
     if dhe:
@@ -746,7 +745,7 @@ def main():
     node.add_child(Close())
 
     conversations["resume non-EMS session with EMS extension"] = \
-            conversation
+        conversation
 
     # EMS with renegotiation
     conversation = Connect(host, port)
@@ -767,8 +766,8 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None}))
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -782,11 +781,11 @@ def main():
     node = node.add_child(ResetHandshakeHashes())
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        session_id=bytearray(0), # do not resume
+        session_id=bytearray(0),  # do not resume
         extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None}))
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -798,7 +797,7 @@ def main():
     node = node.add_child(ExpectFinished())
     if http:
         node = node.add_child(ApplicationDataGenerator(
-               bytearray(b"GET / HTTP/1.0\n\n")))
+            bytearray(b"GET / HTTP/1.0\n\n")))
         node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
@@ -825,7 +824,7 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -849,11 +848,11 @@ def main():
             SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        session_id=bytearray(0), # do not resume
+        session_id=bytearray(0),  # do not resume
         extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None}))
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -893,8 +892,8 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None,
-                    ExtensionType.extended_master_secret:None}))
+        extensions={ExtensionType.renegotiation_info: None,
+                    ExtensionType.extended_master_secret: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -917,10 +916,10 @@ def main():
             SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        session_id=bytearray(0), # do not resume
+        session_id=bytearray(0),  # do not resume
         extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -959,7 +958,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -989,12 +988,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -1012,14 +1011,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -1028,6 +1027,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-extensions.py
+++ b/scripts/test-extensions.py
@@ -11,20 +11,21 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_message
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_message
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.extensions import TLSExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -140,7 +141,7 @@ def main():
                           for i in range(90, 90 + ext_n - 1))
         if ExtensionType.supports_npn in ext:
             del ext[ExtensionType.supports_npn]
-            ext[90+ext_n] = TLSExtension(extType=90+ext_n)
+            ext[90 + ext_n] = TLSExtension(extType=90 + ext_n)
         ext[ExtensionType.renegotiation_info] = None
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         ext = {ExtensionType.renegotiation_info: None}
@@ -170,7 +171,7 @@ def main():
                           for i in range(91, 90 + ext_n - 1))
         if ExtensionType.supports_npn in ext:
             del ext[ExtensionType.supports_npn]
-            ext[90+ext_n] = TLSExtension(extType=90+ext_n)
+            ext[90 + ext_n] = TLSExtension(extType=90 + ext_n)
         ext[ExtensionType.renegotiation_info] = None
         ext[90] = TLSExtension(extType=90)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -200,11 +201,11 @@ def main():
             ((j, TLSExtension(extType=j)) for j in range(90, 99)),
             [(ExtensionType.renegotiation_info, None)]))
         hello = ClientHelloGenerator(ciphers, extensions=ext)
-        node = node.add_child(fuzz_message(hello, xors={-42:i}))
+        node = node.add_child(fuzz_message(hello, xors={-42: i}))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.decode_error))
         node = node.add_child(ExpectClose())
-        conversations["fuzz ext length to {0}".format(41^i)] = conversation
+        conversations["fuzz ext length to {0}".format(41 ^ i)] = conversation
 
     # run the conversation
     good = 0
@@ -223,7 +224,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -253,35 +254,35 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
         else:
             if res:
-                good+=1
+                good += 1
                 print("OK")
             else:
-                bad+=1
+                bad += 1
                 failed.append(c_name)
 
     print("Test end")
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -290,6 +291,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-fallback-scsv.py
+++ b/scripts/test-fallback-scsv.py
@@ -10,20 +10,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType
+    GroupName, ExtensionType
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 version = 4
 
@@ -101,7 +100,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -144,7 +143,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -183,7 +182,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -226,7 +225,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -269,7 +268,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
@@ -308,7 +307,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -357,7 +356,7 @@ def main():
             ext = {}
             groups = [GroupName.secp256r1,
                       GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -406,7 +405,7 @@ def main():
             ext = {}
             groups = [GroupName.secp256r1,
                       GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -435,7 +434,7 @@ def main():
             ext = {}
             groups = [GroupName.secp256r1,
                       GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -484,7 +483,7 @@ def main():
             ext = {}
             groups = [GroupName.secp256r1,
                       GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -533,7 +532,7 @@ def main():
             ext = {}
             groups = [GroupName.secp256r1,
                       GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ciphers = [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV,
                        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -558,7 +557,7 @@ def main():
             ext = {}
             groups = [GroupName.secp256r1,
                       GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -601,7 +600,6 @@ def main():
             node.next_sibling = ExpectClose()
         conversations["FALLBACK - record SSL3.4 hello SSL3.4 - pos {0}".format(place)] = conversation
 
-
     # run the conversation
     good = 0
     bad = 0
@@ -619,7 +617,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -649,12 +647,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -672,14 +670,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -688,6 +686,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-ffdhe-expected-params.py
+++ b/scripts/test-ffdhe-expected-params.py
@@ -11,22 +11,21 @@ from itertools import chain
 from random import sample
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.extensions import \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlslite.mathtls import FFDHE_PARAMETERS
 import tlslite.dh as dh
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 version = 1
 
@@ -110,9 +109,9 @@ def main():
     except KeyError as e:
         raise ValueError(
             "Unrecognised group name: {0}, known names: {1}"
-            .format(str(e),
-                ", ".join("'{0}'".format(i) for i in
-                          FFDHE_PARAMETERS.keys())))
+                .format(str(e),
+                        ", ".join("'{0}'".format(i) for i in
+                                  FFDHE_PARAMETERS.keys())))
 
     if dh_file:
         with open(dh_file, "r") as f:
@@ -134,7 +133,7 @@ def main():
         SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                        renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
@@ -168,7 +167,7 @@ def main():
         SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                        renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange(valid_params=valid_params))
     node = node.add_child(ExpectServerHelloDone())
@@ -258,7 +257,7 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
@@ -274,6 +273,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-ffdhe-negotiation.py
+++ b/scripts/test-ffdhe-negotiation.py
@@ -12,20 +12,21 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, GroupName
+    ExtensionType, GroupName
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import sig_algs_to_ids, RSA_SIG_ALL
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -110,7 +111,7 @@ def main():
             SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
@@ -144,7 +145,7 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(cipher=CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                                             extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
@@ -171,7 +172,7 @@ def main():
         ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
         ext = {ExtensionType.renegotiation_info: None}
         ext[ExtensionType.supported_groups] = \
-                SupportedGroupsExtension().create([group])
+            SupportedGroupsExtension().create([group])
         if sig_algs:
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(sig_algs)
@@ -179,7 +180,7 @@ def main():
                 SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-            renegotiation_info:None}))
+                                                renegotiation_info: None}))
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerKeyExchange(valid_groups=[group]))
         node = node.add_child(ExpectServerHelloDone())
@@ -199,14 +200,14 @@ def main():
         node.add_child(ExpectClose())
 
         conversations["{0} negotiation".format(GroupName.toStr(group))] = \
-                conversation
+            conversation
 
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
         ext = {ExtensionType.renegotiation_info: None}
         ext[ExtensionType.supported_groups] = \
-                SupportedGroupsExtension().create([511, group])
+            SupportedGroupsExtension().create([511, group])
         if sig_algs:
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(sig_algs)
@@ -214,7 +215,7 @@ def main():
                 SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-            renegotiation_info:None}))
+                                                renegotiation_info: None}))
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerKeyExchange(valid_groups=[group]))
         node = node.add_child(ExpectServerHelloDone())
@@ -234,14 +235,14 @@ def main():
         node.add_child(ExpectClose())
 
         conversations["unassigned tolerance, {0} negotiation".format(GroupName.toStr(group))] = \
-                conversation
+            conversation
 
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
         ext = {ExtensionType.renegotiation_info: None}
         ext[ExtensionType.supported_groups] = \
-                SupportedGroupsExtension().create([GroupName.secp256r1, group])
+            SupportedGroupsExtension().create([GroupName.secp256r1, group])
         if sig_algs:
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(sig_algs)
@@ -249,7 +250,7 @@ def main():
                 SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-            renegotiation_info:None}))
+                                                renegotiation_info: None}))
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerKeyExchange(valid_groups=[group]))
         node = node.add_child(ExpectServerHelloDone())
@@ -270,7 +271,7 @@ def main():
 
         conversations["tolerate ECC curve in groups without ECC cipher, "
                       "negotiate {0} ".format(GroupName.toStr(group))] = \
-                conversation
+            conversation
 
         for group2 in GroupName.allFF:
             if group == group2:
@@ -280,7 +281,7 @@ def main():
             ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
             ext = {ExtensionType.renegotiation_info: None}
             ext[ExtensionType.supported_groups] = \
-                    SupportedGroupsExtension().create([511, group, group2])
+                SupportedGroupsExtension().create([511, group, group2])
             if sig_algs:
                 ext[ExtensionType.signature_algorithms] = \
                     SignatureAlgorithmsExtension().create(sig_algs)
@@ -289,7 +290,7 @@ def main():
             node = node.add_child(ClientHelloGenerator(ciphers,
                                                        extensions=ext))
             node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                renegotiation_info:None}))
+                                                    renegotiation_info: None}))
             node = node.add_child(ExpectCertificate())
             node = node.add_child(ExpectServerKeyExchange(
                 valid_groups=[group, group2]))
@@ -310,7 +311,7 @@ def main():
             node.add_child(ExpectClose())
 
             conversations["{0} or {1} negotiation".format(GroupName.toStr(group),
-                    GroupName.toStr(group2))] = conversation
+                                                          GroupName.toStr(group2))] = conversation
 
     conversation = Connect(host, port)
     node = conversation
@@ -318,7 +319,7 @@ def main():
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None}
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create([511])
+        SupportedGroupsExtension().create([511])
     if sig_algs:
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(sig_algs)
@@ -327,7 +328,7 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(cipher=CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                                             extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -353,7 +354,7 @@ def main():
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None}
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create([GroupName.secp256r1, 511])
+        SupportedGroupsExtension().create([GroupName.secp256r1, 511])
     if sig_algs:
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(sig_algs)
@@ -362,7 +363,7 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(cipher=CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                                             extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -389,7 +390,7 @@ def main():
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None}
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create([511])
+        SupportedGroupsExtension().create([511])
     if sig_algs:
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(sig_algs)
@@ -401,7 +402,6 @@ def main():
     node.add_child(ExpectClose())
 
     conversations["no overlap between groups"] = conversation
-
 
     good = 0
     bad = 0
@@ -418,7 +418,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -448,12 +448,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -469,14 +469,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -485,6 +485,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-fuzzed-MAC.py
+++ b/scripts/test-fuzzed-MAC.py
@@ -11,17 +11,18 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        fuzz_mac, AlertGenerator, fuzz_padding
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    fuzz_mac, AlertGenerator, fuzz_padding
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -109,18 +110,18 @@ def main():
     conversations["sanity"] = conversation
 
     for pos, val in [
-                     (-1, 0x01),
-                     (-1, 0xff),
-                     (-2, 0x01),
-                     (-2, 0xff),
-                     (-6, 0x01),
-                     (-6, 0xff),
-                     (-12, 0x01),
-                     (-12, 0xff),
-                     (-20, 0x01),
-                     (-20, 0xff),
-                     # SHA-1 HMAC has just 20 bytes
-                     ]:
+        (-1, 0x01),
+        (-1, 0xff),
+        (-2, 0x01),
+        (-2, 0xff),
+        (-6, 0x01),
+        (-6, 0xff),
+        (-12, 0x01),
+        (-12, 0xff),
+        (-20, 0x01),
+        (-20, 0xff),
+        # SHA-1 HMAC has just 20 bytes
+    ]:
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
@@ -135,14 +136,14 @@ def main():
         node = node.add_child(ExpectChangeCipherSpec())
         node = node.add_child(ExpectFinished())
         node = node.add_child(fuzz_mac(ApplicationDataGenerator(
-                                                        b"GET / HTTP/1.0\n\n"),
-                                       xors={pos:val}))
+            b"GET / HTTP/1.0\n\n"),
+            xors={pos: val}))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.bad_record_mac))
         node = node.add_child(ExpectClose())
 
         conversations["XOR position " + str(pos) + " with " + str(hex(val))] = \
-                conversation
+            conversation
 
         conversation = Connect(host, port)
         node = conversation
@@ -160,14 +161,14 @@ def main():
         app_data = b"GET / HTTP/1.0\r\nX-Fo: 0\r\n\r\n"
         assert (len(app_data) + 20 + 1) % 16 == 0
         node = node.add_child(fuzz_mac(ApplicationDataGenerator(app_data),
-                                       xors={pos:val}))
+                                       xors={pos: val}))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.bad_record_mac))
         node = node.add_child(ExpectClose())
 
         conversations["XOR position {0} with {1} (short pad)"
-                      .format(pos, hex(val))] = \
-                conversation
+            .format(pos, hex(val))] = \
+            conversation
 
         conversation = Connect(host, port)
         node = conversation
@@ -189,14 +190,14 @@ def main():
         assert (len(text) + hmac_tag_length) % block_size == 0
         node = node.add_child(fuzz_mac(fuzz_padding(ApplicationDataGenerator(text),
                                                     min_length=255),
-                                       xors={pos:val}))
+                                       xors={pos: val}))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.bad_record_mac))
         node = node.add_child(ExpectClose())
 
         conversations["XOR position {0} with {1} (long pad)"
-                      .format(pos, hex(val))] = \
-                conversation
+            .format(pos, hex(val))] = \
+            conversation
 
     # run the conversation
     good = 0
@@ -215,7 +216,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -245,12 +246,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
                     bad += 1
                     failed.append(c_name)
                     print("Expected error message: {0}\n"
-                        .format(expected_failures[c_name]))
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -266,14 +267,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -282,6 +283,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-fuzzed-ciphertext.py
+++ b/scripts/test-fuzzed-ciphertext.py
@@ -12,17 +12,18 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        fuzz_encrypted_message, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    fuzz_encrypted_message, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -87,7 +88,7 @@ def main():
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
-        CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers))
     node = node.add_child(ExpectServerHello())
     node = node.add_child(ExpectCertificate())
@@ -111,12 +112,12 @@ def main():
     # 16 chars: GCM tag 128 bit
     # 1 char: experimentally determined there mysteriously is one more byte
     #         in the message.
-    fuzzes = [(-i, 1) for i in range(1,8+16+16+1)]
+    fuzzes = [(-i, 1) for i in range(1, 8 + 16 + 16 + 1)]
     for pos, val in fuzzes:
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
-            CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         node = node.add_child(ClientHelloGenerator(ciphers))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectCertificate())
@@ -127,13 +128,13 @@ def main():
         node = node.add_child(ExpectChangeCipherSpec())
         node = node.add_child(ExpectFinished())
         node = node.add_child(fuzz_encrypted_message(
-            ApplicationDataGenerator(b"GET / HTTP/1.0\n\n"), xors={pos:val}))
+            ApplicationDataGenerator(b"GET / HTTP/1.0\n\n"), xors={pos: val}))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.bad_record_mac))
         node = node.add_child(ExpectClose())
 
         conversations["XOR position " + str(pos) + " with " + str(hex(val))] = \
-                conversation
+            conversation
 
     # run the conversation
     good = 0
@@ -152,7 +153,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -182,12 +183,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -203,14 +204,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -219,6 +220,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-fuzzed-finished.py
+++ b/scripts/test-fuzzed-finished.py
@@ -10,17 +10,18 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_message
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_message
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -105,18 +106,18 @@ def main():
     conversations["sanity"] = conversation
 
     for pos, val in [
-                     (-1, 0x01),
-                     (-1, 0xff),
-                     (-2, 0x01),
-                     (-2, 0xff),
-                     (-6, 0x01),
-                     (-6, 0xff),
-                     (-12, 0x01),
-                     (-12, 0xff),
-                     # Finished messages have just 12 octets of data so
-                     # by going to -13 we would be modifying the length
-                     # of the message
-                     ]:
+        (-1, 0x01),
+        (-1, 0xff),
+        (-2, 0x01),
+        (-2, 0xff),
+        (-6, 0x01),
+        (-6, 0xff),
+        (-12, 0x01),
+        (-12, 0xff),
+        # Finished messages have just 12 octets of data so
+        # by going to -13 we would be modifying the length
+        # of the message
+    ]:
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
@@ -127,16 +128,16 @@ def main():
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(ClientKeyExchangeGenerator())
         node = node.add_child(ChangeCipherSpecGenerator())
-        node = node.add_child(fuzz_message(FinishedGenerator(), xors={pos:val}))
-        #node = node.add_child(ExpectChangeCipherSpec())
-        #node = node.add_child(ExpectFinished())
+        node = node.add_child(fuzz_message(FinishedGenerator(), xors={pos: val}))
+        # node = node.add_child(ExpectChangeCipherSpec())
+        # node = node.add_child(ExpectFinished())
         node = node.add_child(ExpectAlert(level=AlertLevel.fatal,
                                           description=AlertDescription.decrypt_error))
         node.next_sibling = ExpectClose()
         node = node.add_child(ExpectClose())
 
         conversations["XOR position " + str(pos) + " with " + str(hex(val))] = \
-                conversation
+            conversation
 
     # run the conversation
     good = 0
@@ -155,7 +156,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -185,12 +186,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -206,14 +207,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -222,6 +223,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-fuzzed-padding.py
+++ b/scripts/test-fuzzed-padding.py
@@ -11,21 +11,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        fuzz_padding, CertificateGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    fuzz_padding, CertificateGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData, ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        SignatureScheme, GroupName, ExtensionType
+    SignatureScheme, GroupName, ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import SupportedGroupsExtension, SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 version = 4
 
@@ -100,7 +99,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -143,25 +142,25 @@ def main():
     conversations["sanity"] = conversation
 
     for pos, val in [
-                     (-1, 0x01),
-                     (-1, 0xff),
-                     (-2, 0x01),
-                     (-2, 0xff),
-                     (-6, 0x01),
-                     (-6, 0xff),
-                     (-12, 0x01),
-                     (-12, 0xff),
-                     (-20, 0x01),
-                     (-20, 0xff),
-                     # we're generating at least 20 bytes of padding
-                     ]:
+        (-1, 0x01),
+        (-1, 0xff),
+        (-2, 0x01),
+        (-2, 0xff),
+        (-6, 0x01),
+        (-6, 0xff),
+        (-12, 0x01),
+        (-12, 0xff),
+        (-20, 0x01),
+        (-20, 0xff),
+        # we're generating at least 20 bytes of padding
+    ]:
         conversation = Connect(host, port)
         node = conversation
         if dhe:
             ext = {}
             groups = [GroupName.secp256r1,
                       GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -195,16 +194,16 @@ def main():
         node = node.add_child(ExpectChangeCipherSpec())
         node = node.add_child(ExpectFinished())
         node = node.add_child(fuzz_padding(ApplicationDataGenerator(
-                                                        b"GET / HTTP/1.0\n\n"),
-                                           xors={pos:val},
-                                           min_length=20))
+            b"GET / HTTP/1.0\n\n"),
+            xors={pos: val},
+            min_length=20))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.bad_record_mac))
-#        node.next_sibling = ExpectClose()
+        #        node.next_sibling = ExpectClose()
         node = node.add_child(ExpectClose())
 
         conversations["XOR position " + str(pos) + " with " + str(hex(val))] = \
-                conversation
+            conversation
 
     # zero-fill the padding
     conversation = Connect(host, port)
@@ -213,7 +212,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -252,14 +251,14 @@ def main():
     # which means the padding will be two bytes - 1 byte of padding and one
     # byte length
     node = node.add_child(fuzz_padding(ApplicationDataGenerator(
-                                                    b"GET / HTTP"),
-                                       substitutions={0:0}))
+        b"GET / HTTP"),
+        substitutions={0: 0}))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.bad_record_mac))
     node = node.add_child(ExpectClose())
 
     conversations["zero-filled"] = \
-            conversation
+        conversation
 
     # run the conversation
     good = 0
@@ -278,7 +277,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -308,12 +307,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -331,14 +330,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -347,6 +346,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-fuzzed-plaintext.py
+++ b/scripts/test-fuzzed-plaintext.py
@@ -13,22 +13,21 @@ from math import ceil
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, replace_plaintext, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, replace_plaintext, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData, ExpectServerKeyExchange
 from tlsfuzzer.fuzzers import structured_random_iter, StructuredRandom
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import SIG_ALL
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType
+    GroupName, ExtensionType
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
-
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 
 version = 8
 
@@ -78,7 +77,7 @@ def help_msg():
 def add_dhe_extensions(extensions):
     groups = [GroupName.secp256r1,
               GroupName.ffdhe2048]
-    extensions[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    extensions[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     extensions[ExtensionType.signature_algorithms] = \
         SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -127,8 +126,8 @@ def add_app_data_conversation(conversations, host, port, cipher, dhe, data):
                                       AlertDescription.bad_record_mac))
     node = node.add_child(ExpectClose())
     conversations["encrypted Application Data plaintext of {0}"
-                  .format(data)] = \
-            conversation
+        .format(data)] = \
+        conversation
 
 
 def add_handshake_conversation(conversations, host, port, cipher, dhe, data):
@@ -169,7 +168,7 @@ def add_handshake_conversation(conversations, host, port, cipher, dhe, data):
                                       AlertDescription.bad_record_mac))
     node = node.add_child(ExpectClose())
     conversations["encrypted Handshake plaintext of {0}".format(data)] = \
-            conversation
+        conversation
 
 
 def str_to_int_or_none(text):
@@ -207,7 +206,7 @@ def main():
 
     argv = sys.argv[1:]
     opts, args = getopt.getopt(argv, "h:p:e:x:X:n:dC:", ["help", "random=",
-                                                     "1/n-1", "0/n"])
+                                                         "1/n-1", "0/n"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -225,7 +224,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '--random':
-            rand_limit = int(arg)//2
+            rand_limit = int(arg) // 2
         elif opt == '-d':
             dhe = True
         elif opt == '--1/n-1':
@@ -261,9 +260,8 @@ def main():
     if block_size == 8:
         rand_limit *= 2
 
-
     dhe = cipher in CipherSuite.ecdhAllSuites or \
-            cipher in CipherSuite.dhAllSuites
+          cipher in CipherSuite.dhAllSuites
 
     if args:
         run_only = set(args)
@@ -321,7 +319,7 @@ def main():
     node.next_sibling = ExpectClose()
     node = node.add_child(ExpectClose())
     conversations["sanity"] = \
-            conversation
+        conversation
 
     # test all combinations of lengths and values for plaintexts up to 256
     # bytes long with uniform content (where every byte has the same value)
@@ -349,7 +347,7 @@ def main():
 
     # 2**14 is the TLS protocol max
     rand = structured_random_iter(rand_len_to_generate,
-                                  min_length=block_size, max_length=2**14,
+                                  min_length=block_size, max_length=2 ** 14,
                                   step=block_size)
 
     if not run_only:
@@ -394,7 +392,7 @@ def main():
 
     # 2**14 is the TLS protocol max
     rand = structured_random_iter(rand_len_to_generate,
-                                  min_length=block_size, max_length=2**14,
+                                  min_length=block_size, max_length=2 ** 14,
                                   step=block_size)
 
     if not run_only:
@@ -454,12 +452,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -485,14 +483,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -501,6 +499,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-heartbeat.py
+++ b/scripts/test-heartbeat.py
@@ -10,23 +10,21 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        HeartbeatGenerator, SetMaxRecordSize, fuzz_message
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    HeartbeatGenerator, SetMaxRecordSize, fuzz_message
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange, ExpectHeartbeat
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange, ExpectHeartbeat
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
 
-
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType, HeartbeatMode
+    GroupName, ExtensionType, HeartbeatMode
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
-        HeartbeatExtension
-
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+    HeartbeatExtension
 
 version = 4
 
@@ -55,7 +53,7 @@ def help_msg():
 def add_dhe_extensions(extensions):
     groups = [GroupName.secp256r1,
               GroupName.ffdhe2048]
-    extensions[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    extensions[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     extensions[ExtensionType.signature_algorithms] = \
         SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -141,7 +139,7 @@ def main():
     conversation = Connect(host, port)
     node = conversation
     ext = {ExtensionType.heartbeat: HeartbeatExtension()
-           .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
+        .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -176,7 +174,7 @@ def main():
     conversation = Connect(host, port)
     node = conversation
     ext = {ExtensionType.heartbeat: HeartbeatExtension()
-           .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
+        .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -187,7 +185,7 @@ def main():
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     ext = {ExtensionType.heartbeat:
-           HeartbeatExtension().create(HeartbeatMode.PEER_ALLOWED_TO_SEND),
+               HeartbeatExtension().create(HeartbeatMode.PEER_ALLOWED_TO_SEND),
            ExtensionType.renegotiation_info: None}
     node = node.add_child(ExpectServerHello(extensions=ext))
     node = node.add_child(ExpectCertificate())
@@ -207,13 +205,13 @@ def main():
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["negotiate and check for peer_allowed_to_send"] = \
-            conversation
+        conversation
 
     # send valid heartbeat, check for reply
     conversation = Connect(host, port)
     node = conversation
     ext = {ExtensionType.heartbeat: HeartbeatExtension()
-           .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
+        .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -245,13 +243,13 @@ def main():
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["check if server replies to heartbeats after handshake"] = \
-            conversation
+        conversation
 
     # verify that padding is minimal in responses
     conversation = Connect(host, port)
     node = conversation
     ext = {ExtensionType.heartbeat: HeartbeatExtension()
-           .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
+        .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -284,13 +282,13 @@ def main():
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["check padding size in response"] = \
-            conversation
+        conversation
 
     # send valid empty heartbeat, check for reply
     conversation = Connect(host, port)
     node = conversation
     ext = {ExtensionType.heartbeat: HeartbeatExtension()
-           .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
+        .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -322,13 +320,13 @@ def main():
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["empty heartbeat"] = \
-            conversation
+        conversation
 
     # verify that server replies with minimal size of padding
     conversation = Connect(host, port)
     node = conversation
     ext = {ExtensionType.heartbeat: HeartbeatExtension()
-           .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
+        .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -361,14 +359,14 @@ def main():
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["empty heartbeat - verify padding size"] = \
-            conversation
+        conversation
 
     # check if server will reply to requests even if we set that we don't
     # want any requests
     conversation = Connect(host, port)
     node = conversation
     ext = {ExtensionType.heartbeat: HeartbeatExtension()
-           .create(HeartbeatMode.PEER_NOT_ALLOWED_TO_SEND)}
+        .create(HeartbeatMode.PEER_NOT_ALLOWED_TO_SEND)}
     if dhe:
         add_dhe_extensions(ext)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -400,7 +398,7 @@ def main():
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["heartbeat with peer_not_allowed_to_send"] = \
-            conversation
+        conversation
 
     # check if invalid modes are rejected by server
     # 1 and 2 are allocated
@@ -408,7 +406,7 @@ def main():
         conversation = Connect(host, port)
         node = conversation
         ext = {ExtensionType.heartbeat: HeartbeatExtension()
-               .create(mode)}
+            .create(mode)}
         if dhe:
             add_dhe_extensions(ext)
             ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -422,14 +420,14 @@ def main():
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["invalid mode in extension - {0}".format(mode)] = \
-                conversation
+            conversation
 
     # invalid type of heartbeat type
     for hb_type in chain([0], range(2, 256)):
         conversation = Connect(host, port)
         node = conversation
         ext = {ExtensionType.heartbeat: HeartbeatExtension()
-               .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
+            .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
         if dhe:
             add_dhe_extensions(ext)
             ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -463,14 +461,14 @@ def main():
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
         conversations["invalid heartbeat type - {0}".format(hb_type)] = \
-                conversation
+            conversation
 
     for pad_len in range(0, 16):
         # check too small padding with empty payload
         conversation = Connect(host, port)
         node = conversation
         ext = {ExtensionType.heartbeat: HeartbeatExtension()
-               .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
+            .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
         if dhe:
             add_dhe_extensions(ext)
             ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -502,12 +500,12 @@ def main():
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
         conversations["empty heartbeat, small padding - {0}".format(pad_len)] = \
-                conversation
+            conversation
 
         conversation = Connect(host, port)
         node = conversation
         ext = {ExtensionType.heartbeat: HeartbeatExtension()
-               .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
+            .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
         if dhe:
             add_dhe_extensions(ext)
             ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -539,16 +537,16 @@ def main():
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
         conversations["heartbeat with small padding - {0}".format(pad_len)] = \
-                conversation
+            conversation
 
     # check if server replies with small padding even if we send large one
     # and that if we send too large padding, the server rejects the message
     # as malformed
-    for pad_size in [17, 32, 64, 128, 1024, 2**14-3-14, 2**14-3-13]:
+    for pad_size in [17, 32, 64, 128, 1024, 2 ** 14 - 3 - 14, 2 ** 14 - 3 - 13]:
         conversation = Connect(host, port)
         node = conversation
         ext = {ExtensionType.heartbeat: HeartbeatExtension()
-               .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
+            .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
         if dhe:
             add_dhe_extensions(ext)
             ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -570,11 +568,11 @@ def main():
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ExpectChangeCipherSpec())
         node = node.add_child(ExpectFinished())
-        if pad_size > 2**13:
-            node = node.add_child(SetMaxRecordSize(2**16))
+        if pad_size > 2 ** 13:
+            node = node.add_child(SetMaxRecordSize(2 ** 16))
         node = node.add_child(HeartbeatGenerator(bytearray(b'heartbeat test'),
                                                  padding_length=pad_size))
-        if pad_size > 2**14-3-14:
+        if pad_size > 2 ** 14 - 3 - 14:
             node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                               AlertDescription.record_overflow))
         else:
@@ -588,8 +586,8 @@ def main():
             node = node.add_child(ExpectAlert())
             node.next_sibling = ExpectClose()
         conversations["large padding ({0}) check padding size in response"
-                      .format(pad_size)] = \
-                conversation
+            .format(pad_size)] = \
+            conversation
 
     # fuzz the payload_length in message
     # the length is in the 2nd and 3rd byte from the beginning
@@ -602,7 +600,7 @@ def main():
         conversation = Connect(host, port)
         node = conversation
         ext = {ExtensionType.heartbeat: HeartbeatExtension()
-               .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
+            .create(HeartbeatMode.PEER_ALLOWED_TO_SEND)}
         if dhe:
             add_dhe_extensions(ext)
             ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -625,8 +623,8 @@ def main():
         node = node.add_child(ExpectChangeCipherSpec())
         node = node.add_child(ExpectFinished())
         node = node.add_child(
-                fuzz_message(HeartbeatGenerator(bytearray(b'some payload?')),
-                             substitutions=subs))
+            fuzz_message(HeartbeatGenerator(bytearray(b'some payload?')),
+                         substitutions=subs))
         node = node.add_child(ApplicationDataGenerator(
             bytearray(b"GET / HTTP/1.0\r\n\r\n")))
         node = node.add_child(ExpectApplicationData())
@@ -635,8 +633,8 @@ def main():
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
         conversations["heartbeat with fuzzed payload length - {0}"
-                      .format(subs)] = \
-                conversation
+            .format(subs)] = \
+            conversation
 
     # run the conversation
     good = 0
@@ -655,7 +653,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -685,12 +683,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -710,14 +708,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -726,6 +724,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-hello-request-by-client.py
+++ b/scripts/test-hello-request-by-client.py
@@ -11,18 +11,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, RawMessageGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, RawMessageGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -81,7 +82,6 @@ def main():
     else:
         run_only = None
 
-
     conversations = {}
 
     conversation = Connect(host, port)
@@ -134,7 +134,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -164,12 +164,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -185,14 +185,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -201,6 +201,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-interleaved-application-data-and-fragmented-handshakes-in-renegotiation.py
+++ b/scripts/test-interleaved-application-data-and-fragmented-handshakes-in-renegotiation.py
@@ -10,18 +10,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, split_message, FlushMessageList
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, split_message, FlushMessageList
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -111,12 +112,12 @@ def main():
 
     conver = Connect(host, port)
     node = conver
-    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    # ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
     #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -129,12 +130,12 @@ def main():
     fragment_list = []
     node = node.add_child(split_message(ClientHelloGenerator([CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA],
                                                              session_id=bytearray(0),
-                                                             extensions={ExtensionType.renegotiation_info:None}),
+                                                             extensions={ExtensionType.renegotiation_info: None}),
                                         fragment_list, 30))
     # interleaved AppData
     node = node.add_child(ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0")))
     node = node.add_child(FlushMessageList(fragment_list))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -153,12 +154,12 @@ def main():
 
     conver = Connect(host, port)
     node = conver
-    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    # ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
     #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -170,8 +171,8 @@ def main():
     node = node.add_child(ResetHandshakeHashes())
     node = node.add_child(ClientHelloGenerator([CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA],
                                                session_id=bytearray(0),
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     fragment_list = []
@@ -193,16 +194,16 @@ def main():
     conversations["Application data inside Client Key Exchange"] = conver
 
     # CCS is one byte, can't split it
-    #conversations["Application data inside Change Cipher Spec"] = conver
+    # conversations["Application data inside Change Cipher Spec"] = conver
 
     conver = Connect(host, port)
     node = conver
-    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    # ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
     #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -214,8 +215,8 @@ def main():
     node = node.add_child(ResetHandshakeHashes())
     node = node.add_child(ClientHelloGenerator([CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA],
                                                session_id=bytearray(0),
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -246,7 +247,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -276,12 +277,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -297,14 +298,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -313,6 +314,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-interleaved-application-data-in-renegotiation.py
+++ b/scripts/test-interleaved-application-data-in-renegotiation.py
@@ -11,18 +11,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -114,12 +115,12 @@ def main():
     # before CKE
     conver = Connect(host, port)
     node = conver
-    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    # ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
     #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -131,8 +132,8 @@ def main():
     node = node.add_child(ResetHandshakeHashes())
     node = node.add_child(ClientHelloGenerator([CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA],
                                                session_id=bytearray(0),
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     # interleaved AppData
@@ -153,12 +154,12 @@ def main():
 
     conver = Connect(host, port)
     node = conver
-    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    # ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
     #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -170,8 +171,8 @@ def main():
     node = node.add_child(ResetHandshakeHashes())
     node = node.add_child(ClientHelloGenerator([CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA],
                                                session_id=bytearray(0),
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -192,12 +193,12 @@ def main():
 
     conver = Connect(host, port)
     node = conver
-    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    # ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
     #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -209,8 +210,8 @@ def main():
     node = node.add_child(ResetHandshakeHashes())
     node = node.add_child(ClientHelloGenerator([CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA],
                                                session_id=bytearray(0),
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -239,7 +240,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -269,12 +270,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -290,14 +291,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -306,6 +307,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-invalid-cipher-suites.py
+++ b/scripts/test-invalid-cipher-suites.py
@@ -10,19 +10,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, SetMaxRecordSize, pad_handshake
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, SetMaxRecordSize, pad_handshake
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.extensions import TLSExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -88,33 +89,32 @@ def main():
     conversations = {}
 
     for name, ciphers in [
-                          ("NULL_NULL cipher", [0x00]),
-                          ("FORTEZZA", range(0x1c,0x1e)),
-                          ("Unknown 0x0047", range(0x47, 0x60)),
-                          ("EXPORT1024", range(0x60, 0x66)),
-                          ("TLS_DHE_DSS_WITH_RC4_128_SHA", [0x66]),
-                          ("Unknown 0x006e", range(0x6e, 0x80)),
-                          ("GOST", range(0x80, 0x84)),
-                          ("Unknown 0x00c6", range(0xc6, 0xff)),
-                          ("TLS_EMPTY_RENEGOTIATION_INFO_SCSV", [0xff]),
-                          ("Unknown 0x0100", range(0x0100, 0x1001)),
-                          ("Unknown 0x2000", range(0x2000, 0x3001)),
-                          ("Unknown 0x3000", range(0x3000, 0x4001)),
-                          ("Unknown 0x4000", range(0x4000, 0x5001)),
-                          ("Unknown 0x5000", range(0x5000, 0x6001)),
-                          ("Unknown 0x6000", range(0x6000, 0x7001)),
-                          ("Unknown 0x7000", range(0x7000, 0x8001)),
-                          ("Unknown 0x8000", range(0x8000, 0x9001)),
-                          ("Unknown 0x9000", range(0x9000, 0xa001)),
-                          ("Unknown 0xa000", range(0xa000, 0xb001)),
-                          ("Unknown 0xb000", range(0xb000, 0xc001)),
-                          ("Unknown 0xc0b0", range(0xc0b0, 0xcca8)),
-                          ("Unknown 0xccaf", range(0xccaf, 0xd000)),
-                          ("Unknown 0xd000", range(0xd000, 0xe001)),
-                          ("Unknown 0xe000", range(0xe000, 0xf001)),
-                          ("Unknown 0xf000", range(0xf000, 0xffff)),
-                          ]:
-
+        ("NULL_NULL cipher", [0x00]),
+        ("FORTEZZA", range(0x1c, 0x1e)),
+        ("Unknown 0x0047", range(0x47, 0x60)),
+        ("EXPORT1024", range(0x60, 0x66)),
+        ("TLS_DHE_DSS_WITH_RC4_128_SHA", [0x66]),
+        ("Unknown 0x006e", range(0x6e, 0x80)),
+        ("GOST", range(0x80, 0x84)),
+        ("Unknown 0x00c6", range(0xc6, 0xff)),
+        ("TLS_EMPTY_RENEGOTIATION_INFO_SCSV", [0xff]),
+        ("Unknown 0x0100", range(0x0100, 0x1001)),
+        ("Unknown 0x2000", range(0x2000, 0x3001)),
+        ("Unknown 0x3000", range(0x3000, 0x4001)),
+        ("Unknown 0x4000", range(0x4000, 0x5001)),
+        ("Unknown 0x5000", range(0x5000, 0x6001)),
+        ("Unknown 0x6000", range(0x6000, 0x7001)),
+        ("Unknown 0x7000", range(0x7000, 0x8001)),
+        ("Unknown 0x8000", range(0x8000, 0x9001)),
+        ("Unknown 0x9000", range(0x9000, 0xa001)),
+        ("Unknown 0xa000", range(0xa000, 0xb001)),
+        ("Unknown 0xb000", range(0xb000, 0xc001)),
+        ("Unknown 0xc0b0", range(0xc0b0, 0xcca8)),
+        ("Unknown 0xccaf", range(0xccaf, 0xd000)),
+        ("Unknown 0xd000", range(0xd000, 0xe001)),
+        ("Unknown 0xe000", range(0xe000, 0xf001)),
+        ("Unknown 0xf000", range(0xf000, 0xffff)),
+    ]:
         conversation = Connect(host, port)
         node = conversation
 
@@ -163,7 +163,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -193,12 +193,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -214,14 +214,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -230,6 +230,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-invalid-client-hello-w-record-overflow.py
+++ b/scripts/test-invalid-client-hello-w-record-overflow.py
@@ -10,18 +10,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_message
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_message
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -87,7 +88,7 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3)))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -110,7 +111,7 @@ def main():
     ext = {ExtensionType.renegotiation_info: None}
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -140,7 +141,6 @@ def main():
         node = node.add_child(ExpectClose())
         conversations["Client Hello type fuzz to {0}".format(1 ^ i)] = conversation
 
-
     # test invalid sizes for session ID length
     for i in range(1, 0x100):
         conversation = Connect(host, port)
@@ -167,7 +167,6 @@ def main():
         node = node.add_child(ExpectClose())
         conversations["session ID len fuzz to {0} w/ext".format(i)] = conversation
 
-
     # test invalid sizes for cipher suites length
     for i in range(1, 0x100):
         conversation = Connect(host, port)
@@ -192,7 +191,7 @@ def main():
             node = node.add_child(ExpectAlert(level=AlertLevel.fatal,
                                               description=AlertDescription.decode_error))
             node = node.add_child(ExpectClose())
-            conversations["cipher suites len fuzz to {0}".format((i<<8) + j)] = conversation
+            conversations["cipher suites len fuzz to {0}".format((i << 8) + j)] = conversation
 
     for i in range(1, 0x100):
         conversation = Connect(host, port)
@@ -219,7 +218,7 @@ def main():
             node = node.add_child(ExpectAlert(level=AlertLevel.fatal,
                                               description=AlertDescription.decode_error))
             node = node.add_child(ExpectClose())
-            conversations["cipher suites len fuzz to {0} w/ext".format((i<<8) + j)] = conversation
+            conversations["cipher suites len fuzz to {0} w/ext".format((i << 8) + j)] = conversation
 
     # test invalid sizes for compression methods
     for i in range(1, 0x100):
@@ -275,7 +274,7 @@ def main():
             node = node.add_child(ExpectAlert(level=AlertLevel.fatal,
                                               description=AlertDescription.decode_error))
             node = node.add_child(ExpectClose())
-            conversations["extensions len fuzz to {0}".format((i<<8)+j)] = conversation
+            conversations["extensions len fuzz to {0}".format((i << 8) + j)] = conversation
 
     # run the conversation
     good = 0
@@ -319,35 +318,35 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
         else:
             if res:
-                good+=1
+                good += 1
                 print("OK")
             else:
-                bad+=1
+                bad += 1
                 failed.append(c_name)
 
     print("Test end")
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -356,6 +355,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-invalid-client-hello.py
+++ b/scripts/test-invalid-client-hello.py
@@ -11,18 +11,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_message
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_message
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -88,7 +89,7 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3)))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -111,7 +112,7 @@ def main():
     ext = {ExtensionType.renegotiation_info: None}
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -141,7 +142,6 @@ def main():
         node = node.add_child(ExpectClose())
         conversations["Client Hello type fuzz to {0}".format(1 ^ i)] = conversation
 
-
     # test invalid sizes for session ID length
     for i in range(1, 0x100):
         conversation = Connect(host, port)
@@ -168,7 +168,6 @@ def main():
         node = node.add_child(ExpectClose())
         conversations["session ID len fuzz to {0} w/ext".format(i)] = conversation
 
-
     # test invalid sizes for cipher suites length
     for i in range(1, 0x100):
         conversation = Connect(host, port)
@@ -193,7 +192,7 @@ def main():
             node = node.add_child(ExpectAlert(level=AlertLevel.fatal,
                                               description=AlertDescription.decode_error))
             node = node.add_child(ExpectClose())
-            conversations["cipher suites len fuzz to {0}".format((i<<8) + j)] = conversation
+            conversations["cipher suites len fuzz to {0}".format((i << 8) + j)] = conversation
 
     for i in range(1, 0x100):
         conversation = Connect(host, port)
@@ -220,7 +219,7 @@ def main():
             node = node.add_child(ExpectAlert(level=AlertLevel.fatal,
                                               description=AlertDescription.decode_error))
             node = node.add_child(ExpectClose())
-            conversations["cipher suites len fuzz to {0} w/ext".format((i<<8) + j)] = conversation
+            conversations["cipher suites len fuzz to {0} w/ext".format((i << 8) + j)] = conversation
 
     # test invalid sizes for compression methods
     for i in range(1, 0x100):
@@ -276,7 +275,7 @@ def main():
             node = node.add_child(ExpectAlert(level=AlertLevel.fatal,
                                               description=AlertDescription.decode_error))
             node = node.add_child(ExpectClose())
-            conversations["extensions len fuzz to {0}".format((i<<8)+j)] = conversation
+            conversations["extensions len fuzz to {0}".format((i << 8) + j)] = conversation
 
     # run the conversation
     good = 0
@@ -322,12 +321,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -343,14 +342,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -359,6 +358,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-invalid-compression-methods.py
+++ b/scripts/test-invalid-compression-methods.py
@@ -10,18 +10,17 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, SetMaxRecordSize, pad_handshake
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, SetMaxRecordSize, pad_handshake
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.extensions import TLSExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 4
 
@@ -132,7 +131,6 @@ def main():
 
     conversations['only deflate compression method'] = conversation
 
-
     # run the conversation
     good = 0
     bad = 0
@@ -150,7 +148,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -180,12 +178,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -203,14 +201,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -219,6 +217,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-invalid-content-type.py
+++ b/scripts/test-invalid-content-type.py
@@ -10,18 +10,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, RawMessageGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, RawMessageGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -85,7 +86,6 @@ def main():
     else:
         run_only = None
 
-
     conversations = {}
 
     conversation = Connect(host, port)
@@ -114,8 +114,8 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(RawMessageGenerator(24, bytearray(b"hello server!\n")))
@@ -129,8 +129,8 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -145,8 +145,8 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -162,8 +162,8 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -192,7 +192,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -222,12 +222,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -243,14 +243,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -259,6 +259,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-invalid-rsa-key-exchange-messages.py
+++ b/scripts/test-invalid-rsa-key-exchange-messages.py
@@ -10,18 +10,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        TCPBufferingEnable, TCPBufferingDisable, TCPBufferingFlush
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    TCPBufferingEnable, TCPBufferingDisable, TCPBufferingFlush
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -87,8 +88,8 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -111,8 +112,8 @@ def main():
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
         node = node.add_child(ClientHelloGenerator(ciphers,
-                                                   extensions={ExtensionType.renegotiation_info:None}))
-        node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                                   extensions={ExtensionType.renegotiation_info: None}))
+        node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(TCPBufferingEnable())
@@ -126,16 +127,16 @@ def main():
                                           AlertDescription.bad_record_mac))
         node.add_child(ExpectClose())
 
-        conversations["encrypted premaster set to all zero ({0})".format(size)] =\
-                conversation
+        conversations["encrypted premaster set to all zero ({0})".format(size)] = \
+            conversation
 
     # set the encrypted premaster to the the value of server modulus
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(TCPBufferingEnable())
@@ -150,7 +151,6 @@ def main():
     node.add_child(ExpectClose())
 
     conversations["modulus as encrypted premaster"] = conversation
-
 
     good = 0
     bad = 0
@@ -168,7 +168,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -198,12 +198,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -219,14 +219,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -235,6 +235,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-invalid-server-name-extension-resumption.py
+++ b/scripts/test-invalid-server-name-extension-resumption.py
@@ -11,20 +11,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, Close, \
-        ResetHandshakeHashes, ResetRenegotiationInfo
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, Close, \
+    ResetHandshakeHashes, ResetRenegotiationInfo
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, HashAlgorithm, SignatureAlgorithm, NameType
+    ExtensionType, HashAlgorithm, SignatureAlgorithm, NameType
 from tlslite.extensions import TLSExtension, SignatureAlgorithmsExtension, \
-        SNIExtension, SignatureAlgorithmsCertExtension
+    SNIExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 version = 3
 
@@ -49,6 +48,7 @@ def help_msg():
     print(" --sni hostname name of host used in SNI extension, \"localhost4\"")
     print("                by default")
     print(" --help         this message")
+
 
 def main():
     """check if server handles incorrect resumption w/server name indication"""
@@ -98,13 +98,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -128,13 +128,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     sni = SNIExtension().create(bytearray(hostname, 'utf-8'))
     ext[ExtensionType.server_name] = sni
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -160,13 +160,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     sni = SNIExtension().create(bytearray(hostname, 'utf-8') +
                                 bytearray(b'\x00'))
     ext[ExtensionType.server_name] = sni
@@ -180,10 +180,10 @@ def main():
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
-    ext = {ExtensionType.renegotiation_info : None,
-           ExtensionType.server_name : SNIExtension().create(
-                                       bytearray(hostname, 'utf-8'))
-          }
+    ext = {ExtensionType.renegotiation_info: None,
+           ExtensionType.server_name: SNIExtension().create(
+               bytearray(hostname, 'utf-8'))
+           }
     node = node.add_child(ClientHelloGenerator(
         ciphers,
         session_id=bytearray(32),
@@ -209,9 +209,9 @@ def main():
 
     node = node.add_child(ResetHandshakeHashes())
     node = node.add_child(ResetRenegotiationInfo())
-    ext = {ExtensionType.renegotiation_info:None,
-           ExtensionType.server_name:SNIExtension().create(bytearray(hostname, 'utf-8') +
-                                                           bytearray(b'\x00'))}
+    ext = {ExtensionType.renegotiation_info: None,
+           ExtensionType.server_name: SNIExtension().create(bytearray(hostname, 'utf-8') +
+                                                            bytearray(b'\x00'))}
     node = node.add_child(ClientHelloGenerator(
         ciphers,
         extensions=ext))
@@ -226,10 +226,10 @@ def main():
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
-    ext = {ExtensionType.renegotiation_info : None,
-           ExtensionType.server_name : SNIExtension().create(
-                                       bytearray(hostname, 'utf-8'))
-          }
+    ext = {ExtensionType.renegotiation_info: None,
+           ExtensionType.server_name: SNIExtension().create(
+               bytearray(hostname, 'utf-8'))
+           }
     node = node.add_child(ClientHelloGenerator(
         ciphers,
         session_id=bytearray(32),
@@ -255,14 +255,14 @@ def main():
 
     node = node.add_child(ResetHandshakeHashes())
     node = node.add_child(ResetRenegotiationInfo())
-    ext = {ExtensionType.renegotiation_info:None,
-           ExtensionType.server_name:SNIExtension().create(bytearray(b'www.') +
-                                                           bytearray(hostname, 'utf-8'))}
+    ext = {ExtensionType.renegotiation_info: None,
+           ExtensionType.server_name: SNIExtension().create(bytearray(b'www.') +
+                                                            bytearray(hostname, 'utf-8'))}
     node = node.add_child(ClientHelloGenerator(
         ciphers,
         extensions=ext))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None},
+        extensions={ExtensionType.renegotiation_info: None},
         resume=False))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
@@ -283,7 +283,6 @@ def main():
 
     conversations["session resume with different SNI"] = conversation
 
-
     # run the conversation
     good = 0
     bad = 0
@@ -301,7 +300,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -331,12 +330,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -360,14 +359,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)

--- a/scripts/test-invalid-server-name-extension.py
+++ b/scripts/test-invalid-server-name-extension.py
@@ -11,19 +11,18 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, HashAlgorithm, SignatureAlgorithm, NameType
+    ExtensionType, HashAlgorithm, SignatureAlgorithm, NameType
 from tlslite.extensions import TLSExtension, SignatureAlgorithmsExtension, \
-        SNIExtension, SignatureAlgorithmsCertExtension
+    SNIExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import RSA_SIG_ALL
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 4
 
@@ -102,13 +101,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
@@ -132,13 +131,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     sni = SNIExtension().create(bytearray(hostname, 'utf-8'))
     ext[ExtensionType.server_name] = sni
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -164,13 +163,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     sni = TLSExtension(extType=ExtensionType.server_name).create(bytearray(0))
     ext[ExtensionType.server_name] = sni
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -184,13 +183,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     sni = SNIExtension().create(serverNames=[])
     ext[ExtensionType.server_name] = sni
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -204,13 +203,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     sni = SNIExtension().create(hostNames=[bytearray(0)])
     ext[ExtensionType.server_name] = sni
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -224,18 +223,18 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     payload = bytearray(b'\x00\x04'  # overall length
-                        b'\x00'      # type - host_name
+                        b'\x00'  # type - host_name
                         b'\x00\x01'  # length of host name
-                        b'e'         # host name
-                        b'x'         # trailing data
+                        b'e'  # host name
+                        b'x'  # trailing data
                         )
     sni = TLSExtension(extType=ExtensionType.server_name).create(payload)
     ext[ExtensionType.server_name] = sni
@@ -250,13 +249,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     sni = SNIExtension().create(bytearray(b'www.') +
                                 bytearray(hostname, 'utf-8'))
     ext[ExtensionType.server_name] = sni
@@ -290,13 +289,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     # names MUST be valid DNS host names
     sni = SNIExtension().create(bytearray(hostname[:-1], 'utf-8') +
                                 bytearray(b'\x00') +
@@ -314,13 +313,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     # names MUST be valid DNS host names
     sni = SNIExtension().create(bytearray(hostname[:-1], 'utf-8') +
                                 bytearray(b'\x07') +
@@ -338,13 +337,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     # names MUST be valid DNS host names
     sni = SNIExtension().create(bytearray(hostname[:-1], 'utf-8') +
                                 bytearray(b'\xc4\x85') +
@@ -361,13 +360,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     # names MUST be valid DNS host names
     sni = SNIExtension().create(bytearray(hostname, 'utf-8') +
                                 bytearray(b'\x1b[31mBAD\x1b[0;37m'))
@@ -379,12 +378,11 @@ def main():
 
     conversations["SNI name with ANSI color escapes code"] = conversation
 
-
     # malformed extension
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
-    ext = {ExtensionType.server_name: lambda _:TLSExtension().create(0, bytearray(b'\xff'*4))}
+    ext = {ExtensionType.server_name: lambda _: TLSExtension().create(0, bytearray(b'\xff' * 4))}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -397,13 +395,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     # RFC 6066 client MUST NOT send two names of the same type
     sni = SNIExtension().create(hostNames=[bytearray(hostname, 'utf-8'),
                                            bytearray(b'www.') +
@@ -420,13 +418,13 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     names = [SNIExtension.ServerName(NameType.host_name,
                                      bytearray(hostname, 'utf-8')),
              # some unknown SNI type, should be ignored by server
@@ -457,19 +455,19 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-             (getattr(HashAlgorithm, x),
-              SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                'sha224', 'sha1']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
-    names = [# some unknown SNI type, should be ignored by server
-             SNIExtension.ServerName(NameType.host_name + 1,
-                                     bytearray(range(0, 24))),
-             # actual SNI payload
-             SNIExtension.ServerName(NameType.host_name,
-                                     bytearray(hostname, 'utf-8'))]
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    names = [  # some unknown SNI type, should be ignored by server
+        SNIExtension.ServerName(NameType.host_name + 1,
+                                bytearray(range(0, 24))),
+        # actual SNI payload
+        SNIExtension.ServerName(NameType.host_name,
+                                bytearray(hostname, 'utf-8'))]
     sni = SNIExtension().create(serverNames=names)
     ext[ExtensionType.server_name] = sni
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -491,7 +489,6 @@ def main():
     # hangs gnutls-serv
     conversations["multiple types in SNI, host_name last"] = conversation
 
-
     # run the conversation
     good = 0
     bad = 0
@@ -509,7 +506,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -539,12 +536,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -562,14 +559,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)

--- a/scripts/test-invalid-session-id.py
+++ b/scripts/test-invalid-session-id.py
@@ -10,18 +10,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, SetMaxRecordSize, pad_handshake
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, SetMaxRecordSize, pad_handshake
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.extensions import TLSExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
+
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -90,7 +92,7 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               session_id=bytearray(b'\x03'*33)))
+                                               session_id=bytearray(b'\x03' * 33)))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
 
@@ -135,7 +137,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -165,12 +167,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -186,14 +188,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -202,6 +204,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-invalid-version.py
+++ b/scripts/test-invalid-version.py
@@ -10,19 +10,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, SetMaxRecordSize, pad_handshake
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, SetMaxRecordSize, pad_handshake
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.extensions import TLSExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -82,7 +83,6 @@ def main():
     else:
         run_only = None
 
-
     conversations = {}
 
     conversation = Connect(host, port)
@@ -111,7 +111,7 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               version=(1,3)))
+                                               version=(1, 3)))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
 
@@ -134,7 +134,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -164,12 +164,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -185,14 +185,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -201,6 +201,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-large-hello.py
+++ b/scripts/test-large-hello.py
@@ -11,19 +11,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        split_message, FlushMessageList
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    split_message, FlushMessageList
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.extensions import PaddingExtension, TLSExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -114,12 +115,12 @@ def main():
 
     # send client hello with large padding extension
     for i in chain(range(10), range(0x3f00, 0x4010), range(0x1ff0, 0x2010),
-                   range(0x8ff0, 0x9010), range(0xff00, 0xffff-4)):
+                   range(0x8ff0, 0x9010), range(0xff00, 0xffff - 4)):
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {ExtensionType.client_hello_padding:PaddingExtension().create(i)}
+        ext = {ExtensionType.client_hello_padding: PaddingExtension().create(i)}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectCertificate())
@@ -140,12 +141,12 @@ def main():
 
     # send large extension from unallocated range
     for i in chain(range(10), range(0x3f00, 0x4010), range(0x1ff0, 0x2010),
-                   range(0x8ff0, 0x9010), range(0xff00, 0xffff-4)):
+                   range(0x8ff0, 0x9010), range(0xff00, 0xffff - 4)):
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {80:TLSExtension(extType=80).create(bytearray(i))}
+        ext = {80: TLSExtension(extType=80).create(bytearray(i))}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectCertificate())
@@ -168,12 +169,12 @@ def main():
     # changing size
     for i in chain(range(10), range(0x2f00, 0x3010),
                    range(0x3f00, 0x4010), range(0x1ff0, 0x2010),
-                   range(0x8ff0, 0x9010), range(0xef00, 0xefff-8)):
+                   range(0x8ff0, 0x9010), range(0xef00, 0xefff - 8)):
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {80:TLSExtension(extType=80).create(bytearray(i)),
+        ext = {80: TLSExtension(extType=80).create(bytearray(i)),
                ExtensionType.client_hello_padding:
                    PaddingExtension().create(0x1000)}
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -195,9 +196,9 @@ def main():
         conversations["two ext, #80 {0} bytes".format(i)] = conversation
 
     # send client hello messages with multiple extensions
-    for i in chain(range(10//4), range(0x3f00//4, 0x4010//4),
-                   range(0x1ff0//4, 0x2010//4),
-                   range(0x8ff0//4, 0x9010//4), range(0xff00//4, 0x10000//4)):
+    for i in chain(range(10 // 4), range(0x3f00 // 4, 0x4010 // 4),
+                   range(0x1ff0 // 4, 0x2010 // 4),
+                   range(0x8ff0 // 4, 0x9010 // 4), range(0xff00 // 4, 0x10000 // 4)):
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
@@ -208,11 +209,11 @@ def main():
         # increase the count if some extension points will be skipped because
         # they are meaningful
         for num in high_num_ext:
-            if i+min_ext > num:
-                i+=1
+            if i + min_ext > num:
+                i += 1
         ext = dict((j, TLSExtension(extType=j))
-                    for j in range(min_ext, min_ext+i)
-                    if j not in high_num_ext)
+                   for j in range(min_ext, min_ext + i)
+                   if j not in high_num_ext)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectCertificate())
@@ -233,9 +234,9 @@ def main():
 
     # send client hello with large number of ciphersuites but overall
     # even length
-    for i in chain(range(1, 10//2), range(0x3f00//2, 0x4010//2),
-                   range(0x1ff0//2, 0x2010//2),
-                   range(0x8ff0//2, 0x9010//2), range(0xff00//2, 0xffff//2-2)):
+    for i in chain(range(1, 10 // 2), range(0x3f00 // 2, 0x4010 // 2),
+                   range(0x1ff0 // 2, 0x2010 // 2),
+                   range(0x8ff0 // 2, 0x9010 // 2), range(0xff00 // 2, 0xffff // 2 - 2)):
         conversation = Connect(host, port)
         node = conversation
         if i < 0x5600 - 0x0100:
@@ -266,9 +267,9 @@ def main():
 
     # send client hello with large number of ciphersuites but overall
     # odd length
-    for i in chain(range(1, 10//2), range(0x3f00//2, 0x4010//2),
-                   range(0x1ff0//2, 0x2010//2),
-                   range(0x8ff0//2, 0x9010//2), range(0xff00//2, 0xffff//2-2)):
+    for i in chain(range(1, 10 // 2), range(0x3f00 // 2, 0x4010 // 2),
+                   range(0x1ff0 // 2, 0x2010 // 2),
+                   range(0x8ff0 // 2, 0x9010 // 2), range(0xff00 // 2, 0xffff // 2 - 2)):
         conversation = Connect(host, port)
         node = conversation
         if i < 0x5600 - 0x0100:
@@ -302,13 +303,13 @@ def main():
 
     # hello split over at least two records, first very small (2B)
     for i in chain(range(10), range(0x3f00, 0x4010), range(0x1ff0, 0x2010),
-                   range(0x8ff0, 0x9010), range(0xff00, 0xffff-4)):
+                   range(0x8ff0, 0x9010), range(0xff00, 0xffff - 4)):
         fragment_list = []
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        ext = {ExtensionType.client_hello_padding:PaddingExtension().create(i)}
+        ext = {ExtensionType.client_hello_padding: PaddingExtension().create(i)}
         hello_gen = ClientHelloGenerator(ciphers, extensions=ext)
         node = node.add_child(split_message(hello_gen, fragment_list, 2))
         node = node.add_child(FlushMessageList(fragment_list))
@@ -368,7 +369,7 @@ def main():
     ciphers += [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV,
                 CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     # the 4 bytes subtracted from 0xffff are for ext ID and ext len
-    ext = {80:TLSExtension(extType=80).create(bytearray(0xffff-4))}
+    ext = {80: TLSExtension(extType=80).create(bytearray(0xffff - 4))}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
     node = node.add_child(ExpectCertificate())
@@ -431,12 +432,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -452,14 +453,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -468,6 +469,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-large-number-of-extensions.py
+++ b/scripts/test-large-number-of-extensions.py
@@ -16,19 +16,18 @@ except ImportError:
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, ExpectServerKeyExchange
 from tlsfuzzer.helpers import AutoEmptyExtension
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, SignatureScheme, GroupName
+    ExtensionType, SignatureScheme, GroupName
 from tlslite.extensions import SupportedGroupsExtension, SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 3
 
@@ -100,8 +99,8 @@ def main():
     conversations = {}
 
     sig_algs = [SignatureScheme.rsa_pkcs1_sha256,
-               SignatureScheme.rsa_pss_rsae_sha256,
-               SignatureScheme.rsa_pss_pss_sha256]
+                SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256]
 
     conversation = Connect(host, port)
     node = conversation
@@ -109,7 +108,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(sig_algs)
@@ -149,7 +148,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(sig_algs)
@@ -186,14 +185,14 @@ def main():
               4094, 4095, 4096, 8190, 8191, 8192, max_ext]:
         conversation = Connect(host, port)
         node = conversation
-        ext = OrderedDict((j+64, AutoEmptyExtension()) for j in range(i))
+        ext = OrderedDict((j + 64, AutoEmptyExtension()) for j in range(i))
         if ExtensionType.supports_npn in ext:
             del ext[ExtensionType.supports_npn]
-            ext[i+64+1] = AutoEmptyExtension()
+            ext[i + 64 + 1] = AutoEmptyExtension()
         if dhe:
             groups = [GroupName.secp256r1,
                       GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             ext[ExtensionType.signature_algorithms] = \
                 SignatureAlgorithmsExtension().create(sig_algs)
@@ -223,7 +222,7 @@ def main():
                                              AlertDescription.close_notify))
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
-        conversations["{0} extensions".format(i+1)] = conversation
+        conversations["{0} extensions".format(i + 1)] = conversation
 
     # run the conversation
     good = 0
@@ -242,7 +241,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -272,12 +271,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -296,14 +295,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -312,6 +311,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-legacy-renegotiation.py
+++ b/scripts/test-legacy-renegotiation.py
@@ -10,21 +10,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, GroupName
+    ExtensionType, GroupName
 from tlslite.extensions import ALPNExtension, TLSExtension, \
-        SupportedGroupsExtension, SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension, RenegotiationInfoExtension
+    SupportedGroupsExtension, SignatureAlgorithmsExtension, \
+    SignatureAlgorithmsCertExtension, RenegotiationInfoExtension
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 from tlsfuzzer.utils.lists import natural_sort_keys
 
@@ -100,11 +99,11 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1, GroupName.ffdhe2048]
         ext = {ExtensionType.supported_groups:
-               SupportedGroupsExtension().create(groups),
+                   SupportedGroupsExtension().create(groups),
                ExtensionType.signature_algorithms:
-               SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
+                   SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
                ExtensionType.signature_algorithms_cert:
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -231,7 +230,7 @@ def main():
         bytearray(b"GET /?Renegotiation_Test=tlsfuzzer HTTP/1.0\r\n")))
     # 2nd handshake
     node = node.add_child(ResetHandshakeHashes())
-    ext = {ExtensionType.renegotiation_info:None}
+    ext = {ExtensionType.renegotiation_info: None}
     if dhe:
         groups = [GroupName.secp256r1, GroupName.ffdhe2048]
         ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
@@ -272,11 +271,11 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1, GroupName.ffdhe2048]
         ext = {ExtensionType.supported_groups:
-               SupportedGroupsExtension().create(groups),
+                   SupportedGroupsExtension().create(groups),
                ExtensionType.signature_algorithms:
-               SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
+                   SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
                ExtensionType.signature_algorithms_cert:
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     else:
@@ -298,11 +297,11 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1, GroupName.ffdhe2048]
         ext = {ExtensionType.supported_groups:
-               SupportedGroupsExtension().create(groups),
+                   SupportedGroupsExtension().create(groups),
                ExtensionType.signature_algorithms:
-               SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
+                   SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
                ExtensionType.signature_algorithms_cert:
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                session_id=bytearray(0),
                                                extensions=ext))
@@ -336,11 +335,11 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1, GroupName.ffdhe2048]
         ext = {ExtensionType.supported_groups:
-               SupportedGroupsExtension().create(groups),
+                   SupportedGroupsExtension().create(groups),
                ExtensionType.signature_algorithms:
-               SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
+                   SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
                ExtensionType.signature_algorithms_cert:
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     else:
@@ -365,11 +364,11 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1, GroupName.ffdhe2048]
         ext = {ExtensionType.supported_groups:
-               SupportedGroupsExtension().create(groups),
+                   SupportedGroupsExtension().create(groups),
                ExtensionType.signature_algorithms:
-               SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
+                   SignatureAlgorithmsExtension().create(RSA_SIG_ALL),
                ExtensionType.signature_algorithms_cert:
-               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                session_id=bytearray(0),
                                                extensions=ext))
@@ -509,8 +508,8 @@ def main():
     conversation = Connect(host, port)
     node = conversation
 
-    ext = {ExtensionType.renegotiation_info :
-           RenegotiationInfoExtension().create(bytearray(b'abc'))}
+    ext = {ExtensionType.renegotiation_info:
+               RenegotiationInfoExtension().create(bytearray(b'abc'))}
     if dhe:
         groups = [GroupName.secp256r1, GroupName.ffdhe2048]
         ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
@@ -535,8 +534,8 @@ def main():
     conversation = Connect(host, port)
     node = conversation
 
-    ext = {ExtensionType.renegotiation_info :
-           RenegotiationInfoExtension().create(bytearray(b'abc'))}
+    ext = {ExtensionType.renegotiation_info:
+               RenegotiationInfoExtension().create(bytearray(b'abc'))}
     if dhe:
         groups = [GroupName.secp256r1, GroupName.ffdhe2048]
         ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
@@ -572,7 +571,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -603,12 +602,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -626,14 +625,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -642,6 +641,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-message-duplication.py
+++ b/scripts/test-message-duplication.py
@@ -11,16 +11,17 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -253,7 +254,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -283,35 +284,35 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
         else:
             if res:
-                good+=1
+                good += 1
                 print("OK")
             else:
-                bad+=1
+                bad += 1
                 failed.append(c_name)
 
     print("Test end")
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -320,6 +321,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-message-skipping.py
+++ b/scripts/test-message-skipping.py
@@ -10,21 +10,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType
+    GroupName, ExtensionType
 
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import SIG_ALL
-
 
 version = 4
 
@@ -108,7 +107,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -150,11 +149,11 @@ def main():
     if dhe:
         node = node.add_child(ClientKeyExchangeGenerator(cipher=CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                                                          version=(3, 3),
-                                                         dh_Yc=2**2047-1))
+                                                         dh_Yc=2 ** 2047 - 1))
     else:
         node = node.add_child(ClientKeyExchangeGenerator(cipher=CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                                                          version=(3, 3),
-                                                         encrypted_premaster=bytearray(b'\xff'*256)))
+                                                         encrypted_premaster=bytearray(b'\xff' * 256)))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.unexpected_message))
     node = node.add_child(ExpectClose())
@@ -167,7 +166,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -201,7 +200,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -235,7 +234,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -281,7 +280,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -311,12 +310,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -334,14 +333,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -350,6 +349,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-no-heartbeat.py
+++ b/scripts/test-no-heartbeat.py
@@ -10,24 +10,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        HeartbeatGenerator, TCPBufferingDisable, TCPBufferingEnable, \
-        TCPBufferingFlush, SetRecordVersion, fuzz_message
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    HeartbeatGenerator, TCPBufferingDisable, TCPBufferingEnable, \
+    TCPBufferingFlush, SetRecordVersion, fuzz_message
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
 
-
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType, HeartbeatMode, HeartbeatMessageType
+    GroupName, ExtensionType, HeartbeatMode, HeartbeatMessageType
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
-        HeartbeatExtension
-
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+    HeartbeatExtension
 
 version = 3
 
@@ -101,7 +99,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -143,7 +141,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -186,7 +184,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -226,7 +224,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -265,7 +263,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -302,7 +300,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -334,7 +332,6 @@ def main():
     node.add_child(ExpectClose())
     conversations["heartbleed after handshake"] = conversation
 
-
     # run the conversation
     good = 0
     bad = 0
@@ -352,7 +349,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -382,12 +379,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -406,14 +403,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -422,6 +419,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-ocsp-stapling.py
+++ b/scripts/test-ocsp-stapling.py
@@ -10,23 +10,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectCertificateStatus, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectCertificateStatus, ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, GroupName
+    ExtensionType, GroupName
 from tlslite.extensions import StatusRequestExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
-        SupportedGroupsExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+    SupportedGroupsExtension
 
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 version = 4
 
@@ -112,7 +111,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -157,7 +156,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -190,7 +189,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -216,9 +215,9 @@ def main():
     node = node.add_child(FinishedGenerator())
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
-    #node = node.add_child(ApplicationDataGenerator(
+    # node = node.add_child(ApplicationDataGenerator(
     #    bytearray(b"GET / HTTP/1.0\n\n")))
-    #node = node.add_child(ExpectApplicationData())
+    # node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
@@ -228,14 +227,16 @@ def main():
     # check if responder_id_list is supported
     conversation = Connect(host, port)
     node = conversation
-                                                              # DER encoding of CHOICE[1] OCTETSTRING (20)
-    ocsp = StatusRequestExtension().create(responder_id_list=[bytearray(b'\xa2\x16\x04\x14') + bytearray([(i+2) % 256]*20) for i in range(625)])
-    ocsp.responder_id_list += [bytearray(b'\xa2\x16\x04\x14') + bytearray(b'\x18\x70\x95\x0B\xE0\x8E\x49\x98\x76\x23\x54\xE7\xD1\xFB\x4E\x9B\xB6\x67\x5E\x2B')]
+    # DER encoding of CHOICE[1] OCTETSTRING (20)
+    ocsp = StatusRequestExtension().create(
+        responder_id_list=[bytearray(b'\xa2\x16\x04\x14') + bytearray([(i + 2) % 256] * 20) for i in range(625)])
+    ocsp.responder_id_list += [bytearray(b'\xa2\x16\x04\x14') + bytearray(
+        b'\x18\x70\x95\x0B\xE0\x8E\x49\x98\x76\x23\x54\xE7\xD1\xFB\x4E\x9B\xB6\x67\x5E\x2B')]
     ext = {ExtensionType.status_request: ocsp}
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -268,7 +269,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -295,9 +296,9 @@ def main():
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ExpectChangeCipherSpec())
         node = node.add_child(ExpectFinished())
-    #node = node.add_child(ApplicationDataGenerator(
+    # node = node.add_child(ApplicationDataGenerator(
     #    bytearray(b"GET / HTTP/1.0\n\n")))
-    #node = node.add_child(ExpectApplicationData())
+    # node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
@@ -321,7 +322,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -351,12 +352,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
                     bad += 1
                     failed.append(c_name)
                     print("Expected error message: {0}\n"
-                        .format(expected_failures[c_name]))
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -382,6 +383,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-openssl-3712.py
+++ b/scripts/test-openssl-3712.py
@@ -10,18 +10,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -110,12 +111,12 @@ def main():
 
     conversation = Connect(host, port)
     node = conversation
-    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    # ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
     #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -127,8 +128,8 @@ def main():
     node = node.add_child(ResetHandshakeHashes())
     node = node.add_child(ClientHelloGenerator([CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA],
                                                session_id=bytearray(0),
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ApplicationDataGenerator(bytearray(b"hello server!\n")))
@@ -138,7 +139,7 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
     node = node.add_child(ApplicationDataGenerator(bytearray(b"hello server!\n")))
-    #node = node.add_child(ExpectApplicationData(bytearray(b"hello client!\n")))
+    # node = node.add_child(ExpectApplicationData(bytearray(b"hello client!\n")))
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
@@ -163,7 +164,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -193,12 +194,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -214,14 +215,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -230,6 +231,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-record-layer-fragmentation.py
+++ b/scripts/test-record-layer-fragmentation.py
@@ -11,19 +11,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, SetMaxRecordSize
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, SetMaxRecordSize
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.extensions import TLSExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -43,6 +44,7 @@ def help_msg():
     print("                execution of preceding expected failure probe")
     print("                usage: [-x probe-name] [-X exception], order is compulsory!")
     print(" --help         this message")
+
 
 def main():
     #
@@ -95,7 +97,7 @@ def main():
     ext = {21: TLSExtension().create(21, bytearray(10))}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -121,28 +123,28 @@ def main():
     # maximum - 2**14
 
     for name, ext_len, record_len in [
-                                ("small hello", 20, None),
-                                ("medium hello", 1024, None),
-                                ("medium hello, pow2 fragmentation", 1024, 127),
-                                ("medium hello, pow2 fragmentation", 1024, 128),
-                                ("medium hello, pow2 fragmentation", 1024, 128),
-                                ("medium hello, pow2 fragmentation", 1024, 255),
-                                ("medium hello, pow2 fragmentation", 1024, 256),
-                                ("medium hello, pow2 fragmentation", 1024, 257),
-                                ("big, non fragmented", 2**12, None),
-                                ("big, needs fragmentation", 2**14-49, None),
-                                ("big, needs fragmentation", 2**14-48, None),
-                                ("big, needs fragmentation", 2**15, None),
-                                ("maximum size", 2**16-5, None),
-                                ("small, reasonable fragmentation", 20, 1024),
-                                ("medium, reasonable fragmentation", 1024, 1024),
-                                ("big, reasonable fragmentation", 2**12, 1024),
-                                ("small, excessive fragmentation", 20, 20),
-                                ("medium, excessive fragmentation", 1024, 20),
-                                ("big, excessive fragmentation", 2**12, 20),
-                                ("small, maximum fragmentation", 20, 1),
-                                ("medium, maximum fragmentation", 1024, 1),
-                                ("maximum size without fragmentation", 2**14-53, None)]:
+        ("small hello", 20, None),
+        ("medium hello", 1024, None),
+        ("medium hello, pow2 fragmentation", 1024, 127),
+        ("medium hello, pow2 fragmentation", 1024, 128),
+        ("medium hello, pow2 fragmentation", 1024, 128),
+        ("medium hello, pow2 fragmentation", 1024, 255),
+        ("medium hello, pow2 fragmentation", 1024, 256),
+        ("medium hello, pow2 fragmentation", 1024, 257),
+        ("big, non fragmented", 2 ** 12, None),
+        ("big, needs fragmentation", 2 ** 14 - 49, None),
+        ("big, needs fragmentation", 2 ** 14 - 48, None),
+        ("big, needs fragmentation", 2 ** 15, None),
+        ("maximum size", 2 ** 16 - 5, None),
+        ("small, reasonable fragmentation", 20, 1024),
+        ("medium, reasonable fragmentation", 1024, 1024),
+        ("big, reasonable fragmentation", 2 ** 12, 1024),
+        ("small, excessive fragmentation", 20, 20),
+        ("medium, excessive fragmentation", 1024, 20),
+        ("big, excessive fragmentation", 2 ** 12, 20),
+        ("small, maximum fragmentation", 20, 1),
+        ("medium, maximum fragmentation", 1024, 1),
+        ("maximum size without fragmentation", 2 ** 14 - 53, None)]:
 
         conversation = Connect(host, port)
         node = conversation
@@ -152,7 +154,7 @@ def main():
         ext = {21: TLSExtension().create(21, bytearray(ext_len))}
         node = node.add_child(ClientHelloGenerator(ciphers,
                                                    extensions=ext))
-        node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+        node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
         node = node.add_child(ExpectCertificate())
         node = node.add_child(ExpectServerHelloDone())
         node = node.add_child(ClientKeyExchangeGenerator())
@@ -175,11 +177,11 @@ def main():
                       str(ext_len) + "B extension"] = conversation
 
     # check if records bigger than TLSPlaintext limit are rejected
-    padding_extension = TLSExtension().create(21, bytearray(2**14-52))
+    padding_extension = TLSExtension().create(21, bytearray(2 ** 14 - 52))
 
     conversation = Connect(host, port)
     node = conversation
-    node = node.add_child(SetMaxRecordSize(2**16-1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -187,8 +189,8 @@ def main():
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
 
-    conversations["non fragmented, over fragmentation limit: " + str(2**16-1) +
-                  " fragment - " + str(2**14-52) + "B extension"] = conversation
+    conversations["non fragmented, over fragmentation limit: " + str(2 ** 16 - 1) +
+                  " fragment - " + str(2 ** 14 - 52) + "B extension"] = conversation
 
     # run the conversation
     good = 0
@@ -207,7 +209,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -237,12 +239,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -258,14 +260,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -274,6 +276,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-record-size-limit.py
+++ b/scripts/test-record-size-limit.py
@@ -10,30 +10,29 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        SetMaxRecordSize, SetPaddingCallback, ResetHandshakeHashes, \
-        Close, ResetRenegotiationInfo, ch_cookie_handler
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    SetMaxRecordSize, SetPaddingCallback, ResetHandshakeHashes, \
+    Close, ResetRenegotiationInfo, ch_cookie_handler
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        gen_srv_ext_handler_record_limit, ExpectEncryptedExtensions, \
-        ExpectCertificateVerify, ExpectNewSessionTicket, \
-        srv_ext_handler_supp_vers, gen_srv_ext_handler_psk, \
-        srv_ext_handler_key_share, ExpectHelloRetryRequest
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    gen_srv_ext_handler_record_limit, ExpectEncryptedExtensions, \
+    ExpectCertificateVerify, ExpectNewSessionTicket, \
+    srv_ext_handler_supp_vers, gen_srv_ext_handler_psk, \
+    srv_ext_handler_key_share, ExpectHelloRetryRequest
 from tlsfuzzer.helpers import key_share_ext_gen, RSA_SIG_ALL, \
-        psk_session_ext_gen, psk_ext_updater, key_share_gen
+    psk_session_ext_gen, psk_ext_updater, key_share_gen
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, GroupName, TLS_1_3_DRAFT, SignatureScheme, \
-        PskKeyExchangeMode
+    ExtensionType, GroupName, TLS_1_3_DRAFT, SignatureScheme, \
+    PskKeyExchangeMode
 from tlslite.extensions import RecordSizeLimitExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
-        PskKeyExchangeModesExtension, TLSExtension, ClientKeyShareExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+    PskKeyExchangeModesExtension, TLSExtension, ClientKeyShareExtension
 from tlslite.utils.compat import compatAscii2Bytes
-
 
 version = 3
 
@@ -80,7 +79,7 @@ def main():
     run_exclude = set()
     expected_failures = {}
     last_exp_tmp = None
-    expect_size = 2**14
+    expect_size = 2 ** 14
     minimal_size = 64
     supported_groups = False
     hrr_supported_groups = False
@@ -145,7 +144,7 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     extensions = {ExtensionType.record_size_limit:
-                  RecordSizeLimitExtension().create(2**14+1)}
+                      RecordSizeLimitExtension().create(2 ** 14 + 1)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=extensions))
     node = node.add_child(ExpectServerHello())
     node = node.add_child(ExpectCertificate())
@@ -172,17 +171,17 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
-        .create(2**14+1)
+    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
+        .create(2 ** 14 + 1)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -202,7 +201,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -217,11 +216,11 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         extensions = {ExtensionType.record_size_limit:
-                      RecordSizeLimitExtension().create(2**14+1)}
+                          RecordSizeLimitExtension().create(2 ** 14 + 1)}
         node = node.add_child(ClientHelloGenerator(
             ciphers, version=vers, extensions=extensions))
         ext = {ExtensionType.record_size_limit:
-               gen_srv_ext_handler_record_limit(expect_size),
+                   gen_srv_ext_handler_record_limit(expect_size),
                ExtensionType.renegotiation_info: None}
         node = node.add_child(ExpectServerHello(extensions=ext))
         node = node.add_child(ExpectCertificate())
@@ -236,7 +235,7 @@ def main():
         if vers == (3, 1):
             # 1/n-1 record splitting
             node = node.add_child(ExpectApplicationData(size=1))
-            node = node.add_child(ExpectApplicationData(size=reply_size-1))
+            node = node.add_child(ExpectApplicationData(size=reply_size - 1))
         else:
             node = node.add_child(ExpectApplicationData(size=reply_size))
         node = node.add_child(AlertGenerator(AlertLevel.warning,
@@ -252,15 +251,15 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         extensions = {ExtensionType.record_size_limit:
-                      RecordSizeLimitExtension().create(2**14+1),
+                          RecordSizeLimitExtension().create(2 ** 14 + 1),
                       # TODO: migrate to dedicated extension object
                       1:
-                      TLSExtension(extType=1)
-                      .create(bytearray(b'\x01'))}
+                          TLSExtension(extType=1)
+                              .create(bytearray(b'\x01'))}
         node = node.add_child(ClientHelloGenerator(
             ciphers, version=vers, extensions=extensions))
         ext = {ExtensionType.record_size_limit:
-               gen_srv_ext_handler_record_limit(expect_size),
+                   gen_srv_ext_handler_record_limit(expect_size),
                ExtensionType.renegotiation_info: None}
         node = node.add_child(ExpectServerHello(extensions=ext))
         node = node.add_child(ExpectCertificate())
@@ -275,7 +274,7 @@ def main():
         if vers == (3, 1):
             # 1/n-1 record splitting
             node = node.add_child(ExpectApplicationData(size=1))
-            node = node.add_child(ExpectApplicationData(size=reply_size-1))
+            node = node.add_child(ExpectApplicationData(size=reply_size - 1))
         else:
             node = node.add_child(ExpectApplicationData(size=reply_size))
         node = node.add_child(AlertGenerator(AlertLevel.warning,
@@ -283,7 +282,7 @@ def main():
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
         conversations["check server sent size in {0} with max_fragment_length"
-                      .format(name)] = conversation
+            .format(name)] = conversation
 
         # minimal size test
         conversation = Connect(host, port)
@@ -291,11 +290,11 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         extensions = {ExtensionType.record_size_limit:
-                      RecordSizeLimitExtension().create(minimal_size)}
+                          RecordSizeLimitExtension().create(minimal_size)}
         node = node.add_child(ClientHelloGenerator(
             ciphers, version=vers, extensions=extensions))
         ext = {ExtensionType.record_size_limit:
-               gen_srv_ext_handler_record_limit(expect_size),
+                   gen_srv_ext_handler_record_limit(expect_size),
                ExtensionType.renegotiation_info: None}
         node = node.add_child(ExpectServerHello(extensions=ext))
         node = node.add_child(ExpectCertificate())
@@ -327,11 +326,11 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         extensions = {ExtensionType.record_size_limit:
-                      RecordSizeLimitExtension().create(2**16-1)}
+                          RecordSizeLimitExtension().create(2 ** 16 - 1)}
         node = node.add_child(ClientHelloGenerator(
             ciphers, version=vers, extensions=extensions))
         ext = {ExtensionType.record_size_limit:
-               gen_srv_ext_handler_record_limit(expect_size),
+                   gen_srv_ext_handler_record_limit(expect_size),
                ExtensionType.renegotiation_info: None}
         node = node.add_child(ExpectServerHello(extensions=ext))
         node = node.add_child(ExpectCertificate())
@@ -346,7 +345,7 @@ def main():
         if vers == (3, 1):
             # 1/n-1 record splitting
             node = node.add_child(ExpectApplicationData(size=1))
-            node = node.add_child(ExpectApplicationData(size=reply_size-1))
+            node = node.add_child(ExpectApplicationData(size=reply_size - 1))
         else:
             node = node.add_child(ExpectApplicationData(size=reply_size))
         node = node.add_child(AlertGenerator(AlertLevel.warning,
@@ -362,11 +361,11 @@ def main():
         ciphers = [ciph,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         extensions = {ExtensionType.record_size_limit:
-                      RecordSizeLimitExtension().create(2**14+1)}
+                          RecordSizeLimitExtension().create(2 ** 14 + 1)}
         node = node.add_child(ClientHelloGenerator(
             ciphers, version=(3, 3), extensions=extensions))
         ext = {ExtensionType.record_size_limit:
-               gen_srv_ext_handler_record_limit(expect_size),
+                   gen_srv_ext_handler_record_limit(expect_size),
                ExtensionType.renegotiation_info: None}
         node = node.add_child(ExpectServerHello(extensions=ext))
         node = node.add_child(ExpectCertificate())
@@ -393,17 +392,17 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
-        .create(2**14+1)
+    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
+        .create(2 ** 14 + 1)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -428,7 +427,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData(size=reply_size)
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -443,21 +442,21 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     # TODO migrate to real extension once it is implemented in tlslite-ng
     ext[1] = \
-        TLSExtension(extType=1)\
-        .create(bytearray(b'\x01'))
-    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
-        .create(2**14+1)
+        TLSExtension(extType=1) \
+            .create(bytearray(b'\x01'))
+    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
+        .create(2 ** 14 + 1)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -482,17 +481,17 @@ def main():
 
     node.next_sibling = ExpectApplicationData(size=reply_size)
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
-    conversations["check server sent size in TLS 1.3 with max_fragment_length"]\
+    conversations["check server sent size in TLS 1.3 with max_fragment_length"] \
         = conversation
 
     # verify that server omits record_size_limit if value in
     # [64..minimal_size-1] is specified
     if minimal_size > 64:
-        for size in [64, minimal_size-1]:
+        for size in [64, minimal_size - 1]:
             conversation = Connect(host, port)
             node = conversation
             ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
@@ -500,17 +499,17 @@ def main():
             ext = {}
             groups = [GroupName.secp256r1]
             ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-            ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
                 .create([TLS_1_3_DRAFT, (3, 3)])
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
-            ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
+            ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
                 .create(size)
             sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                         SignatureScheme.rsa_pss_pss_sha256]
-            ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+            ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
                 .create(sig_algs)
-            ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+            ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
                 .create(RSA_SIG_ALL)
             node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
             node = node.add_child(ExpectServerHello())
@@ -537,7 +536,8 @@ def main():
 
             node = node.add_child(ExpectAlert())
             node.next_sibling = ExpectClose()
-            conversations["check if server omits extension for unrecognized size {0} in TLS 1.3".format(size)] = conversation
+            conversations[
+                "check if server omits extension for unrecognized size {0} in TLS 1.3".format(size)] = conversation
 
     # check if server accepts small sizes
     conversation = Connect(host, port)
@@ -547,17 +547,17 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
+    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
         .create(minimal_size)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -580,16 +580,16 @@ def main():
     node = node.add_child(cycle)
     node.add_child(cycle)
 
-    node.next_sibling = ExpectApplicationData(size=minimal_size-1)
+    node.next_sibling = ExpectApplicationData(size=minimal_size - 1)
     node = node.next_sibling
     # in TLS 1.3 the content type is included in the limit so every
     # record will send one byte less than simple reading of extension would
     # indicate
-    for _ in range(0, max(reply_size-(minimal_size-1)*2, 0), minimal_size-1):
-        node = node.add_child(ExpectApplicationData(size=minimal_size-1))
-    node = node.add_child(ExpectApplicationData(size=reply_size%(minimal_size-1)))
+    for _ in range(0, max(reply_size - (minimal_size - 1) * 2, 0), minimal_size - 1):
+        node = node.add_child(ExpectApplicationData(size=minimal_size - 1))
+    node = node.add_child(ExpectApplicationData(size=reply_size % (minimal_size - 1)))
     node = node.add_child(AlertGenerator(AlertLevel.warning,
-                          AlertDescription.close_notify))
+                                         AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -603,17 +603,17 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
-        .create(2**16-1)
+    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
+        .create(2 ** 16 - 1)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -638,7 +638,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData(size=reply_size)
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -650,7 +650,7 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     extensions = {ExtensionType.record_size_limit:
-                  RecordSizeLimitExtension().create(63)}
+                      RecordSizeLimitExtension().create(63)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=extensions))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.illegal_parameter))
@@ -665,17 +665,17 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
+    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
         .create(63)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -689,7 +689,7 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     extensions = {ExtensionType.record_size_limit:
-                  RecordSizeLimitExtension().create(None)}
+                      RecordSizeLimitExtension().create(None)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=extensions))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.decode_error))
@@ -704,17 +704,17 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
+    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
         .create(None)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -728,8 +728,8 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     extensions = {ExtensionType.record_size_limit:
-                  TLSExtension(extType=ExtensionType.record_size_limit).
-                  create(bytearray(b'\x00\x40\x00'))}
+                      TLSExtension(extType=ExtensionType.record_size_limit).
+                          create(bytearray(b'\x00\x40\x00'))}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=extensions))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.decode_error))
@@ -744,18 +744,18 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ext[ExtensionType.record_size_limit] = \
-        TLSExtension(extType=ExtensionType.record_size_limit).\
+        TLSExtension(extType=ExtensionType.record_size_limit). \
             create(bytearray(b'\x00\x40\x00'))
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -769,11 +769,11 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     extensions = {ExtensionType.record_size_limit:
-                  RecordSizeLimitExtension().create(2**14+2)}
+                      RecordSizeLimitExtension().create(2 ** 14 + 2)}
     node = node.add_child(ClientHelloGenerator(
         ciphers, version=(3, 3), extensions=extensions))
     ext = {ExtensionType.record_size_limit:
-           gen_srv_ext_handler_record_limit(expect_size),
+               gen_srv_ext_handler_record_limit(expect_size),
            ExtensionType.renegotiation_info: None}
     node = node.add_child(ExpectServerHello(extensions=ext))
     node = node.add_child(ExpectCertificate())
@@ -783,11 +783,11 @@ def main():
     node = node.add_child(FinishedGenerator())
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
-    node = node.add_child(SetMaxRecordSize(expect_size+1))
+    node = node.add_child(SetMaxRecordSize(expect_size + 1))
     data = bytearray(b"GET / HTTP/1.0\r\nX-bad: ") + \
            bytearray(b"A" * (expect_size + 1 - 27)) + \
            bytearray(b"\r\n\r\n")
-    assert len(data) == expect_size+1
+    assert len(data) == expect_size + 1
     node = node.add_child(ApplicationDataGenerator(data))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.record_overflow))
@@ -802,17 +802,17 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
-        .create(2**14+2)
+    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
+        .create(2 ** 14 + 2)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -829,11 +829,11 @@ def main():
     node = node.add_child(FinishedGenerator())
     # while the server will advertise expect_size+1, it does include
     # content type, which is added transparently to application data
-    node = node.add_child(SetMaxRecordSize(expect_size+1))
+    node = node.add_child(SetMaxRecordSize(expect_size + 1))
     data = bytearray(b"GET / HTTP/1.0\r\nX-bad: ") + \
            bytearray(b"A" * (expect_size + 1 - 27)) + \
            bytearray(b"\r\n\r\n")
-    assert len(data) == expect_size+1
+    assert len(data) == expect_size + 1
     node = node.add_child(ApplicationDataGenerator(data))
 
     # This message is optional and may show up 0 to many times
@@ -853,17 +853,17 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
-        .create(2**14+2)
+    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
+        .create(2 ** 14 + 2)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -880,7 +880,7 @@ def main():
     node = node.add_child(FinishedGenerator())
     # while the server will advertise expect_size+1, it does include
     # content type, which is added transparently to application data
-    node = node.add_child(SetMaxRecordSize(expect_size+1))
+    node = node.add_child(SetMaxRecordSize(expect_size + 1))
     data = bytearray(request)
     padding_size = expect_size - len(data) + 1
     node = node.add_child(SetPaddingCallback(
@@ -904,11 +904,11 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.record_size_limit:
-           RecordSizeLimitExtension().create(2**14+1)}
+               RecordSizeLimitExtension().create(2 ** 14 + 1)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.record_size_limit:
-           gen_srv_ext_handler_record_limit(expect_size)}
+               gen_srv_ext_handler_record_limit(expect_size)}
     node = node.add_child(ExpectServerHello(extensions=ext))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
@@ -921,13 +921,13 @@ def main():
     node = node.add_child(ResetHandshakeHashes())
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.record_size_limit:
-           RecordSizeLimitExtension().create(minimal_size)}
+               RecordSizeLimitExtension().create(minimal_size)}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                session_id=bytearray(0),
                                                extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.record_size_limit:
-           gen_srv_ext_handler_record_limit(expect_size)}
+               gen_srv_ext_handler_record_limit(expect_size)}
     node = node.add_child(ExpectServerHello(extensions=ext))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
@@ -954,11 +954,11 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.record_size_limit:
-           RecordSizeLimitExtension().create(minimal_size)}
+               RecordSizeLimitExtension().create(minimal_size)}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.record_size_limit:
-           gen_srv_ext_handler_record_limit(expect_size)}
+               gen_srv_ext_handler_record_limit(expect_size)}
     node = node.add_child(ExpectServerHello(extensions=ext))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
@@ -997,13 +997,13 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.record_size_limit:
-           RecordSizeLimitExtension().create(2**14)}
+               RecordSizeLimitExtension().create(2 ** 14)}
     node = node.add_child(ClientHelloGenerator(
         ciphers,
         extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.record_size_limit:
-           gen_srv_ext_handler_record_limit(expect_size)}
+               gen_srv_ext_handler_record_limit(expect_size)}
     node = node.add_child(ExpectServerHello(
         cipher=CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
         extensions=ext))
@@ -1030,11 +1030,11 @@ def main():
         ciphers,
         extensions={ExtensionType.renegotiation_info: None,
                     ExtensionType.record_size_limit:
-                    RecordSizeLimitExtension().create(minimal_size)}))
+                        RecordSizeLimitExtension().create(minimal_size)}))
     node = node.add_child(ExpectServerHello(
         extensions={ExtensionType.renegotiation_info: None,
                     ExtensionType.record_size_limit:
-                    gen_srv_ext_handler_record_limit(expect_size)},
+                        gen_srv_ext_handler_record_limit(expect_size)},
         resume=True))
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
@@ -1058,13 +1058,13 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.record_size_limit:
-           RecordSizeLimitExtension().create(minimal_size)}
+               RecordSizeLimitExtension().create(minimal_size)}
     node = node.add_child(ClientHelloGenerator(
         ciphers,
         extensions=ext))
     ext = {ExtensionType.renegotiation_info: None,
            ExtensionType.record_size_limit:
-           gen_srv_ext_handler_record_limit(expect_size)}
+               gen_srv_ext_handler_record_limit(expect_size)}
     node = node.add_child(ExpectServerHello(
         cipher=CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
         extensions=ext))
@@ -1115,20 +1115,20 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
-    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
-        .create(2**14)
+    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
+        .create(2 ** 14)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
     node = node.add_child(ExpectChangeCipherSpec())
@@ -1171,7 +1171,7 @@ def main():
     node = node.add_child(ResetRenegotiationInfo())
     ext = OrderedDict(ext)
     ext[ExtensionType.pre_shared_key] = psk_session_ext_gen()
-    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
+    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
         .create(minimal_size)
     mods = []
     mods.append(psk_ext_updater())
@@ -1201,11 +1201,11 @@ def main():
     node = node.add_child(cycle)
     node.add_child(cycle)
 
-    node.next_sibling = ExpectApplicationData(size=minimal_size-1)
+    node.next_sibling = ExpectApplicationData(size=minimal_size - 1)
     node = node.next_sibling
-    for _ in range(0, max(reply_size-(minimal_size-1)*2, 0), minimal_size-1):
-        node = node.add_child(ExpectApplicationData(size=minimal_size-1))
-    node = node.add_child(ExpectApplicationData(size=reply_size%(minimal_size-1)))
+    for _ in range(0, max(reply_size - (minimal_size - 1) * 2, 0), minimal_size - 1):
+        node = node.add_child(ExpectApplicationData(size=minimal_size - 1))
+    node = node.add_child(ExpectApplicationData(size=reply_size % (minimal_size - 1)))
     node = node.add_child(
         AlertGenerator(AlertLevel.warning,
                        AlertDescription.close_notify))
@@ -1224,19 +1224,19 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
-    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension()\
+    ext[ExtensionType.record_size_limit] = RecordSizeLimitExtension() \
         .create(minimal_size)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -1324,18 +1324,18 @@ def main():
     groups = [GroupName.secp256r1]
     key_shares = []
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.record_size_limit] = \
-        RecordSizeLimitExtension().create(2**14+1)
+        RecordSizeLimitExtension().create(2 ** 14 + 1)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
 
     ext = OrderedDict()
@@ -1352,20 +1352,20 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     if cookie:
         ext[ExtensionType.cookie] = ch_cookie_handler
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.record_size_limit] = \
-        RecordSizeLimitExtension().create(2**14+1)
+        RecordSizeLimitExtension().create(2 ** 14 + 1)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
     ee_ext = {}
@@ -1387,7 +1387,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["HRR sanity"] = conversation
@@ -1401,18 +1401,18 @@ def main():
     groups = [GroupName.secp256r1]
     key_shares = []
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.record_size_limit] = \
-        RecordSizeLimitExtension().create(2**14+1)
+        RecordSizeLimitExtension().create(2 ** 14 + 1)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
 
     ext = OrderedDict()
@@ -1429,20 +1429,20 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     if cookie:
         ext[ExtensionType.cookie] = ch_cookie_handler
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.record_size_limit] = \
-        RecordSizeLimitExtension().create(2**14)
+        RecordSizeLimitExtension().create(2 ** 14)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.illegal_parameter))
@@ -1458,18 +1458,18 @@ def main():
     groups = [GroupName.secp256r1]
     key_shares = []
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.record_size_limit] = \
-        RecordSizeLimitExtension().create(2**14+1)
+        RecordSizeLimitExtension().create(2 ** 14 + 1)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
 
     ext = OrderedDict()
@@ -1486,17 +1486,17 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     if cookie:
         ext[ExtensionType.cookie] = ch_cookie_handler
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -1513,15 +1513,15 @@ def main():
     groups = [GroupName.secp256r1]
     key_shares = []
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
 
@@ -1539,20 +1539,20 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     if cookie:
         ext[ExtensionType.cookie] = ch_cookie_handler
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.record_size_limit] = \
-        RecordSizeLimitExtension().create(2**14+1)
+        RecordSizeLimitExtension().create(2 ** 14 + 1)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.illegal_parameter))
@@ -1576,7 +1576,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -1606,12 +1606,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -1632,14 +1632,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -1648,6 +1648,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-renegotiation-changed-clienthello.py
+++ b/scripts/test-renegotiation-changed-clienthello.py
@@ -10,26 +10,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange, ExpectCertificateStatus
-
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange, ExpectCertificateStatus
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType, PskKeyExchangeMode, ECPointFormat
+    GroupName, ExtensionType, PskKeyExchangeMode, ECPointFormat
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
-        PskKeyExchangeModesExtension, ECPointFormatsExtension, \
-        StatusRequestExtension, ALPNExtension, SupportedVersionsExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+    PskKeyExchangeModesExtension, ECPointFormatsExtension, \
+    StatusRequestExtension, ALPNExtension, SupportedVersionsExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlsfuzzer.helpers import SIG_ALL, psk_ext_gen, AutoEmptyExtension, \
-        key_share_ext_gen, psk_session_ext_gen, psk_ext_updater
-
+    key_share_ext_gen, psk_session_ext_gen, psk_ext_updater
 
 version = 1
 
@@ -130,7 +128,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -175,7 +173,7 @@ def main():
         SignatureAlgorithmsCertExtension().create(SIG_ALL)
     groups = [GroupName.secp256r1,
               GroupName.ffdhe2048]
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     ext[ExtensionType.key_share] = key_share_ext_gen([GroupName.secp256r1])
@@ -192,7 +190,7 @@ def main():
         StatusRequestExtension().create()
     ext[ExtensionType.post_handshake_auth] = AutoEmptyExtension()
     # yes, don't include TLS 1.3, as we want to be able to renegotiate...
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([(3, 3), (3, 2)])
     ext[ExtensionType.psk_key_exchange_modes] = \
         PskKeyExchangeModesExtension().create(
@@ -265,18 +263,18 @@ def main():
     # signature_algorithms and signature_algorithms_cert are covered
     # by the test-sig-algs-renegotiation-resumption.py
     for drop_ext, exp_result in [
-            (ExtensionType.supported_groups, None),
-            (ExtensionType.extended_master_secret,
-             AlertDescription.handshake_failure),
-            (ExtensionType.key_share, None),
-            (ExtensionType.alpn, None),
-            (ExtensionType.ec_point_formats, None),
-            (18, None),  # signed_certificate_timestamp
-            (ExtensionType.status_request, None),
-            (ExtensionType.post_handshake_auth, None),
-            (ExtensionType.supported_versions, None),
-            (ExtensionType.psk_key_exchange_modes, None),
-            (ExtensionType.pre_shared_key, None)]:
+        (ExtensionType.supported_groups, None),
+        (ExtensionType.extended_master_secret,
+         AlertDescription.handshake_failure),
+        (ExtensionType.key_share, None),
+        (ExtensionType.alpn, None),
+        (ExtensionType.ec_point_formats, None),
+        (18, None),  # signed_certificate_timestamp
+        (ExtensionType.status_request, None),
+        (ExtensionType.post_handshake_auth, None),
+        (ExtensionType.supported_versions, None),
+        (ExtensionType.psk_key_exchange_modes, None),
+        (ExtensionType.pre_shared_key, None)]:
         conversation = Connect(host, port)
         node = conversation
         ext = OrderedDict()
@@ -286,7 +284,7 @@ def main():
             SignatureAlgorithmsCertExtension().create(SIG_ALL)
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
         ext[ExtensionType.key_share] = key_share_ext_gen([GroupName.secp256r1])
@@ -303,7 +301,7 @@ def main():
             StatusRequestExtension().create()
         ext[ExtensionType.post_handshake_auth] = AutoEmptyExtension()
         # yes, don't include TLS 1.3, as we want to be able to renegotiate...
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([(3, 3), (3, 2)])
         ext[ExtensionType.psk_key_exchange_modes] = \
             PskKeyExchangeModesExtension().create(
@@ -372,7 +370,7 @@ def main():
             node = node.add_child(ExpectAlert())
             node.next_sibling = ExpectClose()
         conversations["drop {0} in renegotiation"
-                      .format(ExtensionType.toStr(drop_ext))] = conversation
+            .format(ExtensionType.toStr(drop_ext))] = conversation
 
     # run the conversation
     good = 0
@@ -418,12 +416,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -446,14 +444,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -462,6 +460,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-renegotiation-disabled-client-cert.py
+++ b/scripts/test-renegotiation-disabled-client-cert.py
@@ -10,25 +10,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_message, ResetHandshakeHashes, \
-        CertificateGenerator, CertificateVerifyGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_message, ResetHandshakeHashes, \
+    CertificateGenerator, CertificateVerifyGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, ExpectServerKeyExchange,\
-        ExpectNoMessage, ExpectCertificateRequest, ExpectHelloRequest
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, ExpectServerKeyExchange, \
+    ExpectNoMessage, ExpectCertificateRequest, ExpectHelloRequest
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, SignatureScheme, GroupName
+    ExtensionType, SignatureScheme, GroupName
 from tlslite.extensions import ALPNExtension, TLSExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
-        SupportedGroupsExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+    SupportedGroupsExtension
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 4
 
@@ -73,7 +72,7 @@ def main():
 
     argv = sys.argv[1:]
     opts, args = getopt.getopt(argv, "h:p:e:x:X:n:k:c:d", ["help", "no-ins-renego",
-                                                      "early-abort"])
+                                                           "early-abort"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -135,8 +134,8 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
-                .create(groups)
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
+            .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
@@ -145,7 +144,7 @@ def main():
         ext = {}
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
     ext[ExtensionType.signature_algorithms_cert] = \
         SignatureAlgorithmsCertExtension().create(sig_algs)
@@ -178,18 +177,18 @@ def main():
                 SignatureScheme.rsa_pkcs1_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
     if dhe:
-        ext = {ExtensionType.renegotiation_info:None}
+        ext = {ExtensionType.renegotiation_info: None}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
-                .create(groups)
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
+            .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     else:
-        ext = {ExtensionType.renegotiation_info:None}
+        ext = {ExtensionType.renegotiation_info: None}
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
     ext[ExtensionType.signature_algorithms_cert] = \
         SignatureAlgorithmsCertExtension().create(sig_algs)
@@ -211,8 +210,8 @@ def main():
     # 2nd handshake
     node = node.add_child(ExpectHelloRequest())
     node = node.add_child(ResetHandshakeHashes())
-    ext = {ExtensionType.renegotiation_info:None}
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext = {ExtensionType.renegotiation_info: None}
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
     ext[ExtensionType.signature_algorithms_cert] = \
         SignatureAlgorithmsCertExtension().create(sig_algs)
@@ -244,18 +243,18 @@ def main():
                 SignatureScheme.rsa_pkcs1_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
     if dhe:
-        ext = {ExtensionType.renegotiation_info:None}
+        ext = {ExtensionType.renegotiation_info: None}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
-                .create(groups)
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
+            .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     else:
-        ext = {ExtensionType.renegotiation_info:None}
+        ext = {ExtensionType.renegotiation_info: None}
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
     ext[ExtensionType.signature_algorithms_cert] = \
         SignatureAlgorithmsCertExtension().create(sig_algs)
@@ -282,10 +281,10 @@ def main():
         # 2nd handshake
         node = node.add_child(ResetHandshakeHashes())
         ext = {}
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
         ext[ExtensionType.signature_algorithms_cert] = \
-                    SignatureAlgorithmsCertExtension().create(sig_algs)
+            SignatureAlgorithmsCertExtension().create(sig_algs)
         node = node.add_child(ClientHelloGenerator(ciphers,
                                                    session_id=bytearray(0),
                                                    extensions=ext))
@@ -327,7 +326,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -357,12 +356,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -383,14 +382,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -399,6 +398,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-renegotiation-disabled.py
+++ b/scripts/test-renegotiation-disabled.py
@@ -10,20 +10,18 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlslite.extensions import ALPNExtension, TLSExtension
 
-
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 3
 
@@ -118,7 +116,7 @@ def main():
     node = conversation
 
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
-    ext = {ExtensionType.renegotiation_info:None}
+    ext = {ExtensionType.renegotiation_info: None}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     ext = {ExtensionType.renegotiation_info: None}
     node = node.add_child(ExpectServerHello(extensions=ext))
@@ -131,7 +129,7 @@ def main():
     node = node.add_child(ExpectFinished())
     # 2nd handshake
     node = node.add_child(ResetHandshakeHashes())
-    ext = {ExtensionType.renegotiation_info:None}
+    ext = {ExtensionType.renegotiation_info: None}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                session_id=bytearray(0),
                                                extensions=ext))
@@ -159,7 +157,7 @@ def main():
     node = conversation
 
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
-    ext = {ExtensionType.renegotiation_info:None}
+    ext = {ExtensionType.renegotiation_info: None}
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     ext = {ExtensionType.renegotiation_info: None}
     node = node.add_child(ExpectServerHello(extensions=ext))
@@ -175,7 +173,7 @@ def main():
         bytearray(b"GET /?Renegotiation_Test=tlsfuzzer HTTP/1.0\r\n")))
     # 2nd handshake
     node = node.add_child(ResetHandshakeHashes())
-    ext = {ExtensionType.renegotiation_info:None}
+    ext = {ExtensionType.renegotiation_info: None}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                session_id=bytearray(0),
                                                extensions=ext))
@@ -271,7 +269,6 @@ def main():
         node.next_sibling = ExpectClose()
     conversations["try insecure (legacy) renegotiation with incomplete GET"] = conversation
 
-
     # run the conversation
     good = 0
     bad = 0
@@ -289,7 +286,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -319,12 +316,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -342,14 +339,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -358,6 +355,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-resumption-with-wrong-ciphers.py
+++ b/scripts/test-resumption-with-wrong-ciphers.py
@@ -9,17 +9,16 @@ from itertools import chain
 from random import sample
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, Close, ResetRenegotiationInfo
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, Close, ResetRenegotiationInfo
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 3
 
@@ -138,11 +137,11 @@ def main():
                CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(
         cipher=CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA if swap_ciphers else
-               CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
-        extensions={ExtensionType.renegotiation_info:None}))
+        CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -164,9 +163,9 @@ def main():
     node = node.add_child(ResetRenegotiationInfo())
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None},
+        extensions={ExtensionType.renegotiation_info: None},
         resume=True))
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
@@ -190,11 +189,11 @@ def main():
                CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(
         cipher=CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA if swap_ciphers else
-               CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
-        extensions={ExtensionType.renegotiation_info:None}))
+        CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -220,7 +219,7 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.illegal_parameter))
     node.add_child(ExpectClose())
@@ -232,9 +231,9 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -257,13 +256,12 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_NULL_SHA]
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.illegal_parameter))
     node.add_child(ExpectClose())
 
     conversations["resumption of safe session with NULL cipher"] = conversation
-
 
     # run the conversation
     good = 0
@@ -282,7 +280,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -312,12 +310,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -338,14 +336,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -354,6 +352,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-rsa-pss-sigs-on-certificate-verify.py
+++ b/scripts/test-rsa-pss-sigs-on-certificate-verify.py
@@ -11,26 +11,25 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        TCPBufferingEnable, TCPBufferingDisable, TCPBufferingFlush
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    TCPBufferingEnable, TCPBufferingDisable, TCPBufferingFlush
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange, ExpectCertificateRequest
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange, ExpectCertificateRequest
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import sig_algs_to_ids, RSA_SIG_ALL
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, HashAlgorithm, SignatureAlgorithm, SignatureScheme
+    ExtensionType, HashAlgorithm, SignatureAlgorithm, SignatureScheme
 from tlslite.extensions import SignatureAlgorithmsExtension, TLSExtension, \
-        SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsCertExtension
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 from tlslite.utils.cryptomath import numBytes
-
 
 version = 6
 
@@ -162,9 +161,9 @@ def main():
             (HashAlgorithm.sha224, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -210,9 +209,9 @@ def main():
             SignatureScheme.rsa_pss_pss_sha512
             ]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -251,9 +250,9 @@ def main():
             SignatureScheme.rsa_pss_pss_sha512
             ]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -307,9 +306,9 @@ def main():
                 SignatureScheme.rsa_pss_pss_sha512
                 ]
         ext = {ExtensionType.signature_algorithms:
-                SignatureAlgorithmsExtension().create(sigs),
+                   SignatureAlgorithmsExtension().create(sigs),
                ExtensionType.signature_algorithms_cert:
-                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -337,7 +336,7 @@ def main():
                                               AlertDescription.decrypt_error))
         node = node.add_child(ExpectClose())
         conversations["{0} in CertificateVerify with {1} key"
-                      .format(SignatureScheme.toRepr(scheme), cert.certAlg)] = conversation
+            .format(SignatureScheme.toRepr(scheme), cert.certAlg)] = conversation
 
     # check if CertificateVerify can be signed with any algorithm
     for scheme in schemes:
@@ -351,9 +350,9 @@ def main():
                 SignatureScheme.rsa_pss_pss_sha512
                 ]
         ext = {ExtensionType.signature_algorithms:
-                SignatureAlgorithmsExtension().create(sigs),
+                   SignatureAlgorithmsExtension().create(sigs),
                ExtensionType.signature_algorithms_cert:
-                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -381,7 +380,7 @@ def main():
         node.next_sibling = ExpectClose()
         node = node.add_child(ExpectClose())
         conversations["{0} in CertificateVerify with {1} key"
-                      .format(SignatureScheme.toRepr(scheme), cert.certAlg)] = conversation
+            .format(SignatureScheme.toRepr(scheme), cert.certAlg)] = conversation
 
     # check if CertificateVerify with wrong salt size is rejected
     for scheme in schemes:
@@ -395,9 +394,9 @@ def main():
                 SignatureScheme.rsa_pss_pss_sha512
                 ]
         ext = {ExtensionType.signature_algorithms:
-                SignatureAlgorithmsExtension().create(sigs),
+                   SignatureAlgorithmsExtension().create(sigs),
                ExtensionType.signature_algorithms_cert:
-                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -422,7 +421,7 @@ def main():
                                           AlertDescription.decrypt_error))
         node = node.add_child(ExpectClose())
         conversations["{0} in CertificateVerify with incorrect salt len"
-                      .format(SignatureScheme.toRepr(scheme))] = conversation
+            .format(SignatureScheme.toRepr(scheme))] = conversation
 
     # check if CertificateVerify with wrong salt size is rejected
     for pos in range(numBytes(private_key.n)):
@@ -437,9 +436,9 @@ def main():
                     SignatureScheme.rsa_pss_pss_sha512
                     ]
             ext = {ExtensionType.signature_algorithms:
-                    SignatureAlgorithmsExtension().create(sigs),
+                       SignatureAlgorithmsExtension().create(sigs),
                    ExtensionType.signature_algorithms_cert:
-                    SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                       SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
             ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                        CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                        CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -459,7 +458,7 @@ def main():
                 scheme = SignatureScheme.rsa_pss_pss_sha256
             node = node.add_child(CertificateVerifyGenerator(private_key,
                                                              msg_alg=scheme,
-                                                             padding_xors={pos:xor}))
+                                                             padding_xors={pos: xor}))
             node = node.add_child(ChangeCipherSpecGenerator())
             node = node.add_child(FinishedGenerator())
             node = node.add_child(TCPBufferingDisable())
@@ -468,7 +467,7 @@ def main():
                                               AlertDescription.decrypt_error))
             node = node.add_child(ExpectClose())
             conversations_long["malformed {0} in CertificateVerify - xor {1} at {2}"
-                               .format(cert.certAlg, hex(xor), pos)] = conversation
+                .format(cert.certAlg, hex(xor), pos)] = conversation
 
     if cert.certAlg == "rsa-pss":
         conversation = Connect(host, port)
@@ -481,9 +480,9 @@ def main():
                 SignatureScheme.rsa_pss_pss_sha512
                 ]
         ext = {ExtensionType.signature_algorithms:
-                SignatureAlgorithmsExtension().create(sigs),
+                   SignatureAlgorithmsExtension().create(sigs),
                ExtensionType.signature_algorithms_cert:
-                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -524,9 +523,9 @@ def main():
             SignatureScheme.rsa_pss_pss_sha512
             ]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -563,7 +562,7 @@ def main():
                                           AlertDescription.decrypt_error))
     node = node.add_child(ExpectClose())
     conversations["{0} signature in CertificateVerify with rsa_pkcs1_sha256 id"
-                  .format(SignatureScheme.toRepr(sig_alg))] = conversation
+        .format(SignatureScheme.toRepr(sig_alg))] = conversation
 
     conversation = Connect(host, port)
     node = conversation
@@ -575,9 +574,9 @@ def main():
             SignatureScheme.rsa_pss_pss_sha512
             ]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -607,7 +606,7 @@ def main():
                                       AlertDescription.decrypt_error))
     node = node.add_child(ExpectClose())
     conversations["short sig with {0} id".format(
-                  SignatureScheme.toRepr(scheme))] = conversation
+        SignatureScheme.toRepr(scheme))] = conversation
 
     # run the conversation
     good = 0
@@ -629,9 +628,9 @@ def main():
         short_tests = [(k, v) for k, v in conversations.items() if (k != 'sanity') and k in run_only]
     else:
         long_tests = [(k, v) for k, v in conversations_long.items() if
-                        k not in run_exclude]
+                      k not in run_exclude]
         short_tests = [(k, v) for k, v in conversations.items() if
-                        (k != 'sanity') and k not in run_exclude]
+                       (k != 'sanity') and k not in run_exclude]
     sampled_tests = sample(long_tests, min(num_limit, len(long_tests)))
     ordered_tests = chain(sanity_tests, short_tests, sampled_tests, sanity_tests)
 
@@ -656,12 +655,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -684,14 +683,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + len(short_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + len(short_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -700,6 +699,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-rsa-sigs-on-certificate-verify.py
+++ b/scripts/test-rsa-sigs-on-certificate-verify.py
@@ -12,25 +12,24 @@ from itertools import chain
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        AlertGenerator, TCPBufferingEnable, TCPBufferingDisable, \
-        TCPBufferingFlush
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    AlertGenerator, TCPBufferingEnable, TCPBufferingDisable, \
+    TCPBufferingFlush
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData, ExpectServerKeyExchange
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension, SupportedGroupsExtension
+    SignatureAlgorithmsCertExtension, SupportedGroupsExtension
 from tlslite.constants import CipherSuite, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, GroupName
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, GroupName
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 from tlsfuzzer.helpers import RSA_SIG_ALL
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 6
 
@@ -114,7 +113,6 @@ def main():
     else:
         run_only = None
 
-
     if not private_key:
         raise ValueError("Specify private key file using -k")
     if not cert:
@@ -129,15 +127,15 @@ def main():
     else:
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create([
-                (getattr(HashAlgorithm, x),
-                    SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                        'sha224', 'sha1', 'md5']]),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+    ext = {ExtensionType.signature_algorithms:
+        SignatureAlgorithmsExtension().create([
+            (getattr(HashAlgorithm, x),
+             SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                               'sha224', 'sha1', 'md5']]),
+        ExtensionType.signature_algorithms_cert:
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     if dhe:
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([GroupName.secp256r1, GroupName.ffdhe2048])
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
@@ -185,13 +183,13 @@ def main():
                 else:
                     ciphers = [CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
                                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-            ext = {ExtensionType.signature_algorithms :
-                   SignatureAlgorithmsExtension().create([
-                     (getattr(HashAlgorithm, x),
-                      SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
-                                                        'sha224', 'sha1', 'md5']]),
-                   ExtensionType.signature_algorithms_cert :
-                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+            ext = {ExtensionType.signature_algorithms:
+                SignatureAlgorithmsExtension().create([
+                    (getattr(HashAlgorithm, x),
+                     SignatureAlgorithm.rsa) for x in ['sha512', 'sha384', 'sha256',
+                                                       'sha224', 'sha1', 'md5']]),
+                ExtensionType.signature_algorithms_cert:
+                    SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
             if dhe:
                 ext[ExtensionType.supported_groups] = \
                     SupportedGroupsExtension().create(
@@ -222,7 +220,7 @@ def main():
             node.next_sibling.add_child(ExpectClose())
 
             conversations["check {0} w/{1} PRF".format(md, prf)] = \
-                    conversation
+                conversation
 
     # run the conversation
     good = 0
@@ -239,7 +237,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -255,9 +253,9 @@ def main():
 
         res = True
         exception = None
-        #because we don't want to abort the testing and we are reporting
-        #the errors to the user, using a bare except is OK
-        #pylint: disable=bare-except
+        # because we don't want to abort the testing and we are reporting
+        # the errors to the user, using a bare except is OK
+        # pylint: disable=bare-except
         try:
             runner.run()
         except Exception as exp:
@@ -265,7 +263,7 @@ def main():
             print("Error while processing")
             print(traceback.format_exc())
             res = False
-        #pylint: enable=bare-except
+        # pylint: enable=bare-except
 
         if c_name in expected_failures:
             if res:
@@ -273,12 +271,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -294,14 +292,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -310,6 +308,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-serverhello-random.py
+++ b/scripts/test-serverhello-random.py
@@ -12,19 +12,18 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        CopyVariables
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    CopyVariables
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import uniqueness_check
-
 
 version = 4
 
@@ -100,9 +99,9 @@ def main():
     collected_session_ids = []
     variables_check = \
         {'ServerHello.random':
-         collected_randoms,
+             collected_randoms,
          'ServerHello.session_id':
-         collected_session_ids}
+             collected_session_ids}
 
     conversations = {}
 
@@ -111,9 +110,9 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions={ExtensionType.
-                                                   renegotiation_info:None}))
+                                               renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(CopyVariables(variables_check))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
@@ -170,7 +169,7 @@ def main():
             conversations["Protocol {0}{1}".format(
                 prot,
                 " in SSLv2 compatible ClientHello" if ssl2 else "")] = \
-                    conversation
+                conversation
 
     # run the conversation
     good = 0
@@ -189,7 +188,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -220,22 +219,22 @@ def main():
                     xpassed.append(c_name)
                     print("XPASS-expected failure but test passed\n")
                 else:
-                    if expected_failures[c_name] is not None and  \
-                        expected_failures[c_name] not in str(exception):
-                            bad += 1
-                            failed.append(c_name)
-                            print("Expected error message: {0}\n"
-                                .format(expected_failures[c_name]))
+                    if expected_failures[c_name] is not None and \
+                            expected_failures[c_name] not in str(exception):
+                        bad += 1
+                        failed.append(c_name)
+                        print("Expected error message: {0}\n"
+                              .format(expected_failures[c_name]))
                     else:
                         xfail += 1
                         print("OK-expected failure\n")
             else:
-                    if res:
-                        good += 1
-                        print("OK\n")
-                    else:
-                        bad += 1
-                        failed.append(c_name)
+                if res:
+                    good += 1
+                    print("OK\n")
+                else:
+                    bad += 1
+                    failed.append(c_name)
 
     failed_tests = uniqueness_check(variables_check, good + bad)
     if failed_tests:
@@ -252,14 +251,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -268,6 +267,7 @@ def main():
 
     if bad > 0 or failed_tests:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-sessionID-resumption.py
+++ b/scripts/test-sessionID-resumption.py
@@ -9,17 +9,16 @@ from itertools import chain
 from random import sample
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, Close, ResetRenegotiationInfo
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, Close, ResetRenegotiationInfo
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 3
 
@@ -111,9 +110,9 @@ def main():
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -135,9 +134,9 @@ def main():
     node = node.add_child(ResetRenegotiationInfo())
     node = node.add_child(ClientHelloGenerator(
         ciphers,
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None},
+        extensions={ExtensionType.renegotiation_info: None},
         resume=True))
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectFinished())
@@ -160,9 +159,9 @@ def main():
     node = node.add_child(ClientHelloGenerator(
         ciphers,
         session_id=bytearray(32),
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectServerHello(
-        extensions={ExtensionType.renegotiation_info:None}))
+        extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -201,7 +200,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -231,12 +230,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -255,14 +254,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -271,6 +270,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-sig-algs-renegotiation-resumption.py
+++ b/scripts/test-sig-algs-renegotiation-resumption.py
@@ -10,22 +10,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, Close
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, Close
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
-
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType
+    GroupName, ExtensionType
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import SIG_ALL
-
 
 version = 1
 
@@ -135,7 +133,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -176,7 +174,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -220,7 +218,7 @@ def main():
         node.add_child(Close())
     else:
         node = node.add_child(ExpectServerHello(
-            extensions={ExtensionType.renegotiation_info:None}))
+            extensions={ExtensionType.renegotiation_info: None}))
         node = node.add_child(ExpectCertificate())
         if dhe:
             node = node.add_child(ExpectServerKeyExchange())
@@ -252,7 +250,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -295,7 +293,7 @@ def main():
         node.add_child(Close())
     else:
         node = node.add_child(ExpectServerHello(
-            extensions={ExtensionType.renegotiation_info:None},
+            extensions={ExtensionType.renegotiation_info: None},
             resume=True))
         node = node.add_child(ExpectChangeCipherSpec())
         node = node.add_child(ExpectFinished())
@@ -319,7 +317,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -358,7 +356,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -404,7 +402,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -453,7 +451,7 @@ def main():
         node.next_sibling = ExpectClose()
     else:
         node = node.add_child(ExpectServerHello(
-            extensions={ExtensionType.renegotiation_info:None}))
+            extensions={ExtensionType.renegotiation_info: None}))
         node = node.add_child(ExpectCertificate())
         if dhe:
             node = node.add_child(ExpectServerKeyExchange())
@@ -485,7 +483,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -530,7 +528,7 @@ def main():
         node.add_child(Close())
     else:
         node = node.add_child(ExpectServerHello(
-            extensions={ExtensionType.renegotiation_info:None}))
+            extensions={ExtensionType.renegotiation_info: None}))
         node = node.add_child(ExpectCertificate())
         if dhe:
             node = node.add_child(ExpectServerKeyExchange())
@@ -562,7 +560,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -608,7 +606,7 @@ def main():
         node.add_child(Close())
     else:
         node = node.add_child(ExpectServerHello(
-            extensions={ExtensionType.renegotiation_info:None}))
+            extensions={ExtensionType.renegotiation_info: None}))
         node = node.add_child(ExpectCertificate())
         if dhe:
             node = node.add_child(ExpectServerKeyExchange())
@@ -640,7 +638,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -684,7 +682,7 @@ def main():
         node.add_child(Close())
     else:
         node = node.add_child(ExpectServerHello(
-            extensions={ExtensionType.renegotiation_info:None},
+            extensions={ExtensionType.renegotiation_info: None},
             resume=True))
         node = node.add_child(ExpectChangeCipherSpec())
         node = node.add_child(ExpectFinished())
@@ -712,7 +710,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -757,7 +755,7 @@ def main():
         node.add_child(Close())
     else:
         node = node.add_child(ExpectServerHello(
-            extensions={ExtensionType.renegotiation_info:None},
+            extensions={ExtensionType.renegotiation_info: None},
             resume=True))
         node = node.add_child(ExpectChangeCipherSpec())
         node = node.add_child(ExpectFinished())
@@ -772,7 +770,8 @@ def main():
         # so just expect one record and then just close the connection
         node = node.add_child(ExpectApplicationData())
         node.add_child(Close())
-    conversations["renegotiation with session_id resumption without signature_algorithms and signature_algorithms_cert ext"] = conversation
+    conversations[
+        "renegotiation with session_id resumption without signature_algorithms and signature_algorithms_cert ext"] = conversation
 
     # check if renegotiation with resumption with missing sig_algs_cert works
     conversation = Connect(host, port)
@@ -785,7 +784,7 @@ def main():
     if dhe:
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -829,7 +828,7 @@ def main():
         node.add_child(Close())
     else:
         node = node.add_child(ExpectServerHello(
-            extensions={ExtensionType.renegotiation_info:None},
+            extensions={ExtensionType.renegotiation_info: None},
             resume=True))
         node = node.add_child(ExpectChangeCipherSpec())
         node = node.add_child(ExpectFinished())
@@ -890,12 +889,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -914,14 +913,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -930,6 +929,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-sig-algs.py
+++ b/scripts/test-sig-algs.py
@@ -11,23 +11,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_message
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_message
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, HashAlgorithm, SignatureAlgorithm, SignatureScheme, \
-        GroupName
+    ExtensionType, HashAlgorithm, SignatureAlgorithm, SignatureScheme, \
+    GroupName
 from tlslite.extensions import SignatureAlgorithmsExtension, TLSExtension, \
-        SignatureAlgorithmsCertExtension, SupportedGroupsExtension
+    SignatureAlgorithmsCertExtension, SupportedGroupsExtension
 from tlsfuzzer.helpers import RSA_SIG_ALL
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlsfuzzer.utils.lists import natural_sort_keys
-
 
 version = 6
 
@@ -105,9 +104,9 @@ def main():
             (HashAlgorithm.sha224, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.secp256r1,
               GroupName.x25519,
               GroupName.secp384r1,
@@ -148,9 +147,9 @@ def main():
         conversation = Connect(host, port)
         node = conversation
         ext = {ExtensionType.signature_algorithms:
-                SignatureAlgorithmsExtension().create([sig]),
+                   SignatureAlgorithmsExtension().create([sig]),
                ExtensionType.signature_algorithms_cert:
-                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ext[ExtensionType.supported_groups] = \
             SupportedGroupsExtension().create(groups)
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -176,7 +175,7 @@ def main():
         node.next_sibling = ExpectClose()
         node = node.add_child(ExpectClose())
         conversations["{0} only"
-                      .format(SignatureScheme.toRepr(sig))] = conversation
+            .format(SignatureScheme.toRepr(sig))] = conversation
 
     # MD5 not selected, even if first
     conversation = Connect(host, port)
@@ -191,9 +190,9 @@ def main():
             SignatureScheme.rsa_pss_pss_sha384,
             SignatureScheme.rsa_pss_pss_sha512]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -231,9 +230,9 @@ def main():
             SignatureScheme.rsa_pss_pss_sha384,
             SignatureScheme.rsa_pss_pss_sha512]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -271,9 +270,9 @@ def main():
             SignatureScheme.rsa_pss_pss_sha384,
             SignatureScheme.rsa_pss_pss_sha512]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -316,9 +315,9 @@ def main():
             SignatureScheme.rsa_pss_pss_sha384,
             SignatureScheme.rsa_pss_pss_sha512]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -352,11 +351,11 @@ def main():
             (10, 10),  # undefined pair
             (9, 24),  # undefined pair
             (0xff, 0xff)  # undefined pair
-           ]
+            ]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -373,9 +372,9 @@ def main():
     conversation = Connect(host, port)
     node = conversation
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create([]),
+               SignatureAlgorithmsExtension().create([]),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -397,7 +396,7 @@ def main():
     ext[ExtensionType.signature_algorithms_cert] = \
         SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
     sigs = [(HashAlgorithm.sha256, SignatureAlgorithm.rsa)]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sigs)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
@@ -418,7 +417,7 @@ def main():
         SupportedGroupsExtension().create(groups)
     ext[ExtensionType.signature_algorithms_cert] = \
         SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
-    ext[ExtensionType.signature_algorithms] =  SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sigs)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
@@ -434,12 +433,12 @@ def main():
     conversation = Connect(host, port)
     node = conversation
     ext = {ExtensionType.signature_algorithms:
-            TLSExtension(extType=ExtensionType.signature_algorithms)
-            .create(bytearray(b'\x00\x03'  # length of array
-                              b'\x04\x01'  # sha256 + rsa
-                              b'\x04')),  # the odd byte
+               TLSExtension(extType=ExtensionType.signature_algorithms)
+                   .create(bytearray(b'\x00\x03'  # length of array
+                                     b'\x04\x01'  # sha256 + rsa
+                                     b'\x04')),  # the odd byte
            ExtensionType.signature_algorithms_cert:
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -456,13 +455,13 @@ def main():
     conversation = Connect(host, port)
     node = conversation
     ext = {ExtensionType.signature_algorithms:
-            TLSExtension(extType=ExtensionType.signature_algorithms)
-            .create(bytearray(b'\x00\x04'  # length of array
-                              b'\x02\x01'  # sha1+rsa
-                              b'\x04\x01'  # sha256 + rsa
-                              b'\x04\x03')),  # extra bytes
+               TLSExtension(extType=ExtensionType.signature_algorithms)
+                   .create(bytearray(b'\x00\x04'  # length of array
+                                     b'\x02\x01'  # sha1+rsa
+                                     b'\x04\x01'  # sha256 + rsa
+                                     b'\x04\x03')),  # extra bytes
            ExtensionType.signature_algorithms_cert:
-           SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -492,7 +491,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -520,12 +519,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -558,7 +557,7 @@ def main():
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -567,6 +566,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-signature-algorithms.py
+++ b/scripts/test-signature-algorithms.py
@@ -11,19 +11,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, Close, \
-        fuzz_message
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, Close, \
+    fuzz_message
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, SignatureScheme, \
-        GroupName
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, SignatureScheme, \
+    GroupName
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension, SupportedGroupsExtension
+    SignatureAlgorithmsCertExtension, SupportedGroupsExtension
 from tlsfuzzer.helpers import RSA_SIG_ALL, SIG_ALL, ECDSA_SIG_ALL
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlsfuzzer.utils.lists import natural_sort_keys
@@ -110,7 +110,7 @@ def main():
     node = conversation
     ext = {}
     groups = [GroupName.secp256r1]
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ext[ExtensionType.signature_algorithms] = \
         SignatureAlgorithmsExtension().create(SIG_ALL)
@@ -143,7 +143,7 @@ def main():
     node = conversation
     groups = [GroupName.secp256r1]
     ext = {}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -186,17 +186,17 @@ def main():
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     sigs = [(HashAlgorithm.sha1, expected_signature)]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(expected_sig_list)}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(expected_sig_list)}
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
     if no_sha1:
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                      AlertDescription.handshake_failure))
+                                          AlertDescription.handshake_failure))
         node = node.add_child(ExpectClose())
     else:
         node = node.add_child(ExpectServerHello(version=(3, 3)))
@@ -226,11 +226,11 @@ def main():
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     sigs = [(HashAlgorithm.sha256, expected_signature)]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(expected_sig_list)}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(expected_sig_list)}
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
@@ -262,11 +262,11 @@ def main():
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     sigs = [(0, expected_signature),
             (HashAlgorithm.sha256, expected_signature)]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(expected_sig_list)}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(expected_sig_list)}
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
@@ -298,11 +298,11 @@ def main():
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     sigs = [(10, expected_signature),
             (HashAlgorithm.sha256, expected_signature)]
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(expected_sig_list)}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(expected_sig_list)}
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
@@ -335,11 +335,11 @@ def main():
     sigs = list(chain(
         ((i, expected_signature) for i in range(10, 224)),
         [(HashAlgorithm.sha256, expected_signature)]))
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(expected_sig_list)}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(expected_sig_list)}
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
@@ -372,11 +372,11 @@ def main():
     sigs = list(chain(
         ((i, j) for i in range(10, 224) for j in range(10, 21)),
         [(HashAlgorithm.sha256, expected_signature)]))
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(expected_sig_list)}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(expected_sig_list)}
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
@@ -408,11 +408,11 @@ def main():
     sigs = list(chain(
         ((i, j) for i in range(10, 224) for j in range(21, 59)),
         [(HashAlgorithm.sha256, expected_signature)]))
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(expected_sig_list)}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(expected_sig_list)}
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
@@ -432,7 +432,6 @@ def main():
     node = node.add_child(Close())  # OpenSSL lists them, which makes the response huge
     conversations["tolerance 8132 RSA or ECDSA methods"] = conversation
 
-
     conversation = Connect(host, port)
     node = conversation
     groups = [GroupName.secp256r1]
@@ -445,7 +444,7 @@ def main():
         ((i, j) for i in range(10, 224) for j in range(10, 121)),
         [(HashAlgorithm.sha256, expected_signature)])))
     ext = {ExtensionType.signature_algorithms: sig_alg}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
@@ -480,7 +479,7 @@ def main():
         ((i, 163) for i in range(10, 27)),
         [(HashAlgorithm.sha256, expected_signature)])))
     ext = {ExtensionType.signature_algorithms: sig_alg}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
@@ -514,11 +513,11 @@ def main():
         ((i, j) for i in range(10, 224) for j in range(10, 86)),
         ((i, 163) for i in range(10, 123)),
         [(HashAlgorithm.sha256, expected_signature)]))
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(sigs)}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(sigs)}
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
@@ -555,11 +554,11 @@ def main():
         ((i, j) for i in range(10, 224) for j in range(10, (n // 214) + 10)),
         ((i, 163) for i in range(10, (n % 214) + 10)),
         [(HashAlgorithm.sha256, expected_signature)]))
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(expected_sig_list)}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(expected_sig_list)}
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                extensions=ext))
@@ -587,12 +586,12 @@ def main():
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     sigs = []
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(sigs),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(SIG_ALL)}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
-    .create(groups)
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sigs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(SIG_ALL)}
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
+        .create(groups)
     hello = ClientHelloGenerator(ciphers, version=(3, 3),
                                  extensions=ext)
     node = node.add_child(hello)
@@ -600,7 +599,7 @@ def main():
                                       getattr(AlertDescription, fatal_alert)))
     node = node.add_child(ExpectClose())
     conversations["empty list of signature methods"] = \
-            conversation
+        conversation
 
     # generate maximum number of methods for 2 extensions
     # (4 bytes for extensions header, 2 bytes for length of list inside
@@ -617,12 +616,12 @@ def main():
         n = n - len(expected_sig_list)  # number of methods in sig_alg_cert extension
         sigs = [(HashAlgorithm.sha1, SignatureAlgorithm.dsa)] * n
         sigs += [(HashAlgorithm.sha256, expected_signature)]
-        ext = {ExtensionType.signature_algorithms :
-               SignatureAlgorithmsExtension().create(sigs),
-               ExtensionType.signature_algorithms_cert :
-               SignatureAlgorithmsCertExtension().create(expected_sig_list)}
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
-        .create(groups)
+        ext = {ExtensionType.signature_algorithms:
+                   SignatureAlgorithmsExtension().create(sigs),
+               ExtensionType.signature_algorithms_cert:
+                   SignatureAlgorithmsCertExtension().create(expected_sig_list)}
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
+            .create(groups)
         node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
                                                    extensions=ext))
         node = node.add_child(ExpectServerHello(version=(3, 3)))
@@ -640,7 +639,7 @@ def main():
         # ApplicationData message may show up 1 to many times
         node = node.add_child(ExpectApplicationData())
         node = node.add_child(AlertGenerator(AlertLevel.warning,
-                              AlertDescription.close_notify))
+                                             AlertDescription.close_notify))
         cycle_alert = ExpectAlert()
         node = node.add_child(cycle_alert)
         node.next_sibling = ExpectApplicationData()
@@ -664,27 +663,27 @@ def main():
         last = 'ecdsa'
     sig_algs = []
     for sig_alg in [first, 'dsa']:
-        sig_algs += [(getattr(HashAlgorithm, x), getattr(SignatureAlgorithm, sig_alg))\
-                      for x in ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']]
+        sig_algs += [(getattr(HashAlgorithm, x), getattr(SignatureAlgorithm, sig_alg)) \
+                     for x in ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']]
     sig_algs += [SignatureScheme.rsa_pss_rsae_sha256,
                  SignatureScheme.rsa_pss_rsae_sha384,
                  SignatureScheme.rsa_pss_rsae_sha512,
                  SignatureScheme.rsa_pss_pss_sha256,
                  SignatureScheme.rsa_pss_pss_sha384,
-                 SignatureScheme.rsa_pss_pss_sha512] 
+                 SignatureScheme.rsa_pss_pss_sha512]
     # ed25519(0x0807), ed448(0x0808)
     sig_algs += [(8, 7), (8, 8)]
-    sig_algs += [(getattr(HashAlgorithm, x), getattr(SignatureAlgorithm, last))\
+    sig_algs += [(getattr(HashAlgorithm, x), getattr(SignatureAlgorithm, last)) \
                  for x in ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']]
 
-    ext = {ExtensionType.signature_algorithms :
-           SignatureAlgorithmsExtension().create(sig_algs),
-           ExtensionType.signature_algorithms_cert :
-           SignatureAlgorithmsCertExtension().create(expected_sig_list)}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
-    .create(groups)
+    ext = {ExtensionType.signature_algorithms:
+               SignatureAlgorithmsExtension().create(sig_algs),
+           ExtensionType.signature_algorithms_cert:
+               SignatureAlgorithmsCertExtension().create(expected_sig_list)}
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
+        .create(groups)
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 3),
-                                                extensions=ext))
+                                               extensions=ext))
     node = node.add_child(ExpectServerHello(version=(3, 3)))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
@@ -700,7 +699,7 @@ def main():
     # ApplicationData message may show up 1 to many times
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
-                          AlertDescription.close_notify))
+                                         AlertDescription.close_notify))
     cycle_alert = ExpectAlert()
     node = node.add_child(cycle_alert)
     node.next_sibling = ExpectApplicationData()
@@ -721,17 +720,17 @@ def main():
         sig_alg.create([(HashAlgorithm.sha256, expected_signature),
                         (HashAlgorithm.sha1, expected_signature)])
         ext = OrderedDict()
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
-        .create(groups)
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
+            .create(groups)
         ext[ExtensionType.signature_algorithms] = sig_alg
         hello = ClientHelloGenerator(ciphers, version=(3, 3),
                                      extensions=ext)
-        node = node.add_child(fuzz_message(hello, xors={-5:i}))
+        node = node.add_child(fuzz_message(hello, xors={-5: i}))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           getattr(AlertDescription, fatal_alert)))
         node = node.add_child(ExpectClose())
-        conversations["fuzz length inside extension to {0}".format(4^i)] = \
-                conversation
+        conversations["fuzz length inside extension to {0}".format(4 ^ i)] = \
+            conversation
 
     # run the conversation
     good = 0
@@ -750,7 +749,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -780,21 +779,21 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
         else:
             if res:
-                good+=1
+                good += 1
                 print("OK")
             else:
-                bad+=1
+                bad += 1
                 failed.append(c_name)
 
     print("Signature Algorithms in TLS 1.2")
@@ -809,14 +808,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -824,6 +823,7 @@ def main():
         print("FAILED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-ssl-death-alert.py
+++ b/scripts/test-ssl-death-alert.py
@@ -12,19 +12,18 @@ import getopt
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType
+    GroupName, ExtensionType
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import flexible_getattr
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 version = 5
 
@@ -116,7 +115,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -154,7 +153,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -166,7 +165,7 @@ def main():
         ext = None
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-    for _ in range(number_of_alerts+1):
+    for _ in range(number_of_alerts + 1):
         node = node.add_child(AlertGenerator(
             AlertLevel.warning, AlertDescription.unsupported_certificate))
     node = node.add_child(ExpectServerHello())
@@ -177,7 +176,6 @@ def main():
     node = node.add_child(ExpectAlert(alert_level, alert_description))
     node = node.add_child(ExpectClose())
     conversations["SSL Death Alert with getting alert"] = conversation
-
 
     # run the conversation
     good = 0
@@ -193,10 +191,10 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k not in run_exclude]
+                         k not in run_exclude]
     sampled_tests = sample(regular_tests, min(num_limit, len(regular_tests)))
 
     for c_name, conversation in sampled_tests:
@@ -224,12 +222,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -256,7 +254,7 @@ def main():
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -265,6 +263,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-sslv2-connection.py
+++ b/scripts/test-sslv2-connection.py
@@ -12,16 +12,17 @@ import getopt
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        ClientMasterKeyGenerator, Close
+    FinishedGenerator, ApplicationDataGenerator, \
+    ClientMasterKeyGenerator, Close
 from tlsfuzzer.expect import ExpectFinished, ExpectApplicationData, \
-        ExpectServerHello2, ExpectVerify
+    ExpectServerHello2, ExpectVerify
 
 from tlslite.constants import CipherSuite, AlertLevel, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     """Print usage information"""
@@ -39,6 +40,7 @@ def help_msg():
     print("                execution of preceding expected failure probe")
     print("                usage: [-x probe-name] [-X exception], order is compulsory!")
     print(" --help        this message")
+
 
 def main():
     """Test if the server supports some of the SSLv2 ciphers"""
@@ -79,10 +81,10 @@ def main():
         raise ValueError("Unknown options: {0}".format(argv))
 
     for cipher_id, cipher_name in {
-            CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5:"DES-CBC3-MD5",
-            CipherSuite.SSL_CK_RC4_128_WITH_MD5:"RC4-MD5",
-            CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5:"EXP-RC4-MD5"
-            }.items():
+        CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5: "DES-CBC3-MD5",
+        CipherSuite.SSL_CK_RC4_128_WITH_MD5: "RC4-MD5",
+        CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5: "EXP-RC4-MD5"
+    }.items():
         # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
         conversation = Connect(host, port, version=(0, 2))
         node = conversation
@@ -106,7 +108,7 @@ def main():
         node.add_child(Close())
 
         conversations["Connect with SSLv2 {0}"
-                      .format(cipher_name)] = conversation
+            .format(cipher_name)] = conversation
 
     good = 0
     bad = 0
@@ -142,21 +144,21 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
         else:
             if res:
-                good+=1
+                good += 1
                 print("OK\n")
             else:
-                xfail+=1
+                xfail += 1
 
     print("Note: This test verifies that an implementation implements and")
     print("      will negotiate SSLv2 protocol. This is a BAD configuration.")
@@ -179,7 +181,7 @@ def main():
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -188,6 +190,7 @@ def main():
 
     if good > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-sslv2-force-cipher-3des.py
+++ b/scripts/test-sslv2-force-cipher-3des.py
@@ -11,19 +11,20 @@ import getopt
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ClientMasterKeyGenerator
+    ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ClientMasterKeyGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, \
-        ExpectAlert, ExpectClose, ExpectApplicationData, ExpectServerHello2, \
-        ExpectVerify, ExpectSSL2Alert
+    ExpectServerHelloDone, ExpectChangeCipherSpec, \
+    ExpectAlert, ExpectClose, ExpectApplicationData, ExpectServerHello2, \
+    ExpectVerify, ExpectSSL2Alert
 
 from tlslite.constants import CipherSuite, AlertLevel, \
-        ExtensionType, SSL2ErrorDescription
+    ExtensionType, SSL2ErrorDescription
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     """Usage information"""
@@ -41,6 +42,7 @@ def help_msg():
     print("                execution of preceding expected failure probe")
     print("                usage: [-x probe-name] [-X exception], order is compulsory!")
     print(" --help        this message")
+
 
 def main():
     """
@@ -85,13 +87,13 @@ def main():
         raise ValueError("Unknown options: {0}".format(argv))
 
     for prot_vers, proto_name in {
-            (0, 2):"SSLv2",
-            (3, 0):"SSLv3",
-            (3, 1):"TLSv1.0"
-            }.items():
+        (0, 2): "SSLv2",
+        (3, 0): "SSLv3",
+        (3, 1): "TLSv1.0"
+    }.items():
         for cipher_id, cipher_name in {
-                CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5:"DES-CBC3-MD5"
-                }.items():
+            CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5: "DES-CBC3-MD5"
+        }.items():
             # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
             conversation = Connect(host, port, version=(0, 2))
             node = conversation
@@ -129,7 +131,7 @@ def main():
             node.add_child(ExpectClose())
 
             conversations["Connect with {1} {0}"
-                          .format(cipher_name, proto_name)] = conversation
+                .format(cipher_name, proto_name)] = conversation
 
     good = 0
     bad = 0
@@ -166,23 +168,23 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
         else:
             if res:
-                good+=1
+                good += 1
                 print("OK\n")
             else:
-                bad+=1
+                bad += 1
                 failed.append(c_name)
-    
+
     print("Note: SSLv2 was officially deprecated (MUST NOT use) in 2011, see")
     print("      RFC 6176.")
     print("      If one or more of the tests fails because of error in form of")
@@ -207,7 +209,7 @@ def main():
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -216,6 +218,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-sslv2-force-cipher-non3des.py
+++ b/scripts/test-sslv2-force-cipher-non3des.py
@@ -10,19 +10,20 @@ import getopt
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ClientMasterKeyGenerator
+    ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ClientMasterKeyGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, \
-        ExpectAlert, ExpectClose, ExpectApplicationData, ExpectServerHello2, \
-        ExpectVerify, ExpectSSL2Alert
+    ExpectServerHelloDone, ExpectChangeCipherSpec, \
+    ExpectAlert, ExpectClose, ExpectApplicationData, ExpectServerHello2, \
+    ExpectVerify, ExpectSSL2Alert
 
 from tlslite.constants import CipherSuite, AlertLevel, \
-        ExtensionType, SSL2ErrorDescription
+    ExtensionType, SSL2ErrorDescription
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     """Usage information"""
@@ -40,6 +41,7 @@ def help_msg():
     print("                execution of preceding expected failure probe")
     print("                usage: [-x probe-name] [-X exception], order is compulsory!")
     print(" --help        this message")
+
 
 def main():
     """
@@ -85,19 +87,19 @@ def main():
         raise ValueError("Unknown options: {0}".format(argv))
 
     for prot_vers, proto_name in {
-            (0, 2):"SSLv2",
-            (3, 0):"SSLv3",
-            (3, 1):"TLSv1.0"
-            }.items():
+        (0, 2): "SSLv2",
+        (3, 0): "SSLv3",
+        (3, 1): "TLSv1.0"
+    }.items():
         for cipher_id, cipher_name in {
-                CipherSuite.SSL_CK_RC4_128_WITH_MD5:"RC4-MD5",
-                CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5:"EXP-RC4-MD5",
-                CipherSuite.SSL_CK_RC2_128_CBC_WITH_MD5:"RC2-CBC-MD5",
-                CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5:
-                    "EXP-RC2-CBC-MD5",
-                CipherSuite.SSL_CK_IDEA_128_CBC_WITH_MD5:"IDEA-CBC-MD5",
-                CipherSuite.SSL_CK_DES_64_CBC_WITH_MD5:"DES-CBC-MD5"
-                }.items():
+            CipherSuite.SSL_CK_RC4_128_WITH_MD5: "RC4-MD5",
+            CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5: "EXP-RC4-MD5",
+            CipherSuite.SSL_CK_RC2_128_CBC_WITH_MD5: "RC2-CBC-MD5",
+            CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5:
+                "EXP-RC2-CBC-MD5",
+            CipherSuite.SSL_CK_IDEA_128_CBC_WITH_MD5: "IDEA-CBC-MD5",
+            CipherSuite.SSL_CK_DES_64_CBC_WITH_MD5: "DES-CBC-MD5"
+        }.items():
             # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
             conversation = Connect(host, port, version=(0, 2))
             node = conversation
@@ -135,7 +137,7 @@ def main():
             node.add_child(ExpectClose())
 
             conversations["Connect with {1} {0}"
-                          .format(cipher_name, proto_name)] = conversation
+                .format(cipher_name, proto_name)] = conversation
 
     good = 0
     bad = 0
@@ -172,22 +174,22 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
         else:
             if res:
-                good+=1
+                good += 1
                 print("OK\n")
             else:
-                bad+=1
-    
+                bad += 1
+
     print("Note: SSLv2 was officially deprecated (MUST NOT use) in 2011, see")
     print("      RFC 6176.")
     print("      If one or more of the tests fails because of error in form of")
@@ -212,7 +214,7 @@ def main():
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -221,6 +223,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-sslv2-force-cipher.py
+++ b/scripts/test-sslv2-force-cipher.py
@@ -10,15 +10,16 @@ import getopt
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientMasterKeyGenerator
+    ClientMasterKeyGenerator
 from tlsfuzzer.expect import ExpectAlert, ExpectClose, ExpectServerHello2, \
-        ExpectSSL2Alert
+    ExpectSSL2Alert
 
 from tlslite.constants import CipherSuite, AlertLevel, \
-        ExtensionType, SSL2ErrorDescription
+    ExtensionType, SSL2ErrorDescription
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     """Print usage information"""
@@ -36,6 +37,7 @@ def help_msg():
     print("                execution of preceding expected failure probe")
     print("                usage: [-x probe-name] [-X exception], order is compulsory!")
     print(" --help        this message")
+
 
 def main():
     """Test if the server supports some of the SSLv2 ciphers"""
@@ -76,20 +78,20 @@ def main():
         raise ValueError("Unknown options: {0}".format(argv))
 
     for prot_vers, proto_name in {
-            (0, 2):"SSLv2",
-            (3, 0):"SSLv3",
-            (3, 1):"TLSv1.0"
-            }.items():
+        (0, 2): "SSLv2",
+        (3, 0): "SSLv3",
+        (3, 1): "TLSv1.0"
+    }.items():
         for cipher_id, cipher_name in {
-                CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5:"DES-CBC3-MD5",
-                CipherSuite.SSL_CK_RC4_128_WITH_MD5:"RC4-MD5",
-                CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5:"EXP-RC4-MD5",
-                CipherSuite.SSL_CK_RC2_128_CBC_WITH_MD5:"RC2-CBC-MD5",
-                CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5:
-                    "EXP-RC2-CBC-MD5",
-                CipherSuite.SSL_CK_IDEA_128_CBC_WITH_MD5:"IDEA-CBC-MD5",
-                CipherSuite.SSL_CK_DES_64_CBC_WITH_MD5:"DES-CBC-MD5"
-                }.items():
+            CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5: "DES-CBC3-MD5",
+            CipherSuite.SSL_CK_RC4_128_WITH_MD5: "RC4-MD5",
+            CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5: "EXP-RC4-MD5",
+            CipherSuite.SSL_CK_RC2_128_CBC_WITH_MD5: "RC2-CBC-MD5",
+            CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5:
+                "EXP-RC2-CBC-MD5",
+            CipherSuite.SSL_CK_IDEA_128_CBC_WITH_MD5: "IDEA-CBC-MD5",
+            CipherSuite.SSL_CK_DES_64_CBC_WITH_MD5: "DES-CBC-MD5"
+        }.items():
             # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
             conversation = Connect(host, port, version=(0, 2))
             node = conversation
@@ -127,7 +129,7 @@ def main():
             node.add_child(ExpectClose())
 
             conversations["Connect with {1} {0}"
-                          .format(cipher_name, proto_name)] = conversation
+                .format(cipher_name, proto_name)] = conversation
 
     good = 0
     bad = 0
@@ -164,22 +166,22 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
         else:
             if res:
-                good+=1
+                good += 1
                 print("OK\n")
             else:
-                bad+=1
-    
+                bad += 1
+
     print("Note: SSLv2 was officially deprecated (MUST NOT use) in 2011, see")
     print("      RFC 6176.")
     print("      If one or more of the tests fails because of error in form of")
@@ -208,7 +210,7 @@ def main():
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -217,6 +219,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-sslv2-force-export-cipher.py
+++ b/scripts/test-sslv2-force-export-cipher.py
@@ -10,19 +10,20 @@ import getopt
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ClientMasterKeyGenerator
+    ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ClientMasterKeyGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, \
-        ExpectAlert, ExpectClose, ExpectApplicationData, ExpectServerHello2, \
-        ExpectVerify, ExpectSSL2Alert
+    ExpectServerHelloDone, ExpectChangeCipherSpec, \
+    ExpectAlert, ExpectClose, ExpectApplicationData, ExpectServerHello2, \
+    ExpectVerify, ExpectSSL2Alert
 
 from tlslite.constants import CipherSuite, AlertLevel, \
-        ExtensionType, SSL2ErrorDescription
+    ExtensionType, SSL2ErrorDescription
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     """Usage information"""
@@ -40,6 +41,7 @@ def help_msg():
     print("                execution of preceding expected failure probe")
     print("                usage: [-x probe-name] [-X exception], order is compulsory!")
     print(" --help        this message")
+
 
 def main():
     """Test if the server supports export grade SSLv2 ciphers"""
@@ -80,15 +82,15 @@ def main():
         raise ValueError("Unknown options: {0}".format(argv))
 
     for prot_vers, proto_name in {
-            (0, 2):"SSLv2",
-            (3, 0):"SSLv3",
-            (3, 1):"TLSv1.0"
-            }.items():
+        (0, 2): "SSLv2",
+        (3, 0): "SSLv3",
+        (3, 1): "TLSv1.0"
+    }.items():
         for cipher_id, cipher_name in {
-                CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5:"EXP-RC4-MD5",
-                CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5:
-                    "EXP-RC2-CBC-MD5"
-                }.items():
+            CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5: "EXP-RC4-MD5",
+            CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5:
+                "EXP-RC2-CBC-MD5"
+        }.items():
             # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
             conversation = Connect(host, port, version=(0, 2))
             node = conversation
@@ -126,7 +128,7 @@ def main():
             node.add_child(ExpectClose())
 
             conversations["Connect with {1} {0}"
-                          .format(cipher_name, proto_name)] = conversation
+                .format(cipher_name, proto_name)] = conversation
 
     good = 0
     bad = 0
@@ -163,22 +165,22 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
         else:
             if res:
-                good+=1
+                good += 1
                 print("OK\n")
             else:
-                bad+=1
-    
+                bad += 1
+
     print("Note: SSLv2 was officially deprecated (MUST NOT use) in 2011, see")
     print("      RFC 6176.")
     print("      If one or more of the tests fails because of error in form of")
@@ -203,7 +205,7 @@ def main():
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -212,6 +214,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-sslv2hello-protocol.py
+++ b/scripts/test-sslv2hello-protocol.py
@@ -10,20 +10,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        RawMessageGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    RawMessageGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData, \
+    ExpectServerKeyExchange
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, ContentType, GroupName
+    ExtensionType, ContentType, GroupName
 from tlslite.extensions import SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL
-
 
 version = 6
 
@@ -108,7 +107,7 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
@@ -125,11 +124,11 @@ def main():
         # any unassigned ciphers are ok, they just work as padding
         # we use them to set the length byte of the cipher list in SSLv2 to
         # value that will cause the packet to be rejected when parsed as SSLv3
-        ciphers += [0x0a00 + i for i in range(1, 1+256-len(ciphers))]
+        ciphers += [0x0a00 + i for i in range(1, 1 + 256 - len(ciphers))]
         # here we are verifying just that the server will not fall over when it
         # receives them
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-    ext={ExtensionType.renegotiation_info:None}
+    ext = {ExtensionType.renegotiation_info: None}
     node = node.add_child(ExpectServerHello(extensions=ext))
     node = node.add_child(ExpectCertificate())
     if dhe:
@@ -169,14 +168,14 @@ def main():
         # SSLv2 CH with a list of ciphers that has length divisible by 256
         # (as cipher IDs in SSLv2 are 3 byte long, 256*3 is the smallest common
         # multiple of 3 and 256)
-        ciphers += [0x0a00 + i for i in range(1, 1+256-len(ciphers))]
+        ciphers += [0x0a00 + i for i in range(1, 1 + 256 - len(ciphers))]
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                ssl2=True))
     if no_ssl2:
         node = node.add_child(ExpectAlert())
         node.add_child(ExpectClose())
     else:
-        ext={ExtensionType.renegotiation_info:None}
+        ext = {ExtensionType.renegotiation_info: None}
         node = node.add_child(ExpectServerHello(extensions=ext))
         node = node.add_child(ExpectCertificate())
         if dhe:
@@ -213,7 +212,7 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     if no_ssl2:
-        ciphers += [0x0a00 + i for i in range(1, 1+256-len(ciphers))]
+        ciphers += [0x0a00 + i for i in range(1, 1 + 256 - len(ciphers))]
         # we depend on alignment of the SSLv2 CH ciphers length and session id
         # length with the SSLv3 CH handshake protocol length value
         # so for the same kind of test, we need to send 0 bytes as the 7th to
@@ -224,14 +223,14 @@ def main():
         # and first byte of length - we thus need to send something that is
         # multiple of 256
         data = bytearray(b'\x04' +  # will be interpreted as second byte of
-                                    # SSLv3 RecordLayer header
+                         # SSLv3 RecordLayer header
                          b'\x01' +  # will be interpreted as handshake protocol
-                                    # message type - client_hello
-                         b'\x00' * 3 + # length of handshake message - 0 bytes
-                                    # (invalid)
-                         b'\xff' * (256-5) # padding needed to bring SSLv2
-                                    # record length to be multiple of 256
-                        )
+                         # message type - client_hello
+                         b'\x00' * 3 +  # length of handshake message - 0 bytes
+                         # (invalid)
+                         b'\xff' * (256 - 5)  # padding needed to bring SSLv2
+                         # record length to be multiple of 256
+                         )
         assert len(data) % 256 == 0
         node = node.add_child(RawMessageGenerator(0, data))
     else:
@@ -259,7 +258,7 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     if no_ssl2:
-        ciphers += [0x0a00 + i for i in range(1, 1+256-len(ciphers))]
+        ciphers += [0x0a00 + i for i in range(1, 1 + 256 - len(ciphers))]
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                ssl2=True))
     node = node.add_child(ExpectAlert())
@@ -281,7 +280,7 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     if no_ssl2:
-        ciphers += [0x0a00 + i for i in range(1, 1+256-len(ciphers))]
+        ciphers += [0x0a00 + i for i in range(1, 1 + 256 - len(ciphers))]
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                ssl2=True))
     node = node.add_child(ExpectAlert())
@@ -303,7 +302,7 @@ def main():
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     if no_ssl2:
-        ciphers += [0x0a00 + i for i in range(1, 1+256-len(ciphers))]
+        ciphers += [0x0a00 + i for i in range(1, 1 + 256 - len(ciphers))]
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                ssl2=True))
     node = node.add_child(ExpectAlert())
@@ -312,7 +311,6 @@ def main():
     node = node.add_child(ExpectClose())
 
     conversations["Just version in SSLv2 hello"] = conversation
-
 
     # run the conversations
     good = 0
@@ -331,7 +329,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -361,12 +359,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -389,14 +387,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -405,6 +403,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-0rtt-garbage.py
+++ b/scripts/test-tls13-0rtt-garbage.py
@@ -10,32 +10,31 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        SetRecordVersion, TCPBufferingEnable, TCPBufferingDisable, \
-        TCPBufferingFlush, ch_cookie_handler, split_message, \
-        PlaintextMessageGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    SetRecordVersion, TCPBufferingEnable, TCPBufferingDisable, \
+    TCPBufferingFlush, ch_cookie_handler, split_message, \
+    PlaintextMessageGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, ExpectHelloRetryRequest, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectHelloRetryRequest, \
+    ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
-        PskKeyExchangeMode, ContentType
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    PskKeyExchangeMode, ContentType
 from tlslite.utils.cryptomath import getRandomNumber, getRandomBytes
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, PskKeyExchangeModesExtension, \
-        PreSharedKeyExtension, PskIdentity, TLSExtension, \
-        SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, PskKeyExchangeModesExtension, \
+    PreSharedKeyExtension, PskIdentity, TLSExtension, \
+    SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
 from tlsfuzzer.utils.ordered_dict import OrderedDict
-
 
 version = 4
 
@@ -71,13 +70,13 @@ def main():
     run_exclude = set()
     expected_failures = {}
     last_exp_tmp = None
-    num_bytes = 2**14
+    num_bytes = 2 ** 14
     cookie = False
     dhe = False
 
     argv = sys.argv[1:]
     opts, args = getopt.getopt(argv, "h:p:e:x:X:n:d", ["help", "num-bytes=",
-                                                  "cookie"])
+                                                       "cookie"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -124,15 +123,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -152,7 +151,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -169,17 +168,17 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     iden = PskIdentity().create(getRandomBytes(320), 0)
     bind = getRandomBytes(32)
@@ -203,7 +202,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -216,24 +215,24 @@ def main():
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ext = OrderedDict()
     groups = [0x1300, GroupName.secp256r1]
-    key_shares = [KeyShareEntry().create(0x1300, bytearray(b'\xab'*32))]
+    key_shares = [KeyShareEntry().create(0x1300, bytearray(b'\xab' * 32))]
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.early_data] = \
         TLSExtension(extType=ExtensionType.early_data)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     iden = PskIdentity().create(getRandomBytes(320),
-                                getRandomNumber(2**30, 2**32))
+                                getRandomNumber(2 ** 30, 2 ** 32))
     bind = getRandomBytes(32)
     ext[ExtensionType.pre_shared_key] = PreSharedKeyExtension().create(
         [iden], [bind])
@@ -257,17 +256,17 @@ def main():
     for group in [GroupName.secp256r1]:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     if cookie:
         ext[ExtensionType.cookie] = ch_cookie_handler
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     ext[ExtensionType.pre_shared_key] = PreSharedKeyExtension().create(
         [iden], [getRandomBytes(32)])
@@ -291,7 +290,7 @@ def main():
     node.next_sibling = ExpectAlert(AlertLevel.fatal,
                                     AlertDescription.bad_record_mac)
     node.next_sibling.add_child(ExpectClose())
-    conversations["handshake with 0-RTT, HRR and early data after 2nd Client Hello"]\
+    conversations["handshake with 0-RTT, HRR and early data after 2nd Client Hello"] \
         = conversation
 
     # fake 0-RTT resumption with HRR
@@ -301,24 +300,24 @@ def main():
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ext = OrderedDict()
     groups = [0x1300, GroupName.secp256r1]
-    key_shares = [KeyShareEntry().create(0x1300, bytearray(b'\xab'*32))]
+    key_shares = [KeyShareEntry().create(0x1300, bytearray(b'\xab' * 32))]
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.early_data] = \
         TLSExtension(extType=ExtensionType.early_data)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     iden = PskIdentity().create(getRandomBytes(320),
-                                getRandomNumber(2**30, 2**32))
+                                getRandomNumber(2 ** 30, 2 ** 32))
     bind = getRandomBytes(32)
     ext[ExtensionType.pre_shared_key] = PreSharedKeyExtension().create(
         [iden], [bind])
@@ -342,17 +341,17 @@ def main():
     for group in [GroupName.secp256r1]:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     if cookie:
         ext[ExtensionType.cookie] = ch_cookie_handler
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     ext[ExtensionType.pre_shared_key] = PreSharedKeyExtension().create(
         [iden], [getRandomBytes(32)])
@@ -375,7 +374,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -392,22 +391,22 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.early_data] = \
         TLSExtension(extType=ExtensionType.early_data)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     iden = PskIdentity().create(getRandomBytes(320),
-                                getRandomNumber(2**30, 2**32))
+                                getRandomNumber(2 ** 30, 2 ** 32))
     bind = getRandomBytes(32)
     ext[ExtensionType.pre_shared_key] = PreSharedKeyExtension().create(
         [iden], [bind])
@@ -437,11 +436,11 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
-    conversations["handshake with invalid 0-RTT with fragmented early data"]\
+    conversations["handshake with invalid 0-RTT with fragmented early data"] \
         = conversation
 
     # fake 0-RTT and early data spliced into the Finished message
@@ -455,22 +454,22 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.early_data] = \
         TLSExtension(extType=ExtensionType.early_data)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     iden = PskIdentity().create(getRandomBytes(320),
-                                getRandomNumber(2**30, 2**32))
+                                getRandomNumber(2 ** 30, 2 ** 32))
     bind = getRandomBytes(32)
     ext[ExtensionType.pre_shared_key] = PreSharedKeyExtension().create(
         [iden], [bind])
@@ -504,7 +503,7 @@ def main():
                                     AlertDescription.bad_record_mac)
 
     node.next_sibling.add_child(ExpectClose())
-    conversations["undecryptable record later in handshake together with early_data"]\
+    conversations["undecryptable record later in handshake together with early_data"] \
         = conversation
 
     # fake 0-RTT resumption and CCS between fake early data
@@ -518,22 +517,22 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.early_data] = \
         TLSExtension(extType=ExtensionType.early_data)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     iden = PskIdentity().create(getRandomBytes(320),
-                                getRandomNumber(2**30, 2**32))
+                                getRandomNumber(2 ** 30, 2 ** 32))
     bind = getRandomBytes(32)
     ext[ExtensionType.pre_shared_key] = PreSharedKeyExtension().create(
         [iden], [bind])
@@ -541,10 +540,10 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(SetRecordVersion((3, 3)))
     node = node.add_child(
-        ApplicationDataGenerator(getRandomBytes(num_bytes//2)))
+        ApplicationDataGenerator(getRandomBytes(num_bytes // 2)))
     node = node.add_child(ChangeCipherSpecGenerator(fake=True))
     node = node.add_child(
-        ApplicationDataGenerator(getRandomBytes(num_bytes//2)))
+        ApplicationDataGenerator(getRandomBytes(num_bytes // 2)))
     node = node.add_child(TCPBufferingDisable())
     node = node.add_child(TCPBufferingFlush())
     node = node.add_child(ExpectServerHello())
@@ -564,11 +563,11 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
-    conversations["handshake with invalid 0-RTT and CCS between early data records"]\
+    conversations["handshake with invalid 0-RTT and CCS between early data records"] \
         = conversation
 
     # fake 0-RTT resumption and CCS
@@ -582,22 +581,22 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.early_data] = \
         TLSExtension(extType=ExtensionType.early_data)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     iden = PskIdentity().create(getRandomBytes(320),
-                                getRandomNumber(2**30, 2**32))
+                                getRandomNumber(2 ** 30, 2 ** 32))
     bind = getRandomBytes(32)
     ext[ExtensionType.pre_shared_key] = PreSharedKeyExtension().create(
         [iden], [bind])
@@ -625,7 +624,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -650,22 +649,22 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([(3, 5), (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.early_data] = \
         TLSExtension(extType=ExtensionType.early_data)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     iden = PskIdentity().create(getRandomBytes(320),
-                                getRandomNumber(2**30, 2**32))
+                                getRandomNumber(2 ** 30, 2 ** 32))
     bind = getRandomBytes(32)
     ext[ExtensionType.pre_shared_key] = PreSharedKeyExtension().create(
         [iden], [bind])
@@ -700,22 +699,22 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.early_data] = \
         TLSExtension(extType=ExtensionType.early_data)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     iden = PskIdentity().create(getRandomBytes(320),
-                                getRandomNumber(2**30, 2**32))
+                                getRandomNumber(2 ** 30, 2 ** 32))
     bind = getRandomBytes(32)
     ext[ExtensionType.pre_shared_key] = PreSharedKeyExtension().create(
         [iden], [bind])
@@ -742,12 +741,11 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["handshake with invalid 0-RTT"] = conversation
-
 
     # run the conversation
     good = 0
@@ -766,7 +764,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -796,12 +794,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -821,14 +819,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -837,6 +835,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-ccs.py
+++ b/scripts/test-tls13-ccs.py
@@ -10,23 +10,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
-
 
 version = 3
 
@@ -100,15 +99,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -128,7 +127,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -144,15 +143,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -192,7 +191,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -222,12 +221,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -247,14 +246,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -263,6 +262,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-certificate-request.py
+++ b/scripts/test-tls13-certificate-request.py
@@ -12,29 +12,28 @@ from itertools import chain
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData, ExpectEncryptedExtensions, \
-        ExpectCertificateVerify, ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData, ExpectEncryptedExtensions, \
+    ExpectCertificateVerify, ExpectNewSessionTicket
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import key_share_gen, sig_algs_to_ids, RSA_SIG_ALL, \
-        expected_ext_parser, dict_update_non_present
+    expected_ext_parser, dict_update_non_present
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        StatusRequestExtension
+    SignatureAlgorithmsCertExtension, ClientKeyShareExtension, \
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    StatusRequestExtension
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, SignatureScheme, \
-        GroupName
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, SignatureScheme, \
+    GroupName
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
-
 
 version = 7
 
@@ -192,7 +191,7 @@ def main():
     node = node.add_child(CertificateGenerator())
     node = node.add_child(FinishedGenerator())
     node = node.add_child(ApplicationDataGenerator(
-    bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
 
     # This message is optional and may show up 0 to many times
     cycle = ExpectNewSessionTicket()
@@ -201,7 +200,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -245,7 +244,7 @@ def main():
         node = node.add_child(CertificateVerifyGenerator(private_key))
         node = node.add_child(FinishedGenerator())
         node = node.add_child(ApplicationDataGenerator(
-        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+            bytearray(b"GET / HTTP/1.0\r\n\r\n")))
         # This message is optional and may show up 0 to many times
         cycle = ExpectNewSessionTicket()
         node = node.add_child(cycle)
@@ -253,7 +252,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                           AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -296,14 +295,14 @@ def main():
     node = node.add_child(CertificateGenerator())
     node = node.add_child(FinishedGenerator())
     node = node.add_child(ApplicationDataGenerator(
-    bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
     # This message is optional and may show up 0 to many times
     cycle = ExpectNewSessionTicket()
     node = node.add_child(cycle)
     node.add_child(cycle)
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
 
@@ -338,7 +337,7 @@ def main():
     node = node.add_child(ExpectChangeCipherSpec())
     node = node.add_child(ExpectEncryptedExtensions())
     ext = {ExtensionType.signature_algorithms:
-           SignatureAlgorithmsExtension().create(sigalgs)}
+               SignatureAlgorithmsExtension().create(sigalgs)}
     ext = dict_update_non_present(ext, ext_spec['CR'])
     node = node.add_child(ExpectCertificateRequest(extensions=ext))
     node = node.add_child(ExpectCertificate())
@@ -347,14 +346,14 @@ def main():
     node = node.add_child(CertificateGenerator())
     node = node.add_child(FinishedGenerator())
     node = node.add_child(ApplicationDataGenerator(
-    bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
     # This message is optional and may show up 0 to many times
     cycle = ExpectNewSessionTicket()
     node = node.add_child(cycle)
     node.add_child(cycle)
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
 
@@ -377,7 +376,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -407,12 +406,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -432,14 +431,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -448,6 +447,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-certificate-verify.py
+++ b/scripts/test-tls13-certificate-verify.py
@@ -12,29 +12,28 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData, ExpectEncryptedExtensions, \
-        ExpectCertificateVerify, ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData, ExpectEncryptedExtensions, \
+    ExpectCertificateVerify, ExpectNewSessionTicket
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import key_share_ext_gen, sig_algs_to_ids, RSA_SIG_ALL
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension
+    SignatureAlgorithmsCertExtension, ClientKeyShareExtension, \
+    SupportedVersionsExtension, SupportedGroupsExtension
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, SignatureScheme, \
-        GroupName
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, SignatureScheme, \
+    GroupName
 from tlslite.utils import tlshashlib
 from tlslite.utils.cryptomath import numBytes
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
-
 
 version = 6
 
@@ -111,7 +110,7 @@ def sigalg_select(alg_type, hash_pref, supported=None, cert_type=None):
     raise ValueError(
         "Couldn't find a supported Signature Algorithm that  matches the" +
         " provided parameters: {0}, {1}, {3}".format(alg_type, hash_pref,
-                                                    cert_type))
+                                                     cert_type))
 
 
 def main():
@@ -231,7 +230,7 @@ def main():
     node = node.add_child(CertificateVerifyGenerator(private_key))
     node = node.add_child(FinishedGenerator())
     node = node.add_child(ApplicationDataGenerator(
-    bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
     # This message is optional and may show up 0 to many times
     cycle = ExpectNewSessionTicket()
     node = node.add_child(cycle)
@@ -239,7 +238,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -272,14 +271,14 @@ def main():
     node = node.add_child(CertificateGenerator())
     node = node.add_child(FinishedGenerator())
     node = node.add_child(ApplicationDataGenerator(
-    bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
     # This message is optional and may show up 0 to many times
     cycle = ExpectNewSessionTicket()
     node = node.add_child(cycle)
     node.add_child(cycle)
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
 
@@ -290,14 +289,14 @@ def main():
         # advertisement and forbidden algorithms
         expectPass = True
         if certType == "rsa" and sigalg in (
-            SignatureScheme.rsa_pss_pss_sha256,
-            SignatureScheme.rsa_pss_pss_sha384,
-            SignatureScheme.rsa_pss_pss_sha512):
+                SignatureScheme.rsa_pss_pss_sha256,
+                SignatureScheme.rsa_pss_pss_sha384,
+                SignatureScheme.rsa_pss_pss_sha512):
             expectPass = False
         elif certType == "rsa-pss" and sigalg in (
-            SignatureScheme.rsa_pss_rsae_sha256,
-            SignatureScheme.rsa_pss_rsae_sha384,
-            SignatureScheme.rsa_pss_rsae_sha512):
+                SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_rsae_sha384,
+                SignatureScheme.rsa_pss_rsae_sha512):
             expectPass = False
         # also verify that pkcs1 signatures are unconditionally refused
         if sigalg in ((HashAlgorithm.md5, SignatureAlgorithm.rsa),
@@ -337,14 +336,14 @@ def main():
         node = node.add_child(CertificateGenerator(X509CertChain([cert])))
         # force sigalg
         node = node.add_child(CertificateVerifyGenerator(private_key, msg_alg=
-            sigalg))
+        sigalg))
         node = node.add_child(FinishedGenerator())
 
         result = "works"
         # only signatures of matching certificate type should work
         if expectPass:
             node = node.add_child(ApplicationDataGenerator(
-            bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+                bytearray(b"GET / HTTP/1.0\r\n\r\n")))
             # This message is optional and may show up 0 to many times
             cycle = ExpectNewSessionTicket()
             node = node.add_child(cycle)
@@ -365,7 +364,7 @@ def main():
             result = "is refused"
 
         conversations["check {0} signature {1}".format(
-                      SignatureScheme.toStr(sigalg), result)] = conversation
+            SignatureScheme.toStr(sigalg), result)] = conversation
 
     # verify that rsa-pss signatures with empty, too short or too long
     # salt fail
@@ -406,7 +405,7 @@ def main():
         node.add_child(ExpectClose())
 
         conversations["check signature with salt length {0}".format(
-                      saltlen)] = conversation
+            saltlen)] = conversation
 
     # verify that a rsa-pkcs1 signature in a rsa-pss ID envelope fails
     sigalg = sigalg_select("rsa_pkcs1", hashalgs)
@@ -559,7 +558,7 @@ def main():
             node = node.add_child(ExpectFinished())
             node = node.add_child(CertificateGenerator(X509CertChain([cert])))
             node = node.add_child(CertificateVerifyGenerator(
-                private_key, padding_xors={pos:xor}))
+                private_key, padding_xors={pos: xor}))
             node = node.add_child(FinishedGenerator())
             node = node.add_child(ExpectAlert(
                 AlertLevel.fatal, AlertDescription.decrypt_error))
@@ -568,8 +567,7 @@ def main():
             scheme = SignatureScheme.toRepr(sigalg)
             conversations_long["check that fuzzed signatures are rejected." +
                                " Malformed {0} - xor {1} at {2}".format(
-                               certType, hex(xor), pos)] = conversation
-
+                                   certType, hex(xor), pos)] = conversation
 
     # run the conversation
     good = 0
@@ -587,14 +585,14 @@ def main():
     sanity_tests = [('sanity', conversations['sanity'])]
     if run_only:
         short_tests = [(k, v) for k, v in conversations.items() if
-                        (k != 'sanity') and k in run_only]
+                       (k != 'sanity') and k in run_only]
         long_tests = [(k, v) for k, v in conversations_long.items() if
-                        k in run_only]
+                      k in run_only]
     else:
         short_tests = [(k, v) for k, v in conversations.items() if
-                         (k != 'sanity') and k not in run_exclude]
+                       (k != 'sanity') and k not in run_exclude]
         long_tests = [(k, v) for k, v in conversations_long.items() if
-                        k not in run_exclude]
+                      k not in run_exclude]
     sampled_tests = sample(long_tests, min(num_limit, len(long_tests)))
     ordered_tests = chain(sanity_tests, short_tests, sampled_tests, sanity_tests)
 
@@ -621,12 +619,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -647,14 +645,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + len(short_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + len(short_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -663,6 +661,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-conversation.py
+++ b/scripts/test-tls13-conversation.py
@@ -10,23 +10,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, SIG_ALL
-
 
 version = 4
 
@@ -100,16 +99,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -129,7 +128,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -179,12 +178,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -204,14 +203,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -220,6 +219,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-count-tickets.py
+++ b/scripts/test-tls13-count-tickets.py
@@ -10,23 +10,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
-
 
 version = 3
 
@@ -104,15 +103,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -132,12 +131,11 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["sanity"] = conversation
-
 
     # specific number of NewSessionTickets
     conversation = Connect(host, port)
@@ -150,15 +148,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -199,7 +197,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -229,12 +227,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -255,14 +253,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -271,6 +269,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-crfg-curves.py
+++ b/scripts/test-tls13-crfg-curves.py
@@ -10,28 +10,27 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        TCPBufferingEnable, TCPBufferingFlush, TCPBufferingDisable
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    TCPBufferingEnable, TCPBufferingFlush, TCPBufferingDisable
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
-        ECPointFormat
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    ECPointFormat
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
-        ECPointFormatsExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+    ECPointFormatsExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
 from tlslite.utils.x25519 import X25519_ORDER_SIZE, X448_ORDER_SIZE
 from tlslite.utils.cryptomath import numberToByteArray
-
 
 version = 3
 
@@ -105,15 +104,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -133,7 +132,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -152,7 +151,7 @@ def main():
             conversation = Connect(host, port)
             node = conversation
             ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                       CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
             ext = {}
             ext[ExtensionType.ec_point_formats] = ECPointFormatsExtension().create([compression_format])
             groups = [test_group]
@@ -160,15 +159,15 @@ def main():
             for group in groups:
                 key_shares.append(key_share_gen(group))
             ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-            ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
                 .create([TLS_1_3_DRAFT, (3, 3)])
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                         SignatureScheme.rsa_pss_pss_sha256]
-            ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+            ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
                 .create(sig_algs)
-            ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+            ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
                 .create(RSA_SIG_ALL)
             node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
             node = node.add_child(ExpectServerHello())
@@ -188,7 +187,7 @@ def main():
 
             node.next_sibling = ExpectApplicationData()
             node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                            AlertDescription.close_notify))
+                                                              AlertDescription.close_notify))
 
             node = node.add_child(ExpectAlert())
             node.next_sibling = ExpectClose()
@@ -204,18 +203,18 @@ def main():
         ext = {}
         groups = [test_group]
 
-        key_shares = [KeyShareEntry().create(test_group,  bytearray(group_size))]
+        key_shares = [KeyShareEntry().create(test_group, bytearray(group_size))]
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
 
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -233,18 +232,18 @@ def main():
         groups = [test_group]
 
         key_shares = [KeyShareEntry().create(test_group,
-            numberToByteArray(1, group_size, "little"))]
+                                             numberToByteArray(1, group_size, "little"))]
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
 
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -264,15 +263,15 @@ def main():
         key_shares = [KeyShareEntry().create(test_group, bytearray([55] * (group_size - 1)))]
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
 
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -292,15 +291,15 @@ def main():
         key_shares = [KeyShareEntry().create(test_group, bytearray())]
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
 
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -320,15 +319,15 @@ def main():
         key_shares = [KeyShareEntry().create(test_group, bytearray([55] * (group_size + 1)))]
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
 
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -353,7 +352,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -383,12 +382,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -407,14 +406,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -423,6 +422,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-dhe-shared-secret-padding.py
+++ b/scripts/test-tls13-dhe-shared-secret-padding.py
@@ -10,25 +10,23 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        CopyVariables
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    CopyVariables
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import RSA_SIG_ALL, key_share_ext_gen
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.extensions import \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
-
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 
 """Script to verify that the DH keys are computed correctly."""
-
 
 version = 5
 
@@ -100,9 +98,9 @@ def main():
     collected_key_shares = []
     variables_check = \
         {'DH shared secret':
-         collected_shared_secrets,
+             collected_shared_secrets,
          'ServerHello.extensions.key_share.key_exchange':
-         collected_key_shares}
+             collected_key_shares}
 
     conversations = {}
 
@@ -113,15 +111,15 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -158,15 +156,15 @@ def main():
         ext = {}
         groups = [group]
         ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -212,7 +210,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -252,12 +250,12 @@ def main():
                     xpassed.append(c_name)
                     print("XPASS-expected failure but test passed\n")
                 else:
-                    if expected_failures[c_name] is not None and  \
-                        expected_failures[c_name] not in str(exception):
-                            bad += 1
-                            failed.append(c_name)
-                            print("Expected error message: {0}\n"
-                                .format(expected_failures[c_name]))
+                    if expected_failures[c_name] is not None and \
+                            expected_failures[c_name] not in str(exception):
+                        bad += 1
+                        failed.append(c_name)
+                        print("Expected error message: {0}\n"
+                              .format(expected_failures[c_name]))
                     else:
                         xfail += 1
                         print("OK-expected failure\n")
@@ -268,13 +266,13 @@ def main():
                     if collected_shared_secrets[-1][:min_zeros] == \
                             bytearray(min_zeros):
                         print("Got shared secret with {0} most significant "
-                                "bytes equal to zero."
-                                .format(min_zeros))
+                              "bytes equal to zero."
+                              .format(min_zeros))
                         break_shared = True
                     # ECDSA key shares have a constant first byte indicating
                     # the point encoding
                     if "secp" in c_name:
-                        if collected_key_shares[-1][:min_zeros+1] == \
+                        if collected_key_shares[-1][:min_zeros + 1] == \
                                 bytearray(b'\x04') + bytearray(min_zeros):
                             print("Got key share with {0} most significant bytes equal"
                                   " to zero.".format(min_zeros))
@@ -304,14 +302,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -320,6 +318,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-ecdhe-curves.py
+++ b/scripts/test-tls13-ecdhe-curves.py
@@ -10,24 +10,23 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, SIG_ALL, key_share_ext_gen, \
-        ECDSA_SIG_TLS1_3_ALL
-
+    ECDSA_SIG_TLS1_3_ALL
 
 version = 3
 
@@ -102,16 +101,16 @@ def main():
               GroupName.x25519,
               GroupName.x448]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
     sig_algs += ECDSA_SIG_TLS1_3_ALL
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -131,7 +130,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -144,13 +143,13 @@ def main():
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = {}
         ext[ExtensionType.key_share] = key_share_ext_gen([group])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -170,7 +169,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                           AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -185,20 +184,20 @@ def main():
         key_share = key_share_gen(group)
         key_share.key_exchange += bytearray(b'\x00')
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - right 0-padded key_share"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         # truncated representation
         conversation = Connect(host, port)
@@ -209,20 +208,20 @@ def main():
         key_share = key_share_gen(group)
         key_share.key_exchange.pop()
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - right-truncated key_share"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         # key share from wrong curve
         conversation = Connect(host, port)
@@ -237,20 +236,20 @@ def main():
             key_share2 = key_share_gen(GroupName.secp256r1)
         key_share.key_exchange = key_share2.key_exchange
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - key share from other curve"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         # 0-point
         conversation = Connect(host, port)
@@ -260,20 +259,20 @@ def main():
         ext = {}
         key_share = KeyShareEntry().create(group, bytearray(b'\x00'))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - point at infinity"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         if group not in (GroupName.x25519, GroupName.x448):
             # points not on curve
@@ -284,19 +283,19 @@ def main():
             ext = {}
             key_share = key_share_gen(group)
             key_share.key_exchange[-1] ^= 0xff
-            ext[ExtensionType.key_share] = ClientKeyShareExtension()\
+            ext[ExtensionType.key_share] = ClientKeyShareExtension() \
                 .create([key_share])
             ext[ExtensionType.supported_versions] = \
-                SupportedVersionsExtension()\
-                .create([TLS_1_3_DRAFT, (3, 3)])
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+                SupportedVersionsExtension() \
+                    .create([TLS_1_3_DRAFT, (3, 3)])
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create([group])
             ext[ExtensionType.signature_algorithms] = \
-                SignatureAlgorithmsExtension()\
-                .create(sig_algs)
+                SignatureAlgorithmsExtension() \
+                    .create(sig_algs)
             ext[ExtensionType.signature_algorithms_cert] = \
-                SignatureAlgorithmsCertExtension()\
-                .create(SIG_ALL)
+                SignatureAlgorithmsCertExtension() \
+                    .create(SIG_ALL)
             node = node.add_child(ClientHelloGenerator(ciphers,
                                                        extensions=ext))
             node = node.add_child(ExpectAlert(
@@ -304,7 +303,7 @@ def main():
                 AlertDescription.illegal_parameter))
             node.add_child(ExpectClose())
             conversations["{0} - point outside curve"
-                          .format(GroupName.toRepr(group))] = conversation
+                .format(GroupName.toRepr(group))] = conversation
 
             # all-zero point
             conversation = Connect(host, port)
@@ -315,19 +314,19 @@ def main():
             key_share = key_share_gen(group)
             key_share.key_exchange = bytearray(len(key_share.key_exchange))
             key_share.key_exchange[0] = 0x04  # SEC1 uncompressed point encoding
-            ext[ExtensionType.key_share] = ClientKeyShareExtension()\
+            ext[ExtensionType.key_share] = ClientKeyShareExtension() \
                 .create([key_share])
             ext[ExtensionType.supported_versions] = \
-                SupportedVersionsExtension()\
-                .create([TLS_1_3_DRAFT, (3, 3)])
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+                SupportedVersionsExtension() \
+                    .create([TLS_1_3_DRAFT, (3, 3)])
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create([group])
             ext[ExtensionType.signature_algorithms] = \
-                SignatureAlgorithmsExtension()\
-                .create(sig_algs)
+                SignatureAlgorithmsExtension() \
+                    .create(sig_algs)
             ext[ExtensionType.signature_algorithms_cert] = \
-                SignatureAlgorithmsCertExtension()\
-                .create(SIG_ALL)
+                SignatureAlgorithmsCertExtension() \
+                    .create(SIG_ALL)
             node = node.add_child(ClientHelloGenerator(ciphers,
                                                        extensions=ext))
             node = node.add_child(ExpectAlert(
@@ -335,7 +334,7 @@ def main():
                 AlertDescription.illegal_parameter))
             node.add_child(ExpectClose())
             conversations["{0} - x=0, y=0"
-                          .format(GroupName.toRepr(group))] = conversation
+                .format(GroupName.toRepr(group))] = conversation
 
     # run the conversation
     good = 0
@@ -354,7 +353,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -384,12 +383,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -410,14 +409,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -426,6 +425,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-ecdsa-in-certificate-verify.py
+++ b/scripts/test-tls13-ecdsa-in-certificate-verify.py
@@ -13,30 +13,29 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        CertificateGenerator, CertificateVerifyGenerator, \
-        AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    CertificateGenerator, CertificateVerifyGenerator, \
+    AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
-        ExpectApplicationData, ExpectEncryptedExtensions, \
-        ExpectCertificateVerify, ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+    ExpectApplicationData, ExpectEncryptedExtensions, \
+    ExpectCertificateVerify, ExpectNewSessionTicket
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import key_share_ext_gen, sig_algs_to_ids, RSA_SIG_ALL,\
-        ECDSA_SIG_ALL
+from tlsfuzzer.helpers import key_share_ext_gen, sig_algs_to_ids, RSA_SIG_ALL, \
+    ECDSA_SIG_ALL
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        SignatureAlgorithmsCertExtension, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension
+    SignatureAlgorithmsCertExtension, ClientKeyShareExtension, \
+    SupportedVersionsExtension, SupportedGroupsExtension
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType, SignatureScheme, \
-        GroupName
+    HashAlgorithm, SignatureAlgorithm, ExtensionType, SignatureScheme, \
+    GroupName
 from tlslite.utils import tlshashlib
 from tlslite.utils.cryptomath import numBytes
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
-
 
 version = 5
 
@@ -115,7 +114,7 @@ def sigalg_select(alg_type, hash_pref, supported=None, cert_type=None):
     raise ValueError(
         "Couldn't find a supported Signature Algorithm that  matches the" +
         " provided parameters: {0}, {1}, {3}".format(alg_type, hash_pref,
-                                                    cert_type))
+                                                     cert_type))
 
 
 def main():
@@ -238,7 +237,7 @@ def main():
     node = node.add_child(CertificateVerifyGenerator(private_key))
     node = node.add_child(FinishedGenerator())
     node = node.add_child(ApplicationDataGenerator(
-    bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
     # This message is optional and may show up 0 to many times
     cycle = ExpectNewSessionTicket()
     node = node.add_child(cycle)
@@ -246,7 +245,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -279,14 +278,14 @@ def main():
     node = node.add_child(CertificateGenerator())
     node = node.add_child(FinishedGenerator())
     node = node.add_child(ApplicationDataGenerator(
-    bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
     # This message is optional and may show up 0 to many times
     cycle = ExpectNewSessionTicket()
     node = node.add_child(cycle)
     node.add_child(cycle)
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
 
@@ -337,14 +336,14 @@ def main():
         node = node.add_child(CertificateGenerator(X509CertChain([cert])))
         # force sigalg
         node = node.add_child(CertificateVerifyGenerator(private_key, msg_alg=
-            sigalg))
+        sigalg))
         node = node.add_child(FinishedGenerator())
 
         result = "works"
         # only signatures of matching certificate type should work
         if expectPass:
             node = node.add_child(ApplicationDataGenerator(
-            bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+                bytearray(b"GET / HTTP/1.0\r\n\r\n")))
             # This message is optional and may show up 0 to many times
             cycle = ExpectNewSessionTicket()
             node = node.add_child(cycle)
@@ -369,7 +368,7 @@ def main():
             name = "{0}+{1}".format(HashAlgorithm.toStr(sigalg[0]),
                                     SignatureAlgorithm.toStr(sigalg[1]))
         conversations["check {0} signature {1}".format(
-                      name, result)] = conversation
+            name, result)] = conversation
 
     # verify that an ECDSA signature with mismatched message hash fails
     if len(private_key) == 256:
@@ -417,7 +416,6 @@ def main():
     conversations["check ecdsa signature with mismatched hash fails"] = \
         conversation
 
-
     # check that fuzzed signatures are rejected
     if len(private_key) == 256:
         # bacause of DER encoding of the signature, the mapping between key size
@@ -458,7 +456,7 @@ def main():
             node = node.add_child(CertificateGenerator(X509CertChain([cert])))
             node = node.add_child(
                 CertificateVerifyGenerator(private_key,
-                                           padding_xors={pos:xor}))
+                                           padding_xors={pos: xor}))
             node = node.add_child(FinishedGenerator())
             node = node.add_child(ExpectAlert(
                 AlertLevel.fatal, AlertDescription.decrypt_error))
@@ -466,7 +464,7 @@ def main():
 
             conversations_long["check that fuzzed signatures are rejected." +
                                " Malformed {0} - xor {1} at {2}".format(
-                               certType, hex(xor), pos)] = conversation
+                                   certType, hex(xor), pos)] = conversation
 
     # run the conversation
     good = 0
@@ -488,9 +486,9 @@ def main():
         short_tests = [(k, v) for k, v in conversations.items() if (k != 'sanity') and k in run_only]
     else:
         long_tests = [(k, v) for k, v in conversations_long.items() if
-                        k not in run_exclude]
+                      k not in run_exclude]
         short_tests = [(k, v) for k, v in conversations.items() if
-                        (k != 'sanity') and k not in run_exclude]
+                       (k != 'sanity') and k not in run_exclude]
     sampled_tests = sample(long_tests, min(num_limit, len(long_tests)))
     ordered_tests = chain(sanity_tests, short_tests, sampled_tests, sanity_tests)
 
@@ -515,12 +513,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -543,14 +541,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + len(short_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + len(short_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -558,6 +556,7 @@ def main():
         print("FAILED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-ecdsa-support.py
+++ b/scripts/test-tls13-ecdsa-support.py
@@ -9,23 +9,22 @@ from itertools import chain, islice
 from random import sample
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
-        HashAlgorithm, SignatureAlgorithm
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    HashAlgorithm, SignatureAlgorithm
 from tlslite.extensions import ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
-
 
 version = 4
 
@@ -99,17 +98,17 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.ecdsa_secp521r1_sha512,
                 SignatureScheme.ecdsa_secp384r1_sha384,
                 SignatureScheme.ecdsa_secp256r1_sha256,
                 (HashAlgorithm.sha1, SignatureAlgorithm.ecdsa)]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(sig_algs + RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -129,7 +128,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -146,13 +145,13 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create([sigalg])
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(sig_algs + RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         if sigalg == (HashAlgorithm.sha1, SignatureAlgorithm.ecdsa):
@@ -178,7 +177,7 @@ def main():
 
             node.next_sibling = ExpectApplicationData()
             node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                               AlertDescription.close_notify))
+                                                              AlertDescription.close_notify))
 
             node = node.add_child(ExpectAlert())
             node.next_sibling = ExpectClose()
@@ -201,7 +200,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -231,12 +230,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -259,14 +258,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -275,6 +274,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-empty-alert.py
+++ b/scripts/test-tls13-empty-alert.py
@@ -11,24 +11,23 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        RawMessageGenerator, SetPaddingCallback
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    RawMessageGenerator, SetPaddingCallback
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, ContentType
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, ContentType
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
-
 
 version = 3
 
@@ -102,15 +101,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -130,7 +129,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -148,15 +147,15 @@ def main():
             for group in groups:
                 key_shares.append(key_share_gen(group))
             ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-            ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
                 .create([TLS_1_3_DRAFT, (3, 3)])
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                         SignatureScheme.rsa_pss_pss_sha256]
-            ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+            ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
                 .create(sig_algs)
-            ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+            ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
                 .create(RSA_SIG_ALL)
             node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
             node = node.add_child(ExpectServerHello())
@@ -169,7 +168,7 @@ def main():
                 node = node.add_child(FinishedGenerator())
             if padsize:
                 node = node.add_child(SetPaddingCallback(
-                                      SetPaddingCallback.fixed_length_cb(padsize)))
+                    SetPaddingCallback.fixed_length_cb(padsize)))
             node = node.add_child(RawMessageGenerator(ContentType.alert, bytearray(0)))
 
             # This message is optional and may show up 0 to many times
@@ -181,10 +180,10 @@ def main():
             node.next_sibling.add_child(ExpectClose())
             if padsize:
                 conversations["empty alert with {0} bytes of padding using {1} keys"
-                              .format(padsize, enc)] = conversation
+                    .format(padsize, enc)] = conversation
             else:
                 conversations["empty alert with no padding using {0} keys"
-                              .format(enc)] = conversation
+                    .format(enc)] = conversation
 
     # run the conversation
     good = 0
@@ -203,7 +202,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -233,12 +232,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -257,14 +256,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -273,6 +272,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-ffdhe-groups.py
+++ b/scripts/test-tls13-ffdhe-groups.py
@@ -10,27 +10,26 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 from tlslite.utils.cryptomath import numberToByteArray
 from tlslite.mathtls import FFDHE2048, FFDHE3072, FFDHE4096, FFDHE6144, \
-        FFDHE8192
+    FFDHE8192
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, SIG_ALL, key_share_ext_gen, \
-        ECDSA_SIG_TLS1_3_ALL
-
+    ECDSA_SIG_TLS1_3_ALL
 
 version = 3
 
@@ -101,16 +100,16 @@ def main():
     ext = {}
     groups = GroupName.allFF
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
     sig_algs += ECDSA_SIG_TLS1_3_ALL
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -130,7 +129,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -143,13 +142,13 @@ def main():
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = {}
         ext[ExtensionType.key_share] = key_share_ext_gen([group])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -169,7 +168,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                           AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -184,22 +183,22 @@ def main():
         key_shares = []
         key_shares.append(key_share_gen(group))
         key_shares.append(key_share_gen(group))
-        ext[ExtensionType.key_share] = ClientKeyShareExtension()\
+        ext[ExtensionType.key_share] = ClientKeyShareExtension() \
             .create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - duplicated key share entry"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         # padded representation
         conversation = Connect(host, port)
@@ -210,20 +209,20 @@ def main():
         key_share = key_share_gen(group)
         key_share.key_exchange += bytearray(b'\x00')
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - right 0-padded key_share"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         # truncated representation (given that all groups use safe primes,
         # any integer between 1 and p-1 is a valid key share, it's just that
@@ -236,20 +235,20 @@ def main():
         key_share = key_share_gen(group)
         key_share.key_exchange.pop()
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - right-truncated key_share"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         # key share from wrong group
         conversation = Connect(host, port)
@@ -264,20 +263,20 @@ def main():
             key_share2 = key_share_gen(GroupName.ffdhe2048)
         key_share.key_exchange = key_share2.key_exchange
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - key share from other group"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         # just 0
         conversation = Connect(host, port)
@@ -287,20 +286,20 @@ def main():
         ext = {}
         key_share = KeyShareEntry().create(group, bytearray(b'\x00'))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - 0 as one byte"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         # 0 key share
         conversation = Connect(host, port)
@@ -311,20 +310,20 @@ def main():
         key_share = key_share_gen(group)
         key_share.key_exchange = bytearray(len(key_share.key_exchange))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - 0 as key share"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         # 1 key share
         conversation = Connect(host, port)
@@ -336,20 +335,20 @@ def main():
         key_share.key_exchange = bytearray(len(key_share.key_exchange))
         key_share.key_exchange[-1] = 0x01
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - 1 as key share"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         # all bits set key share
         conversation = Connect(host, port)
@@ -360,20 +359,20 @@ def main():
         key_share = key_share_gen(group)
         key_share.key_exchange = bytearray([0xff] * len(key_share.key_exchange))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - all bits set key share"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         if group == GroupName.ffdhe2048:
             params = FFDHE2048
@@ -394,22 +393,22 @@ def main():
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = {}
         key_share = KeyShareEntry().create(group,
-                                           numberToByteArray(params[1]-1))
+                                           numberToByteArray(params[1] - 1))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - p-1 as key share"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         # p key share
         conversation = Connect(host, port)
@@ -420,20 +419,20 @@ def main():
         key_share = KeyShareEntry().create(group,
                                            numberToByteArray(params[1]))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - p as key share"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
         # empty key share entry
         conversation = Connect(host, port)
@@ -444,20 +443,20 @@ def main():
         key_share = KeyShareEntry().create(group,
                                            bytearray())
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create([key_share])
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([group])
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.illegal_parameter))
         node.add_child(ExpectClose())
         conversations["{0} - empty key share entry in key_share ext"
-                      .format(GroupName.toRepr(group))] = conversation
+            .format(GroupName.toRepr(group))] = conversation
 
     # run the conversation
     good = 0
@@ -476,7 +475,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -506,12 +505,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -531,14 +530,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -547,6 +546,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-ffdhe-sanity.py
+++ b/scripts/test-tls13-ffdhe-sanity.py
@@ -10,23 +10,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, GroupName
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, GroupName
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, flexible_getattr, RSA_SIG_ALL
-
 
 version = 3
 
@@ -100,15 +99,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -128,7 +127,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -144,15 +143,15 @@ def main():
         key_shares = []
         key_shares.append(key_share_gen(key_share_group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create([key_share_group])
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -172,7 +171,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                           AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -195,7 +194,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -225,12 +224,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -249,14 +248,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -265,6 +264,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-finished-plaintext.py
+++ b/scripts/test-tls13-finished-plaintext.py
@@ -10,24 +10,23 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetWriteConnectionState
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetWriteConnectionState
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
-
 
 version = 3
 
@@ -101,15 +100,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -129,7 +128,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -145,15 +144,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -220,12 +219,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -245,14 +244,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -261,6 +260,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-finished.py
+++ b/scripts/test-tls13-finished.py
@@ -10,24 +10,23 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_message
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_message
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, ExpectNoMessage
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectNoMessage
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import RSA_SIG_ALL, key_share_ext_gen
-
 
 version = 5
 
@@ -99,17 +98,17 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.rsa_pss_rsae_sha384,
                 SignatureScheme.rsa_pss_pss_sha384]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -129,7 +128,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["sanity"] = conversation
@@ -145,17 +144,17 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1]
         ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256,
                     SignatureScheme.rsa_pss_rsae_sha384,
                     SignatureScheme.rsa_pss_pss_sha384]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -178,13 +177,13 @@ def main():
                                         AlertDescription.decode_error)
         node = node.next_sibling.add_child(ExpectClose())
         conversations["empty - cipher %s" \
-                         % (CipherSuite.ietfNames[cipher])] = conversation
+                      % (CipherSuite.ietfNames[cipher])] = conversation
 
     # single bit error
     scenarios = [(CipherSuite.TLS_AES_128_GCM_SHA256, 32),
                  (CipherSuite.TLS_AES_256_GCM_SHA384, 48)]
     for cipher, prf_bytes in scenarios:
-        for mbit in range(8*prf_bytes):
+        for mbit in range(8 * prf_bytes):
             mbyte = mbit // 8 + 1
             conversation = Connect(host, port)
             node = conversation
@@ -193,17 +192,17 @@ def main():
             ext = {}
             groups = [GroupName.secp256r1]
             ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-            ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
                 .create([TLS_1_3_DRAFT, (3, 3)])
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                         SignatureScheme.rsa_pss_pss_sha256,
                         SignatureScheme.rsa_pss_rsae_sha384,
                         SignatureScheme.rsa_pss_pss_sha384]
-            ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+            ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
                 .create(sig_algs)
-            ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+            ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
                 .create(RSA_SIG_ALL)
             node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
             node = node.add_child(ExpectServerHello())
@@ -213,7 +212,7 @@ def main():
             node = node.add_child(ExpectCertificateVerify())
             node = node.add_child(ExpectFinished())
             node = node.add_child(fuzz_message(FinishedGenerator(),
-                                               xors={-mbyte: 0x01 << mbit%8}))
+                                               xors={-mbyte: 0x01 << mbit % 8}))
             # This message may be sent right after server finished
             cycle = ExpectNewSessionTicket()
             node = node.add_child(cycle)
@@ -231,33 +230,33 @@ def main():
     # truncation
     # cipher, start, end
     scenarios = [
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0,  -1),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0,  -2),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0,  -4),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0,  -8),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0,  -16),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0,  -32),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0,  12), # TLS-1.2 size
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 1,  None),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 2,  None),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 4,  None),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 8,  None),
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, -1),
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, -2),
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, -4),
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, -8),
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, -16),
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, -32),
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 12),  # TLS-1.2 size
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 1, None),
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 2, None),
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 4, None),
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 8, None),
         (CipherSuite.TLS_AES_128_GCM_SHA256, 16, None),
         (CipherSuite.TLS_AES_128_GCM_SHA256, 32, None),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0,  -1),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0,  -2),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0,  -4),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0,  -8),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0,  -16), # SHA-256 size
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0,  -32),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0,  12), # TLS-1.2 size
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 1,  None),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 2,  None),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 4,  None),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 8,  None),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 16, None), # SHA-256 size
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, -1),
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, -2),
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, -4),
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, -8),
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, -16),  # SHA-256 size
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, -32),
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 12),  # TLS-1.2 size
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 1, None),
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 2, None),
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 4, None),
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 8, None),
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 16, None),  # SHA-256 size
         (CipherSuite.TLS_AES_256_GCM_SHA384, 32, None)
-        ]
+    ]
     for cipher, start, end in scenarios:
         conversation = Connect(host, port)
         node = conversation
@@ -266,17 +265,17 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1]
         ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256,
                     SignatureScheme.rsa_pss_rsae_sha384,
                     SignatureScheme.rsa_pss_pss_sha384]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -309,47 +308,47 @@ def main():
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 2),
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 4),
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 8),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 16), # SHA-384 size
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 16),  # SHA-384 size
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 32),
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 48),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 2**14-4-32), # max record
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 0x20000), # intermediate
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 0x30000), # bigger than max ClientHello
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 256**3-1-32), # max handshake
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 2 ** 14 - 4 - 32),  # max record
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 0x20000),  # intermediate
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 0x30000),  # bigger than max ClientHello
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 0, 256 ** 3 - 1 - 32),  # max handshake
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 1, 0),
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 2, 0),
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 4, 0),
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 8, 0),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 16, 0), # SHA-384 size
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 16, 0),  # SHA-384 size
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 32, 0),
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 48, 0),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 2**14-4-32, 0), # max record
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 2 ** 14 - 4 - 32, 0),  # max record
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 12, 0),
         (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 1, 1),
-        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 8, 8), # SHA-384 size
+        (CipherSuite.TLS_AES_128_GCM_SHA256, 0, 8, 8),  # SHA-384 size
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 1),
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 2),
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 4),
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 8),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 16), # SHA-512 size
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 16),  # SHA-512 size
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 32),
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 48),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 2**14-4-48), # max record
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 2 ** 14 - 4 - 48),  # max record
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 0x20000),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 0x30000), # bigger than max ClientHello
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 256**3-1-48), # max handshake
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 0x30000),  # bigger than max ClientHello
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 256 ** 3 - 1 - 48),  # max handshake
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 0, 12),
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 1, 0),
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 2, 0),
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 4, 0),
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 8, 0),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 16, 0), # SHA-512 size
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 16, 0),  # SHA-512 size
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 32, 0),
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 48, 0),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 2**14-4-48, 0), # max record
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 2 ** 14 - 4 - 48, 0),  # max record
         (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 1, 1),
-        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 8, 8) # SHA-512 size
-        ]
+        (CipherSuite.TLS_AES_256_GCM_SHA384, 0, 8, 8)  # SHA-512 size
+    ]
     for cipher, pad_byte, pad_left, pad_right in scenarios:
         # longer timeout for longer messages
         # Because the client is sending encrypted data without waiting
@@ -366,7 +365,7 @@ def main():
         # (all graph terminal nodes go through ExpectAlert), server that fails
         # to do that will still cause the whole test conversation to fail in
         # case it just closes the connection on us
-        timeout = 5 if max(pad_left, pad_right) < 2**14 * 4 else 300
+        timeout = 5 if max(pad_left, pad_right) < 2 ** 14 * 4 else 300
         conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [cipher,
@@ -374,17 +373,17 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1]
         ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256,
                     SignatureScheme.rsa_pss_rsae_sha384,
                     SignatureScheme.rsa_pss_pss_sha384]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -414,9 +413,9 @@ def main():
                                  AlertDescription.decode_error)
         close_node.add_child(ExpectClose())
         node = node.add_child(FinishedGenerator(
-                                  pad_byte=pad_byte,
-                                  pad_left=pad_left,
-                                  pad_right=pad_right))
+            pad_byte=pad_byte,
+            pad_left=pad_left,
+            pad_right=pad_right))
         node.next_sibling = close_node
 
         # This message may be sent right after server finished
@@ -479,12 +478,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -502,14 +501,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -518,6 +517,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-hrr.py
+++ b/scripts/test-tls13-hrr.py
@@ -10,25 +10,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ch_cookie_handler
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ch_cookie_handler
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, ExpectHelloRetryRequest
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectHelloRetryRequest
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
-
 
 version = 3
 
@@ -107,15 +106,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -134,7 +133,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -149,15 +148,15 @@ def main():
     groups = [GroupName.secp256r1]
     key_shares = []
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
 
@@ -175,17 +174,17 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     if cookie:
         ext[ExtensionType.cookie] = ch_cookie_handler
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -203,7 +202,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["HRR because of empty key_shares"] = conversation
@@ -225,7 +224,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -255,12 +254,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -281,14 +280,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -297,6 +296,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-invalid-ciphers.py
+++ b/scripts/test-tls13-invalid-ciphers.py
@@ -10,23 +10,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, key_share_ext_gen
-
 
 version = 3
 
@@ -100,15 +99,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -128,7 +127,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -145,15 +144,15 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1]
         ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(cipher=CipherSuite.TLS_AES_128_GCM_SHA256))
@@ -173,7 +172,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                           AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -190,15 +189,15 @@ def main():
         ext = {}
         groups = [GroupName.secp256r1]
         ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -251,12 +250,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -277,14 +276,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -293,6 +292,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-keyshare-omitted.py
+++ b/scripts/test-tls13-keyshare-omitted.py
@@ -10,25 +10,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
-        PskKeyExchangeMode
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    PskKeyExchangeMode
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
-        PskKeyExchangeModesExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+    PskKeyExchangeModesExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, AutoEmptyExtension
-
 
 version = 3
 
@@ -102,15 +101,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -130,7 +129,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -142,15 +141,15 @@ def main():
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ext = {}
     groups = [GroupName.secp256r1]
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(description=AlertDescription.missing_extension))
@@ -164,17 +163,17 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = AutoEmptyExtension()
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_ke, PskKeyExchangeMode.psk_dhe_ke])
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(description=AlertDescription.decode_error))
@@ -188,15 +187,15 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = AutoEmptyExtension()
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(description=AlertDescription.decode_error))
@@ -220,7 +219,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -250,12 +249,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -275,14 +274,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -291,6 +290,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-keyupdate-from-server.py
+++ b/scripts/test-tls13-keyupdate-from-server.py
@@ -10,25 +10,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        KeyUpdateGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    KeyUpdateGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, ExpectKeyUpdate
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectKeyUpdate
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
-        KeyUpdateMessageType, ContentType
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    KeyUpdateMessageType, ContentType
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, key_share_ext_gen
-
 
 version = 3
 
@@ -108,15 +107,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -136,7 +135,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -152,15 +151,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -184,7 +183,7 @@ def main():
         message_type=KeyUpdateMessageType.update_not_requested))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
-                          AlertDescription.close_notify))
+                                         AlertDescription.close_notify))
     node.next_sibling = ExpectAlert(AlertLevel.warning,
                                     AlertDescription.close_notify)
     conversations["post-handshake KeyUpdate msg from server"] = conversation
@@ -206,7 +205,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -236,12 +235,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -261,14 +260,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -277,6 +276,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-keyupdate.py
+++ b/scripts/test-tls13-keyupdate.py
@@ -10,27 +10,26 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        KeyUpdateGenerator, split_message, \
-        FlushMessageList, truncate_handshake, \
-        pad_handshake
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    KeyUpdateGenerator, split_message, \
+    FlushMessageList, truncate_handshake, \
+    pad_handshake
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, ExpectKeyUpdate
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectKeyUpdate
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
-        KeyUpdateMessageType, ContentType
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    KeyUpdateMessageType, ContentType
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, key_share_ext_gen
-
 
 version = 3
 
@@ -110,15 +109,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -138,7 +137,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -154,15 +153,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -186,7 +185,7 @@ def main():
         message_type=KeyUpdateMessageType.update_not_requested)
     node = node.next_sibling.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
-                          AlertDescription.close_notify))
+                                         AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -202,15 +201,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -232,7 +231,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                      AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -248,15 +247,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -291,15 +290,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -328,19 +327,19 @@ def main():
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = {}
         groups = [GroupName.secp256r1]
         ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -374,15 +373,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -408,7 +407,7 @@ def main():
         bytearray(b" / HTTP/1.0\r\n\r\n")))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
-                          AlertDescription.close_notify))
+                                         AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -424,15 +423,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -454,7 +453,6 @@ def main():
     node = node.add_child(cycle)
     node.add_child(cycle)
 
-
     node.next_sibling = ExpectKeyUpdate(
         message_type=KeyUpdateMessageType.update_not_requested)
     node = node.next_sibling
@@ -467,7 +465,7 @@ def main():
 
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
-                          AlertDescription.close_notify))
+                                         AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -483,15 +481,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -518,7 +516,7 @@ def main():
         message_type=KeyUpdateMessageType.update_not_requested)
     node = node.next_sibling.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
-                          AlertDescription.close_notify))
+                                         AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -535,15 +533,15 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -572,7 +570,7 @@ def main():
                                         AlertDescription.unexpected_message)
         node.next_sibling.add_child(ExpectClose())
         conversations["{0}/{1} fragmented keyupdate msg, appdata between"
-                      .format(fragment_len, 5-fragment_len)] = conversation
+            .format(fragment_len, 5 - fragment_len)] = conversation
 
     # run the conversation
     good = 0
@@ -618,12 +616,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -650,7 +648,7 @@ def main():
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -659,6 +657,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-large-number-of-extensions.py
+++ b/scripts/test-tls13-large-number-of-extensions.py
@@ -10,26 +10,25 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
-        TLSExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+    TLSExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, AutoEmptyExtension
 from tlsfuzzer.fuzzers import structured_random_iter
-
 
 version = 4
 
@@ -120,15 +119,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -148,7 +147,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -178,7 +177,7 @@ def main():
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = OrderedDict()
         for ext_id in ext_chunk:
             ext[ext_id] = AutoEmptyExtension()
@@ -190,15 +189,15 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(extensions=expect_exts_sh))
@@ -219,7 +218,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                        AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -233,7 +232,7 @@ def main():
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        random_payload = structured_random_iter(max_length=2**6,
+        random_payload = structured_random_iter(max_length=2 ** 6,
                                                 count=len(ext_chunk))
         ext = OrderedDict()
         for ext_id in ext_chunk:
@@ -246,15 +245,15 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(extensions=expect_exts_sh))
@@ -275,7 +274,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                        AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -287,7 +286,7 @@ def main():
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = OrderedDict()
         if ExtensionType.renegotiation_info in ext:
             ext[ExtensionType.renegotiation_info] = None
@@ -297,15 +296,15 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         ext[ext_id] = AutoEmptyExtension()
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -327,7 +326,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                        AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -348,19 +347,19 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
-        random_payload = structured_random_iter(max_length=2**6,
+        random_payload = structured_random_iter(max_length=2 ** 6,
                                                 count=1)
-        ext[ext_id] = TLSExtension(extType=ext_id)\
+        ext[ext_id] = TLSExtension(extType=ext_id) \
             .create(next(random_payload).data)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello(extensions=expect_exts_sh))
@@ -381,7 +380,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                        AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -432,12 +431,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -457,14 +456,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -473,6 +472,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-legacy-version.py
+++ b/scripts/test-tls13-legacy-version.py
@@ -10,23 +10,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
-
 
 version = 3
 
@@ -100,15 +99,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -128,7 +127,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -146,15 +145,15 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, prot_version])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers,
                                                    extensions=ext,
@@ -180,7 +179,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -210,12 +209,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -235,14 +234,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -251,6 +250,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-multiple-ccs-messages.py
+++ b/scripts/test-tls13-multiple-ccs-messages.py
@@ -10,24 +10,23 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        TCPBufferingFlush, TCPBufferingEnable, TCPBufferingDisable, \
-        RawMessageGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    TCPBufferingFlush, TCPBufferingEnable, TCPBufferingDisable, \
+    RawMessageGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, ExpectNoMessage
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectNoMessage
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, SIG_ALL
-
 
 version = 1
 
@@ -105,16 +104,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -134,7 +133,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -150,16 +149,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ChangeCipherSpecGenerator(fake=True))
@@ -180,7 +179,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -196,16 +195,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ChangeCipherSpecGenerator(fake=True))
@@ -218,7 +217,7 @@ def main():
     node = node.add_child(ChangeCipherSpecGenerator(fake=True))
     node = node.add_child(FinishedGenerator())
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                          AlertDescription.unexpected_message))
+                                      AlertDescription.unexpected_message))
     node = node.add_child(ExpectClose())
     conversations["second CCS before client finished"] = conversation
 
@@ -232,16 +231,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(TCPBufferingEnable())
@@ -256,7 +255,7 @@ def main():
     node = node.add_child(ExpectCertificateVerify())
     node = node.add_child(ExpectFinished())
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                          AlertDescription.unexpected_message))
+                                      AlertDescription.unexpected_message))
     node = node.add_child(ExpectClose())
     conversations["multiple CCS Messages in one TCP packet"] = conversation
 
@@ -270,16 +269,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(TCPBufferingEnable())
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -294,7 +293,7 @@ def main():
     node = node.add_child(ExpectCertificateVerify())
     node = node.add_child(ExpectFinished())
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                          AlertDescription.unexpected_message))
+                                      AlertDescription.unexpected_message))
     node = node.add_child(ExpectClose())
     conversations["CH and multiple CCS Messages in one TCP packet"] = conversation
 
@@ -308,16 +307,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(RawMessageGenerator(20, bytearray(b'\x01' * ccs_num)))
@@ -328,7 +327,7 @@ def main():
     node = node.add_child(ExpectCertificateVerify())
     node = node.add_child(ExpectFinished())
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                          AlertDescription.unexpected_message))
+                                      AlertDescription.unexpected_message))
     node = node.add_child(ExpectClose())
     conversations["multiple CCS Messages in one TLS record"] = conversation
 
@@ -376,12 +375,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -402,14 +401,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -418,6 +417,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-nociphers.py
+++ b/scripts/test-tls13-nociphers.py
@@ -10,24 +10,25 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -98,15 +99,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -126,7 +127,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["sanity"] = conversation
@@ -141,15 +142,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -174,7 +175,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -204,12 +205,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -225,14 +226,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -241,6 +242,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-non-support.py
+++ b/scripts/test-tls13-non-support.py
@@ -9,19 +9,19 @@ from itertools import chain
 from random import sample
 
 from tlslite.extensions import SupportedVersionsExtension, \
-        SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        GroupName, ExtensionType, SignatureScheme
+    GroupName, ExtensionType, SignatureScheme
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import key_share_ext_gen, RSA_SIG_ALL
 
@@ -95,12 +95,12 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.rsa_pkcs1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
     ext[ExtensionType.signature_algorithms_cert] = \
         SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
@@ -136,14 +136,14 @@ def main():
         ext[ExtensionType.key_share] = key_share_ext_gen(groups)
         # draft versions of TLS 1.3 used major version of 127 and minor version
         # equal to the draft version (e.g. draft-23 used (127, 23))
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([(127, tls_ver), (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256,
                     SignatureScheme.rsa_pkcs1_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
         ext[ExtensionType.signature_algorithms_cert] = \
             SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
@@ -166,7 +166,7 @@ def main():
                                              AlertDescription.close_notify))
         node = node.add_child(ExpectAlert())
         conversations["try negotiating (127, {0}) - draft version"
-                      .format(tls_ver)] = \
+            .format(tls_ver)] = \
             conversation
 
     conversation = Connect(host, port)
@@ -177,14 +177,14 @@ def main():
     ext = {}
     groups = [GroupName.secp256r1]
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([(3, 4), (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.rsa_pkcs1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
     ext[ExtensionType.signature_algorithms_cert] = \
         SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
@@ -226,7 +226,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -256,12 +256,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -280,14 +280,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -296,6 +296,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-obsolete-curves.py
+++ b/scripts/test-tls13-obsolete-curves.py
@@ -10,25 +10,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ch_cookie_handler
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ch_cookie_handler
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, ExpectHelloRetryRequest
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectHelloRetryRequest
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, SIG_ALL, key_share_ext_gen
-
 
 version = 4
 
@@ -64,14 +63,14 @@ def negative_test(host, port, additional_extensions, expected_alert):
     ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ext = {}
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     ext.update(additional_extensions)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -139,16 +138,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -168,7 +167,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -183,16 +182,16 @@ def main():
     groups = [GroupName.secp256r1]
     key_shares = []
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
 
@@ -210,16 +209,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -240,7 +239,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -263,12 +262,12 @@ def main():
                 key_shares.append(key_share_gen(group))
         except ValueError:
             # bogus value to move on, if it makes problems, these won't result in handshake_failure
-            key_shares = [KeyShareEntry().create(obsolete_group, bytearray(b'\xab'*32))]
+            key_shares = [KeyShareEntry().create(obsolete_group, bytearray(b'\xab' * 32))]
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         conversation = negative_test(host, port, ext, alert_desc)
-        conversation_name = "{0} in supported_groups and key_share"\
+        conversation_name = "{0} in supported_groups and key_share" \
             .format(obsolete_group_name)
         conversations[conversation_name] = conversation
 
@@ -277,10 +276,10 @@ def main():
         groups = [obsolete_group]
         key_shares = []
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         conversation = negative_test(host, port, ext, alert_desc)
-        conversation_name = "{0} in supported_groups and empty key_share"\
+        conversation_name = "{0} in supported_groups and empty key_share" \
             .format(obsolete_group_name)
         conversations[conversation_name] = conversation
 
@@ -288,10 +287,10 @@ def main():
         ext = {}
         groups = [obsolete_group, GroupName.secp256r1]
         ext[ExtensionType.key_share] = key_share_ext_gen([GroupName.secp256r1])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         conversation = negative_test(host, port, ext, alert_desc)
-        conversation_name = "{0} and secp256r1 in supported_groups and "\
+        conversation_name = "{0} and secp256r1 in supported_groups and " \
                             "secp256r1 in key_share".format(obsolete_group_name)
         conversations[conversation_name] = conversation
 
@@ -305,9 +304,9 @@ def main():
             except ValueError:
                 # bogus value to move on, if it makes problems, these won't result in handshake_failure
                 key_shares.append(KeyShareEntry()
-                    .create(obsolete_group, bytearray(b'\xab'*32)))
+                                  .create(obsolete_group, bytearray(b'\xab' * 32)))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         conversation = negative_test(host, port, ext, alert_desc)
         conversation_name = "{0} and secp256r1 in supported_groups and key_share".format(obsolete_group_name)
@@ -323,9 +322,9 @@ def main():
             except ValueError:
                 # bogus value to move on, if it makes problems, these won't result in handshake_failure
                 key_shares.append(KeyShareEntry()
-                    .create(obsolete_group, bytearray(b'\xab'*32)))
+                                  .create(obsolete_group, bytearray(b'\xab' * 32)))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         conversation = negative_test(host, port, ext, alert_desc)
         conversation_name = "secp256r1 and {0} in supported_groups and key_share".format(obsolete_group_name)
@@ -340,15 +339,15 @@ def main():
         except ValueError:
             # bogus value to move on, if it makes problems, these won't result in handshake_failure
             key_shares.append(KeyShareEntry()
-                .create(obsolete_group, bytearray(b'\xab'*32)))
+                              .create(obsolete_group, bytearray(b'\xab' * 32)))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         conversation = negative_test(host, port, ext, AlertDescription.illegal_parameter)
         conversation_name = \
-            "{0} in key_share and secp256r1 in "\
-            "supported_groups (inconsistent extensions)"\
-            .format(obsolete_group_name)
+            "{0} in key_share and secp256r1 in " \
+            "supported_groups (inconsistent extensions)" \
+                .format(obsolete_group_name)
         conversations[conversation_name] = conversation
 
     # run the conversation
@@ -368,7 +367,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -398,12 +397,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -424,14 +423,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -440,6 +439,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-pkcs-signature.py
+++ b/scripts/test-tls13-pkcs-signature.py
@@ -10,25 +10,26 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
-        HashAlgorithm, SignatureAlgorithm
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    HashAlgorithm, SignatureAlgorithm
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -99,15 +100,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -127,7 +128,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -137,21 +138,21 @@ def main():
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = {}
         groups = [GroupName.secp256r1]
         key_shares = []
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [(getattr(HashAlgorithm, hash_alg), SignatureAlgorithm.rsa)]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -176,7 +177,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -206,12 +207,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -227,14 +228,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -243,6 +244,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-post-handshake-auth.py
+++ b/scripts/test-tls13-post-handshake-auth.py
@@ -10,30 +10,29 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        CertificateVerifyGenerator, CertificateGenerator, KeyUpdateGenerator, \
-        ClearContext
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    CertificateVerifyGenerator, CertificateGenerator, KeyUpdateGenerator, \
+    ClearContext
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, ExpectCertificateRequest, ExpectKeyUpdate
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectCertificateRequest, ExpectKeyUpdate
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
-        KeyUpdateMessageType
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    KeyUpdateMessageType
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, AutoEmptyExtension
 from tlslite.x509certchain import X509CertChain
 from tlslite.x509 import X509
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.utils.compat import compatAscii2Bytes
-
 
 version = 3
 
@@ -151,15 +150,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -182,7 +181,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -199,15 +198,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.post_handshake_auth] = AutoEmptyExtension()
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -248,7 +247,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -267,15 +266,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.post_handshake_auth] = AutoEmptyExtension()
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -345,15 +344,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.post_handshake_auth] = AutoEmptyExtension()
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -398,7 +397,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                           AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -415,15 +414,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     ext[ExtensionType.post_handshake_auth] = AutoEmptyExtension()
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -453,9 +452,8 @@ def main():
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.decrypt_error))
     node.add_child(ExpectClose())
-    #node = node.add_child(FinishedGenerator(context=context))
+    # node = node.add_child(FinishedGenerator(context=context))
     conversations["malformed signature in PHA"] = conversation
-
 
     # run the conversation
     good = 0
@@ -474,7 +472,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -504,12 +502,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -529,14 +527,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -545,6 +543,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-psk_dhe_ke.py
+++ b/scripts/test-tls13-psk_dhe_ke.py
@@ -10,27 +10,26 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, srv_ext_handler_supp_vers, \
-        gen_srv_ext_handler_psk, srv_ext_handler_key_share
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, srv_ext_handler_supp_vers, \
+    gen_srv_ext_handler_psk, srv_ext_handler_key_share
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
-        PskKeyExchangeMode
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    PskKeyExchangeMode
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.utils.compat import a2b_hex, compatAscii2Bytes
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, PskKeyExchangeModesExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, PskKeyExchangeModesExtension
 from tlsfuzzer.helpers import key_share_gen, psk_ext_gen, psk_ext_updater
-
 
 version = 3
 
@@ -73,7 +72,7 @@ def main():
 
     argv = sys.argv[1:]
     opts, args = getopt.getopt(argv, "h:p:e:x:X:n:",
-        ["help", "psk=", "psk-iden=", "psk-sha384"])
+                               ["help", "psk=", "psk-iden=", "psk-sha384"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -117,16 +116,16 @@ def main():
     else:
         ciphers.append(CipherSuite.TLS_AES_256_GCM_SHA384)
     ext = OrderedDict()
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
     groups = [GroupName.secp256r1]
     key_shares = []
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke])
     psk_settings = [(psk_ident, psk_secret, psk_prf)]
     ext[ExtensionType.pre_shared_key] = psk_ext_gen(psk_settings)
@@ -153,7 +152,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -168,16 +167,16 @@ def main():
     else:
         ciphers.append(CipherSuite.TLS_AES_256_GCM_SHA384)
     ext = OrderedDict()
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
     groups = [GroupName.ffdhe2048]
     key_shares = []
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke])
     psk_settings = [(psk_ident, psk_secret, psk_prf)]
     ext[ExtensionType.pre_shared_key] = psk_ext_gen(psk_settings)
@@ -204,7 +203,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -219,16 +218,16 @@ def main():
     else:
         ciphers.append(CipherSuite.TLS_AES_256_GCM_SHA384)
     ext = OrderedDict()
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
     groups = [GroupName.x25519]
     key_shares = []
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke])
     psk_settings = [(psk_ident, psk_secret, psk_prf)]
     ext[ExtensionType.pre_shared_key] = psk_ext_gen(psk_settings)
@@ -255,7 +254,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -278,7 +277,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -308,12 +307,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -333,14 +332,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -349,6 +348,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-psk_ke.py
+++ b/scripts/test-tls13-psk_ke.py
@@ -10,27 +10,26 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, srv_ext_handler_supp_vers, \
-        gen_srv_ext_handler_psk
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, srv_ext_handler_supp_vers, \
+    gen_srv_ext_handler_psk
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
-        PskKeyExchangeMode
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    PskKeyExchangeMode
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.utils.compat import a2b_hex, compatAscii2Bytes
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, PskKeyExchangeModesExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, PskKeyExchangeModesExtension
 from tlsfuzzer.helpers import key_share_gen, psk_ext_gen, psk_ext_updater
-
 
 version = 3
 
@@ -73,7 +72,7 @@ def main():
 
     argv = sys.argv[1:]
     opts, args = getopt.getopt(argv, "h:p:e:x:X:n:",
-        ["help", "psk=", "psk-iden=", "psk-sha384"])
+                               ["help", "psk=", "psk-iden=", "psk-sha384"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -117,9 +116,9 @@ def main():
     else:
         ciphers.append(CipherSuite.TLS_AES_256_GCM_SHA384)
     ext = OrderedDict()
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_ke])
     psk_settings = [(psk_ident, psk_secret, psk_prf)]
     ext[ExtensionType.pre_shared_key] = psk_ext_gen(psk_settings)
@@ -145,7 +144,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -168,7 +167,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -198,12 +197,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -223,14 +222,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -239,6 +238,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-record-layer-limits.py
+++ b/scripts/test-tls13-record-layer-limits.py
@@ -10,31 +10,30 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        SetMaxRecordSize, TCPBufferingEnable, \
-        TCPBufferingDisable, TCPBufferingFlush, PlaintextMessageGenerator, \
-        fuzz_encrypted_message, SetPaddingCallback
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    SetMaxRecordSize, TCPBufferingEnable, \
+    TCPBufferingDisable, TCPBufferingFlush, PlaintextMessageGenerator, \
+    fuzz_encrypted_message, SetPaddingCallback
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
-        PskKeyExchangeMode, ContentType
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    PskKeyExchangeMode, ContentType
 from tlslite.keyexchange import ECDHKeyExchange
 from tlslite.utils.cryptomath import getRandomNumber, getRandomBytes
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
-        TLSExtension, PskKeyExchangeModesExtension, PreSharedKeyExtension, \
-        PskIdentity, PreSharedKeyExtension, PaddingExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+    TLSExtension, PskKeyExchangeModesExtension, PreSharedKeyExtension, \
+    PskIdentity, PreSharedKeyExtension, PaddingExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, key_share_ext_gen
-
 
 version = 3
 
@@ -109,15 +108,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -137,7 +136,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -155,17 +154,17 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
-        node = node.add_child(SetMaxRecordSize(2**16 - 1))
+        node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectChangeCipherSpec())
@@ -175,9 +174,9 @@ def main():
         node = node.add_child(ExpectFinished())
         node = node.add_child(FinishedGenerator())
         data = bytearray(b"GET / HTTP/1.0\r\n" +
-                        b"X-test: " + b"A" * (2**14 - 28) +
-                        b"\r\n\r\n")
-        assert len(data) == 2**14
+                         b"X-test: " + b"A" * (2 ** 14 - 28) +
+                         b"\r\n\r\n")
+        assert len(data) == 2 ** 14
         node = node.add_child(ApplicationDataGenerator(data))
 
         # This message is optional and may show up 0 to many times
@@ -187,7 +186,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                            AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -204,17 +203,17 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
-        node = node.add_child(SetMaxRecordSize(2**16 - 1))
+        node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectChangeCipherSpec())
@@ -224,9 +223,9 @@ def main():
         node = node.add_child(ExpectFinished())
         node = node.add_child(FinishedGenerator())
         data = bytearray(b"GET / HTTP/1.0\r\n" +
-                        b"X-test: " + b"A" * (2**14 - 28 + 1) +
-                        b"\r\n\r\n")
-        assert len(data) == 2**14 + 1
+                         b"X-test: " + b"A" * (2 ** 14 - 28 + 1) +
+                         b"\r\n\r\n")
+        assert len(data) == 2 ** 14 + 1
         node = node.add_child(ApplicationDataGenerator(data))
 
         # This message is optional and may show up 0 to many times
@@ -250,17 +249,17 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
-        node = node.add_child(SetMaxRecordSize(2**16 - 1))
+        node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectChangeCipherSpec())
@@ -270,10 +269,10 @@ def main():
         node = node.add_child(ExpectFinished())
         node = node.add_child(FinishedGenerator())
         data = bytearray(b"GET / HTTP/1.0\r\n" +
-                            b"X-test: " + b"A" * (2**14 - 28 - 8) +
-                            b"\r\n\r\n")
-        assert len(data) == 2**14 - 8
-        padding_size = 2**14 + 2 - len(data) - 1
+                         b"X-test: " + b"A" * (2 ** 14 - 28 - 8) +
+                         b"\r\n\r\n")
+        assert len(data) == 2 ** 14 - 8
+        padding_size = 2 ** 14 + 2 - len(data) - 1
         node = node.add_child(SetPaddingCallback(
             SetPaddingCallback.add_fixed_padding_cb(padding_size)))
         node = node.add_child(ApplicationDataGenerator(data))
@@ -288,7 +287,7 @@ def main():
         node.next_sibling.add_child(ExpectClose())
         conversations["too big plaintext, size: 2**14 - 8, with an additional"
                       " {0} bytes of padding, cipher {1}".format(
-                        padding_size, CipherSuite.ietfNames[cipher])] = conversation
+            padding_size, CipherSuite.ietfNames[cipher])] = conversation
 
         conversation = Connect(host, port)
         node = conversation
@@ -300,17 +299,17 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
-        node = node.add_child(SetMaxRecordSize(2**16 - 1))
+        node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectChangeCipherSpec())
@@ -321,7 +320,7 @@ def main():
         # Finished msg will add 32 bytes
         # 3 bytes for msg length
         # 1 byte for content type
-        padding_left = 2**14 - 32 - 4
+        padding_left = 2 ** 14 - 32 - 4
         node = node.add_child(FinishedGenerator(pad_left=padding_left))
 
         # This message is optional and may show up 0 to many times
@@ -334,7 +333,7 @@ def main():
         node.next_sibling.add_child(ExpectClose())
         conversations["max size payload (2**14) of Finished msg, with {0} bytes"
                       " of left padding, cipher {1}".format(
-                          padding_left, CipherSuite.ietfNames[cipher])] = conversation
+            padding_left, CipherSuite.ietfNames[cipher])] = conversation
 
         conversation = Connect(host, port)
         node = conversation
@@ -346,17 +345,17 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
-        node = node.add_child(SetMaxRecordSize(2**16 - 1))
+        node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectChangeCipherSpec())
@@ -367,7 +366,7 @@ def main():
         # Finished msg will add 32 bytes
         # 3 bytes for msg length
         # 1 byte for content type
-        padding_left = 2**14 - 32 - 4 + 1
+        padding_left = 2 ** 14 - 32 - 4 + 1
         node = node.add_child(FinishedGenerator(pad_left=padding_left))
 
         # This message is optional and may show up 0 to many times
@@ -380,7 +379,7 @@ def main():
         node.next_sibling.add_child(ExpectClose())
         conversations["too big payload (2**14 + 1) of Finished msg, with {0} bytes"
                       " of left padding, cipher {1}".format(
-                        padding_left, CipherSuite.ietfNames[cipher])] = conversation
+            padding_left, CipherSuite.ietfNames[cipher])] = conversation
 
         conversation = Connect(host, port)
         node = conversation
@@ -392,17 +391,17 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
-        node = node.add_child(SetMaxRecordSize(2**16 - 1))
+        node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectChangeCipherSpec())
@@ -414,7 +413,7 @@ def main():
         # 16 bytes added after encryption
         # 3 bytes for msg length
         # 1 byte for content type
-        padding_size = 2**14 + 256 - 32 - 16 - 5
+        padding_size = 2 ** 14 + 256 - 32 - 16 - 5
         node = node.add_child(SetPaddingCallback(
             SetPaddingCallback.add_fixed_padding_cb(padding_size)))
         node = node.add_child(FinishedGenerator())
@@ -429,7 +428,7 @@ def main():
         node.next_sibling.add_child(ExpectClose())
         conversations["max size of Finished msg, with {0} bytes of record layer"
                       " padding {1}".format(
-                        padding_size, CipherSuite.ietfNames[cipher])] = conversation
+            padding_size, CipherSuite.ietfNames[cipher])] = conversation
 
         conversation = Connect(host, port)
         node = conversation
@@ -441,17 +440,17 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
-        node = node.add_child(SetMaxRecordSize(2**16 - 1))
+        node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectChangeCipherSpec())
@@ -463,7 +462,7 @@ def main():
         # 16 bytes added after encryption
         # 3 bytes for msg length
         # 1 byte for content type
-        padding_size = 2**14 + 256 - 32 - 16 - 5 + 1
+        padding_size = 2 ** 14 + 256 - 32 - 16 - 5 + 1
         node = node.add_child(SetPaddingCallback(
             SetPaddingCallback.add_fixed_padding_cb(padding_size)))
         node = node.add_child(FinishedGenerator())
@@ -478,7 +477,7 @@ def main():
         node.next_sibling.add_child(ExpectClose())
         conversations["too big Finished msg, with {0} bytes of record layer"
                       " padding, cipher {1}".format(
-                        padding_size, CipherSuite.ietfNames[cipher])] = conversation
+            padding_size, CipherSuite.ietfNames[cipher])] = conversation
 
     # AEAD tag fuzzed
     for val in [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80]:
@@ -490,17 +489,17 @@ def main():
             ext = {}
             groups = [GroupName.secp256r1]
             ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-            ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
                 .create([TLS_1_3_DRAFT, (3, 3)])
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                         SignatureScheme.rsa_pss_pss_sha256]
-            ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+            ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
                 .create(sig_algs)
-            ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+            ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
                 .create(RSA_SIG_ALL)
-            node = node.add_child(SetMaxRecordSize(2**16 - 1))
+            node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
             node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
             node = node.add_child(ExpectServerHello())
             node = node.add_child(ExpectChangeCipherSpec())
@@ -510,11 +509,11 @@ def main():
             node = node.add_child(ExpectFinished())
             node = node.add_child(FinishedGenerator())
             data = bytearray(b"GET / HTTP/1.0\r\n" +
-                             b"X-test: " + b"A" * (2**14 - 28 + 256 - 16) +
+                             b"X-test: " + b"A" * (2 ** 14 - 28 + 256 - 16) +
                              b"\r\n\r\n")
-            assert len(data) == 2**14 + 256 - 16
+            assert len(data) == 2 ** 14 + 256 - 16
             msg = ApplicationDataGenerator(data)
-            node = node.add_child(fuzz_encrypted_message(msg, xors={pos:val}))
+            node = node.add_child(fuzz_encrypted_message(msg, xors={pos: val}))
 
             # This message is optional and may show up 0 to many times
             cycle = ExpectNewSessionTicket()
@@ -525,7 +524,7 @@ def main():
                                             AlertDescription.record_overflow)
             node.next_sibling.add_child(ExpectClose())
             conversations_long["too big ciphertext with size 2**14 + 256 and"
-                                "fuzzed tag with {0} on pos {1}".format(val, pos)] = conversation
+                               "fuzzed tag with {0} on pos {1}".format(val, pos)] = conversation
 
     conversation = Connect(host, port)
     node = conversation
@@ -537,19 +536,19 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
-    padding_size = 2**14 - 216 - 1
+    padding_size = 2 ** 14 - 216 - 1
     ext[ExtensionType.client_hello_padding] = PaddingExtension().create(padding_size)
-    node = node.add_child(SetMaxRecordSize(2**16 - 1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
     node = node.add_child(ExpectChangeCipherSpec())
@@ -568,7 +567,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -584,22 +583,22 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
-    padding_size = 2**14 - 216
+    padding_size = 2 ** 14 - 216
     ext[ExtensionType.client_hello_padding] = PaddingExtension().create(padding_size)
-    node = node.add_child(SetMaxRecordSize(2**16 - 1))
+    node = node.add_child(SetMaxRecordSize(2 ** 16 - 1))
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                    AlertDescription.record_overflow))
+                                      AlertDescription.record_overflow))
     node.add_child(ExpectClose())
     conversations["too big ClientHello msg, with {0} bytes of padding".format(padding_size)] = conversation
 
@@ -621,9 +620,9 @@ def main():
         long_tests = [(k, v) for k, v in conversations_long.items() if k in run_only]
     else:
         short_tests = [(k, v) for k, v in conversations.items() if
-                        (k != 'sanity') and k not in run_exclude]
+                       (k != 'sanity') and k not in run_exclude]
         long_tests = [(k, v) for k, v in conversations_long.items() if
-                        k not in run_exclude]
+                      k not in run_exclude]
     sampled_tests = sample(long_tests, min(num_limit, len(long_tests)))
     ordered_tests = chain(sanity_tests, sampled_tests, short_tests, sanity_tests)
 
@@ -650,12 +649,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -682,14 +681,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + len(short_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + len(short_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -698,6 +697,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-record-padding.py
+++ b/scripts/test-tls13-record-padding.py
@@ -10,24 +10,23 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        SetPaddingCallback
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    SetPaddingCallback
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
-
 
 version = 3
 
@@ -101,15 +100,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -129,7 +128,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -146,15 +145,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -176,7 +175,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -193,15 +192,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -223,7 +222,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -246,7 +245,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -276,12 +275,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -301,14 +300,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -317,6 +316,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-rsa-signatures.py
+++ b/scripts/test-tls13-rsa-signatures.py
@@ -10,23 +10,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
-
 
 version = 3
 
@@ -52,6 +51,7 @@ def help_msg():
     print("                certificate with rsaEncryption key and")
     print("                with RSASSA-PSS key")
     print(" --help         this message")
+
 
 def main():
     host = "localhost"
@@ -105,9 +105,9 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_rsae_sha384,
@@ -116,9 +116,9 @@ def main():
         sig_algs += [SignatureScheme.rsa_pss_pss_sha256,
                      SignatureScheme.rsa_pss_pss_sha384,
                      SignatureScheme.rsa_pss_pss_sha512]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -138,7 +138,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -151,21 +151,21 @@ def main():
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = {}
         groups = [GroupName.secp256r1]
         key_shares = []
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [sig_alg]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -185,12 +185,11 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                        AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
         conversations["tls13 signature {0}".format(SignatureScheme.toRepr(sig_alg))] = conversation
-
 
     # RSASSA-PSS
     for sig_alg in [SignatureScheme.rsa_pss_pss_sha256,
@@ -199,21 +198,21 @@ def main():
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = {}
         groups = [GroupName.secp256r1]
         key_shares = []
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [sig_alg]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
 
@@ -235,16 +234,15 @@ def main():
 
             node.next_sibling = ExpectApplicationData()
             node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                            AlertDescription.close_notify))
+                                                              AlertDescription.close_notify))
 
             node = node.add_child(ExpectAlert())
             node.next_sibling = ExpectClose()
         else:
             node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                            AlertDescription.handshake_failure))
+                                              AlertDescription.handshake_failure))
             node = node.add_child(ExpectClose())
         conversations["tls13 signature {0}".format(SignatureScheme.toRepr(sig_alg))] = conversation
-
 
     # run the conversation
     good = 0
@@ -263,7 +261,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -293,12 +291,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -320,14 +318,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -336,6 +334,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-rsapss-signatures.py
+++ b/scripts/test-tls13-rsapss-signatures.py
@@ -10,23 +10,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
-
 
 version = 3
 
@@ -106,9 +105,9 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.rsa_pss_pss_sha384,
@@ -117,9 +116,9 @@ def main():
         sig_algs += [SignatureScheme.rsa_pss_rsae_sha256,
                      SignatureScheme.rsa_pss_rsae_sha384,
                      SignatureScheme.rsa_pss_rsae_sha512]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -139,7 +138,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -152,21 +151,21 @@ def main():
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = {}
         groups = [GroupName.secp256r1]
         key_shares = []
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [sig_alg]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
 
@@ -188,13 +187,13 @@ def main():
 
             node.next_sibling = ExpectApplicationData()
             node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                            AlertDescription.close_notify))
+                                                              AlertDescription.close_notify))
 
             node = node.add_child(ExpectAlert())
             node.next_sibling = ExpectClose()
         else:
             node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                            AlertDescription.handshake_failure))
+                                              AlertDescription.handshake_failure))
             node = node.add_child(ExpectClose())
         conversations["tls13 signature {0}".format(SignatureScheme.toRepr(sig_alg))] = conversation
 
@@ -205,21 +204,21 @@ def main():
         conversation = Connect(host, port)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = {}
         groups = [GroupName.secp256r1]
         key_shares = []
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [sig_alg]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -239,12 +238,11 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                        AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
         conversations["tls13 signature {0}".format(SignatureScheme.toRepr(sig_alg))] = conversation
-
 
     # run the conversation
     good = 0
@@ -263,7 +261,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -293,12 +291,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -320,14 +318,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -336,6 +334,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-serverhello-random.py
+++ b/scripts/test-tls13-serverhello-random.py
@@ -10,25 +10,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        CopyVariables
+    ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    CopyVariables
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, key_share_ext_gen, \
-        uniqueness_check
-
+    uniqueness_check
 
 version = 3
 
@@ -99,9 +98,9 @@ def main():
     collected_key_shares = []
     variables_check = \
         {'ServerHello.random':
-         collected_randoms,
+             collected_randoms,
          'ServerHello.extensions.key_share.key_exchange':
-         collected_key_shares}
+             collected_key_shares}
 
     conversations = {}
 
@@ -113,15 +112,15 @@ def main():
     groups = [GroupName.secp256r1]
     key_shares = []
     ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -142,7 +141,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -158,15 +157,15 @@ def main():
         groups = [group]
         key_shares = []
         ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -187,7 +186,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                           AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -211,7 +210,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -242,22 +241,22 @@ def main():
                     xpassed.append(c_name)
                     print("XPASS-expected failure but test passed\n")
                 else:
-                    if expected_failures[c_name] is not None and  \
-                        expected_failures[c_name] not in str(exception):
-                            bad += 1
-                            failed.append(c_name)
-                            print("Expected error message: {0}\n"
-                                .format(expected_failures[c_name]))
+                    if expected_failures[c_name] is not None and \
+                            expected_failures[c_name] not in str(exception):
+                        bad += 1
+                        failed.append(c_name)
+                        print("Expected error message: {0}\n"
+                              .format(expected_failures[c_name]))
                     else:
                         xfail += 1
                         print("OK-expected failure\n")
             else:
-                    if res:
-                        good += 1
-                        print("OK\n")
-                    else:
-                        bad += 1
-                        failed.append(c_name)
+                if res:
+                    good += 1
+                    print("OK\n")
+                else:
+                    bad += 1
+                    failed.append(c_name)
 
     failed_tests = uniqueness_check(variables_check, good + bad)
     if failed_tests:
@@ -273,14 +272,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -289,6 +288,7 @@ def main():
 
     if bad > 0 or failed_tests:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-session-resumption.py
+++ b/scripts/test-tls13-session-resumption.py
@@ -9,28 +9,27 @@ from itertools import chain
 from random import sample
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
-        PskKeyExchangeMode
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    PskKeyExchangeMode
 from tlslite.extensions import ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, PskKeyExchangeModesExtension, \
-        SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, PskKeyExchangeModesExtension, \
+    SignatureAlgorithmsCertExtension
 
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        Close, ResetHandshakeHashes, ResetRenegotiationInfo
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    Close, ResetHandshakeHashes, ResetRenegotiationInfo
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, srv_ext_handler_supp_vers, \
-        gen_srv_ext_handler_psk, srv_ext_handler_key_share
+    ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, srv_ext_handler_supp_vers, \
+    gen_srv_ext_handler_psk, srv_ext_handler_key_share
 from tlsfuzzer.helpers import key_share_gen, psk_session_ext_gen, \
-        psk_ext_updater, RSA_SIG_ALL
-
+    psk_ext_updater, RSA_SIG_ALL
 
 version = 3
 
@@ -105,17 +104,17 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -157,17 +156,17 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
-    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension() \
         .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -257,7 +256,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -287,12 +286,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -310,14 +309,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -326,6 +325,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-shuffled-extentions.py
+++ b/scripts/test-tls13-shuffled-extentions.py
@@ -10,25 +10,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ch_cookie_handler
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ch_cookie_handler
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, ExpectHelloRetryRequest
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectHelloRetryRequest
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, AutoEmptyExtension
-
 
 version = 3
 
@@ -113,15 +112,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -141,7 +140,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -155,15 +154,15 @@ def main():
     groups = [GroupName.secp256r1]
     key_shares = []
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
 
@@ -207,15 +206,15 @@ def main():
         groups = [GroupName.secp256r1]
         key_shares = []
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         for ext_id in ext_chunk:
             ext[ext_id] = AutoEmptyExtension()
@@ -264,7 +263,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -294,12 +293,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -320,14 +319,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -336,6 +335,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-signature-algorithms.py
+++ b/scripts/test-tls13-signature-algorithms.py
@@ -11,26 +11,27 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_message, Close
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_message, Close
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, GroupName, TLS_1_3_DRAFT, SignatureScheme, \
-        HashAlgorithm, SignatureAlgorithm
+    ExtensionType, GroupName, TLS_1_3_DRAFT, SignatureScheme, \
+    HashAlgorithm, SignatureAlgorithm
 from tlslite.extensions import SignatureAlgorithmsExtension, \
-        ClientKeyShareExtension, SupportedVersionsExtension, \
-        SupportedGroupsExtension, TLSExtension, \
-        SignatureAlgorithmsCertExtension
+    ClientKeyShareExtension, SupportedVersionsExtension, \
+    SupportedGroupsExtension, TLSExtension, \
+    SignatureAlgorithmsCertExtension
 
 version = 4
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [OPTIONS] [[probe-name] ...]")
@@ -106,15 +107,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -134,13 +135,12 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["sanity"] = conversation
 
-
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
@@ -151,16 +151,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pkcs1_sha1,
                 SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -180,13 +180,12 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["tolerance legacy RSA PKCS#1.5"] = conversation
 
-
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
@@ -197,16 +196,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [(10, SignatureAlgorithm.rsa),
                 SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -226,7 +225,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -246,15 +245,15 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         n = n - 2  # these are the mandatory methods in the end
         sig_algs = [(HashAlgorithm.sha1, SignatureAlgorithm.dsa)] * n
         sig_algs += [SignatureScheme.rsa_pss_rsae_sha256,
                      SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -275,7 +274,7 @@ def main():
         # ApplicationData message may show up 1 to many times
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                           AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
         cycle_alert = ExpectAlert()
         node = node.add_child(cycle_alert)
         node.next_sibling = ExpectApplicationData()
@@ -295,15 +294,15 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         n = n - 2  # these are the mandatory methods in the end
         sig_algs = [SignatureScheme.rsa_pkcs1_sha1] * n
         sig_algs += [SignatureScheme.rsa_pss_rsae_sha256,
                      SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -324,7 +323,7 @@ def main():
         # ApplicationData message may show up 1 to many times
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                           AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
         cycle_alert = ExpectAlert()
         node = node.add_child(cycle_alert)
         node.next_sibling = ExpectApplicationData()
@@ -343,15 +342,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     # Add all supported sig_algs, put rsa at the end
     sig_algs = []
-    for sig_alg in ['ecdsa', 'dsa','rsa']:
-        sig_algs += [(getattr(HashAlgorithm, x), getattr(SignatureAlgorithm, sig_alg))\
-                      for x in ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']]
+    for sig_alg in ['ecdsa', 'dsa', 'rsa']:
+        sig_algs += [(getattr(HashAlgorithm, x), getattr(SignatureAlgorithm, sig_alg)) \
+                     for x in ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']]
     # ed25519(0x0807), ed448(0x0808)
     sig_algs += [(8, 7), (8, 8)]
     sig_algs += [SignatureScheme.rsa_pss_pss_sha256,
@@ -360,9 +359,9 @@ def main():
                  SignatureScheme.rsa_pss_rsae_sha256,
                  SignatureScheme.rsa_pss_rsae_sha384,
                  SignatureScheme.rsa_pss_rsae_sha512]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -382,7 +381,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -402,9 +401,9 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         n = n - 2  # these are the mandatory methods in the end
         sig_algs = list(chain(
@@ -412,7 +411,7 @@ def main():
             ((i, 163) for i in range(10, (n % 214) + 10)),
             [SignatureScheme.rsa_pss_rsae_sha256,
              SignatureScheme.rsa_pss_pss_sha256]))
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -443,16 +442,16 @@ def main():
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ext = {}
     groups = [GroupName.secp256r1]
     key_shares = []
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     n = n - 2  # these are the mandatory methods in the end
     n = n - len(RSA_SIG_ALL)  # number of methods in sig_alg_cert extension
@@ -461,9 +460,9 @@ def main():
         ((i, 163) for i in range(10, (n % 214) + 10)),
         [SignatureScheme.rsa_pss_rsae_sha256,
          SignatureScheme.rsa_pss_pss_sha256]))
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -498,22 +497,21 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = []
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       getattr(AlertDescription, fatal_alert)))
     node = node.add_child(ExpectClose())
     conversations["empty list of signature methods"] = \
-            conversation
-
+        conversation
 
     # Only undefined algorithms
     conversation = Connect(host, port)
@@ -526,19 +524,19 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sigs = [(HashAlgorithm.sha256, 24),  # undefined signature algorithm
             (24, SignatureAlgorithm.rsa),  # undefined hash algorithm
             (10, 10),  # undefined pair
             (9, 24),  # undefined pair
             (0xff, 0xff)  # undefined pair
-           ]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+            ]
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sigs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
@@ -558,22 +556,21 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sigs = [SignatureScheme.rsa_pkcs1_sha1,
             SignatureScheme.rsa_pkcs1_sha512]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sigs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.handshake_failure))
     node = node.next_sibling = ExpectClose()
     conversations["only legacy sigalgs"] = conversation
-
 
     # padded extension
     conversation = Connect(host, port)
@@ -585,9 +582,9 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ext[ExtensionType.signature_algorithms] = \
         TLSExtension(extType=ExtensionType.signature_algorithms) \
@@ -613,9 +610,9 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ext[ExtensionType.signature_algorithms] = \
         TLSExtension(extType=ExtensionType.signature_algorithms) \
@@ -639,9 +636,9 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ext[ExtensionType.signature_algorithms] = \
         TLSExtension(extType=ExtensionType.signature_algorithms) \
@@ -669,23 +666,23 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
         hello = ClientHelloGenerator(ciphers, extensions=ext)
-        node = node.add_child(fuzz_message(hello, xors={-5:i}))
+        node = node.add_child(fuzz_message(hello, xors={-5: i}))
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           getattr(AlertDescription, fatal_alert)))
         node = node.add_child(ExpectClose())
-        conversations["fuzz length inside extension to {0}".format(4^i)] = \
-                conversation
+        conversations["fuzz length inside extension to {0}".format(4 ^ i)] = \
+            conversation
 
     # run the conversation
     good = 0
@@ -731,12 +728,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -758,14 +755,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -774,6 +771,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-symetric-ciphers.py
+++ b/scripts/test-tls13-symetric-ciphers.py
@@ -10,25 +10,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        fuzz_encrypted_message
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    fuzz_encrypted_message
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, \
-        key_share_ext_gen
-
+    key_share_ext_gen
 
 version = 3
 
@@ -95,7 +94,7 @@ def main():
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256, CipherSuite.TLS_AES_256_GCM_SHA384,
-            CipherSuite.TLS_CHACHA20_POLY1305_SHA256]
+               CipherSuite.TLS_CHACHA20_POLY1305_SHA256]
 
     ext = {}
     groups = [GroupName.secp256r1]
@@ -103,15 +102,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -131,15 +130,15 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["sanity"] = conversation
 
     for cipher in [CipherSuite.TLS_AES_128_GCM_SHA256, CipherSuite.TLS_AES_256_GCM_SHA384,
-           CipherSuite.TLS_CHACHA20_POLY1305_SHA256, CipherSuite.TLS_AES_128_CCM_SHA256,
-           CipherSuite.TLS_AES_128_CCM_8_SHA256]:
+                   CipherSuite.TLS_CHACHA20_POLY1305_SHA256, CipherSuite.TLS_AES_128_CCM_SHA256,
+                   CipherSuite.TLS_AES_128_CCM_8_SHA256]:
 
         conversation = Connect(host, port)
         node = conversation
@@ -151,15 +150,15 @@ def main():
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -179,7 +178,7 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                           AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
@@ -191,7 +190,6 @@ def main():
         # fuzz the tag (last 16 bytes or last 8 bytes for the _8 CCM cipher)
         for val in [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80]:
             for pos in range(-1, -n, -1):
-
                 # Fuzz application data
                 conversation = Connect(host, port)
                 node = conversation
@@ -200,15 +198,15 @@ def main():
                 ext = {}
                 groups = [GroupName.secp256r1]
                 ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-                ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+                ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
                     .create([TLS_1_3_DRAFT, (3, 3)])
-                ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+                ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                     .create(groups)
                 sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                             SignatureScheme.rsa_pss_pss_sha256]
-                ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+                ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
                     .create(sig_algs)
-                ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+                ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
                     .create(RSA_SIG_ALL)
                 node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
                 node = node.add_child(ExpectServerHello())
@@ -220,7 +218,7 @@ def main():
                 node = node.add_child(FinishedGenerator())
                 msg = ApplicationDataGenerator(bytearray(b"GET / HTTP/1.0\r\n\r\n"))
 
-                node = node.add_child(fuzz_encrypted_message(msg, xors={pos:val}))
+                node = node.add_child(fuzz_encrypted_message(msg, xors={pos: val}))
 
                 # This message is optional and may show up 0 to many times
                 cycle = ExpectNewSessionTicket()
@@ -230,7 +228,8 @@ def main():
                 node.next_sibling = ExpectAlert(AlertLevel.fatal, AlertDescription.bad_record_mac)
                 node = node.next_sibling.add_child(ExpectClose())
 
-                conversations["check connection with {0} - fuzz tag on application data with {1} on pos {2}".format(CipherSuite.ietfNames[cipher], val, pos)] = conversation
+                conversations["check connection with {0} - fuzz tag on application data with {1} on pos {2}".format(
+                    CipherSuite.ietfNames[cipher], val, pos)] = conversation
 
                 # Fuzz Finished message
                 conversation = Connect(host, port)
@@ -240,15 +239,15 @@ def main():
                 ext = {}
                 groups = [GroupName.secp256r1]
                 ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-                ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+                ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
                     .create([TLS_1_3_DRAFT, (3, 3)])
-                ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+                ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                     .create(groups)
                 sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                             SignatureScheme.rsa_pss_pss_sha256]
-                ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+                ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
                     .create(sig_algs)
-                ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+                ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
                     .create(RSA_SIG_ALL)
                 node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
                 node = node.add_child(ExpectServerHello())
@@ -259,7 +258,7 @@ def main():
                 node = node.add_child(ExpectFinished())
                 msg = FinishedGenerator()
 
-                node = node.add_child(fuzz_encrypted_message(msg, xors={pos:val}))
+                node = node.add_child(fuzz_encrypted_message(msg, xors={pos: val}))
 
                 # This message is optional and may show up 0 to many times
                 cycle = ExpectNewSessionTicket()
@@ -269,7 +268,8 @@ def main():
                 node.next_sibling = ExpectAlert(AlertLevel.fatal, AlertDescription.bad_record_mac)
                 node = node.next_sibling.add_child(ExpectClose())
 
-                conversations["check connection with {0} - fuzz tag on finished message with {1} on pos {2}".format(CipherSuite.ietfNames[cipher], val, pos)] = conversation
+                conversations["check connection with {0} - fuzz tag on finished message with {1} on pos {2}".format(
+                    CipherSuite.ietfNames[cipher], val, pos)] = conversation
 
     # run the conversation
     good = 0
@@ -315,12 +315,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -340,14 +340,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -356,6 +356,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-unrecognised-groups.py
+++ b/scripts/test-tls13-unrecognised-groups.py
@@ -10,25 +10,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ch_cookie_handler
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ch_cookie_handler
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, ExpectHelloRetryRequest
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectHelloRetryRequest
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
-
 
 version = 3
 
@@ -107,15 +106,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -135,7 +134,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -154,22 +153,22 @@ def main():
                 conversation = Connect(host, port)
                 node = conversation
                 ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                        CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
                 ext = OrderedDict()
 
                 groups = [known_group] + unknown_group
-                key_shares = [KeyShareEntry().create(un_group, bytearray(b'\xab'*size)) for un_group in unknown_group]
+                key_shares = [KeyShareEntry().create(un_group, bytearray(b'\xab' * size)) for un_group in unknown_group]
 
                 ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-                ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+                ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
                     .create([TLS_1_3_DRAFT, (3, 3)])
-                ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+                ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                     .create(groups)
                 sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                             SignatureScheme.rsa_pss_pss_sha256]
-                ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+                ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
                     .create(sig_algs)
-                ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+                ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
                     .create(RSA_SIG_ALL)
                 node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
 
@@ -185,17 +184,17 @@ def main():
                 groups = [known_group] + unknown_group
                 key_shares = [key_share_gen(groups[0])]
                 ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-                ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+                ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
                     .create([TLS_1_3_DRAFT, (3, 3)])
-                ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+                ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                     .create(groups)
                 if cookie:
                     ext[ExtensionType.cookie] = ch_cookie_handler
                 sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                             SignatureScheme.rsa_pss_pss_sha256]
-                ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+                ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
                     .create(sig_algs)
-                ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+                ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
                     .create(RSA_SIG_ALL)
                 node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
                 node = node.add_child(ExpectServerHello())
@@ -214,35 +213,36 @@ def main():
 
                 node.next_sibling = ExpectApplicationData()
                 node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                                AlertDescription.close_notify))
+                                                                  AlertDescription.close_notify))
 
                 node = node.add_child(ExpectAlert())
                 node.next_sibling = ExpectClose()
 
-                conversations["only unknown key_share from {0} range, key_share of size {1} + {2} in supported_groups".format(
-                    group_name, size, GroupName.toRepr(known_group))] = conversation
+                conversations[
+                    "only unknown key_share from {0} range, key_share of size {1} + {2} in supported_groups".format(
+                        group_name, size, GroupName.toRepr(known_group))] = conversation
 
                 # One known group and list of unknown groups, unknown ones are listed first
                 conversation = Connect(host, port)
                 node = conversation
                 ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                        CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
                 ext = OrderedDict()
 
                 groups = unknown_group + [known_group]
-                key_shares = [KeyShareEntry().create(un_group, bytearray(b'\xab'*size)) for un_group in unknown_group]
+                key_shares = [KeyShareEntry().create(un_group, bytearray(b'\xab' * size)) for un_group in unknown_group]
                 key_shares.append(key_share_gen(groups[-1]))
 
                 ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-                ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+                ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
                     .create([TLS_1_3_DRAFT, (3, 3)])
-                ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+                ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                     .create(groups)
                 sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                             SignatureScheme.rsa_pss_pss_sha256]
-                ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+                ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
                     .create(sig_algs)
-                ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+                ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
                     .create(RSA_SIG_ALL)
                 node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
                 node = node.add_child(ExpectServerHello())
@@ -262,7 +262,7 @@ def main():
 
                 node.next_sibling = ExpectApplicationData()
                 node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                                AlertDescription.close_notify))
+                                                                  AlertDescription.close_notify))
 
                 node = node.add_child(ExpectAlert())
                 node.next_sibling = ExpectClose()
@@ -274,26 +274,26 @@ def main():
             conversation = Connect(host, port)
             node = conversation
             ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                       CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
             ext = OrderedDict()
 
             groups = unknown_group
-            key_shares = [KeyShareEntry().create(un_group, bytearray(b'\xab'*size)) for un_group in unknown_group]
+            key_shares = [KeyShareEntry().create(un_group, bytearray(b'\xab' * size)) for un_group in unknown_group]
 
             ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-            ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
                 .create([TLS_1_3_DRAFT, (3, 3)])
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
                 .create(groups)
             sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                         SignatureScheme.rsa_pss_pss_sha256]
-            ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+            ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
                 .create(sig_algs)
-            ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+            ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
                 .create(RSA_SIG_ALL)
             node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
             node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                            AlertDescription.handshake_failure))
+                                              AlertDescription.handshake_failure))
             node.add_child(ExpectClose())
 
             conversations["only unknown supported_groups from {0} range, key_share of size {1}".format(
@@ -316,7 +316,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -346,12 +346,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -372,14 +372,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -388,6 +388,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-version-negotiation.py
+++ b/scripts/test-tls13-version-negotiation.py
@@ -11,23 +11,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket, ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, key_share_ext_gen
-
 
 version = 5
 
@@ -105,15 +104,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -132,7 +131,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -142,22 +141,22 @@ def main():
         conversation = Connect(host, port, version=(3, version_id))
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
-               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         ext = {}
         groups = [GroupName.secp256r1]
         key_shares = []
         for group in groups:
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([TLS_1_3_DRAFT, (3, 3)])
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
-                SignatureScheme.rsa_pss_pss_sha256]
-        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+                    SignatureScheme.rsa_pss_pss_sha256]
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
             .create(sig_algs)
-        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
             .create(RSA_SIG_ALL)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
@@ -176,12 +175,11 @@ def main():
 
         node.next_sibling = ExpectApplicationData()
         node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                          AlertDescription.close_notify))
+                                                          AlertDescription.close_notify))
 
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
         conversations["tls 1.3 negotiation with SSL 3.{0} in record layer".format(version_id)] = conversation
-
 
     conversation = Connect(host, port)
     node = conversation
@@ -193,20 +191,19 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([(3, 9)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal, AlertDescription.protocol_version))
     conversations["tls 1.8 only"] = conversation
-
 
     conversation = Connect(host, port)
     node = conversation
@@ -216,7 +213,7 @@ def main():
                 SignatureScheme.rsa_pss_pss_sha256]
     ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256]
     ext = {}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ext[ExtensionType.signature_algorithms] = \
         SignatureAlgorithmsExtension().create(sig_algs)
@@ -233,12 +230,12 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([(3, 9), (3, 3)])
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     # verify that there is no supported versions in server hello
-    node = node.add_child(ExpectServerHello(version = (3, 3),
-                          extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(version=(3, 3),
+                                            extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -257,7 +254,6 @@ def main():
     node.next_sibling = ExpectClose()
     conversations["fallback from TLS 1.8 to 1.2"] = conversation
 
-
     conversation = Connect(host, port)
     node = conversation
     groups = [GroupName.secp256r1,
@@ -266,7 +262,7 @@ def main():
                 SignatureScheme.rsa_pss_pss_sha256]
     ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256]
     ext = {}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ext[ExtensionType.signature_algorithms] = \
         SignatureAlgorithmsExtension().create(sig_algs)
@@ -283,12 +279,12 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([(3, 9), (3, 2)])
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     # verify that there is no supported versions in server hello
-    node = node.add_child(ExpectServerHello(version = (3, 2),
-                          extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(version=(3, 2),
+                                            extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -307,7 +303,6 @@ def main():
     node.next_sibling = ExpectClose()
     conversations["fallback from TLS 1.8 to 1.1"] = conversation
 
-
     conversation = Connect(host, port)
     node = conversation
     groups = [GroupName.secp256r1,
@@ -316,7 +311,7 @@ def main():
                 SignatureScheme.rsa_pss_pss_sha256]
     ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256]
     ext = {}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ext[ExtensionType.signature_algorithms] = \
         SignatureAlgorithmsExtension().create(sig_algs)
@@ -336,8 +331,8 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 4), extensions=ext))
     # negotiate TLS 1.2; it is valid for an implementation to abort handshake
     # but we don't cover it
-    node = node.add_child(ExpectServerHello(version = (3, 3),
-                          extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(version=(3, 3),
+                                            extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -357,14 +352,13 @@ def main():
     node.next_sibling = ExpectClose()
     conversations["TLS 1.3 in client hello legacy field"] = conversation
 
-
     conversation = Connect(host, port)
     node = conversation
     groups = [GroupName.secp256r1,
               GroupName.ffdhe2048]
     ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256]
     ext = {}
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     ext[ExtensionType.signature_algorithms] = \
         SignatureAlgorithmsExtension().create(sig_algs)
@@ -384,8 +378,8 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers, version=(3, 9), extensions=ext))
     # negotiate TLS 1.2; it is valid for an implementation to abort handshake
     # but we don't cover it
-    node = node.add_child(ExpectServerHello(version = (3, 3),
-                          extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(version=(3, 3),
+                                            extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -404,7 +398,6 @@ def main():
     node.next_sibling = ExpectClose()
     conversations["TLS 1.8 in client hello legacy field"] = conversation
 
-
     conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
@@ -417,20 +410,19 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([(3, 0)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal, AlertDescription.protocol_version))
     conversations["SSL 3.0 in supported version"] = conversation
-
 
     # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
     conversation = Connect(host, port, version=(0, 2))
@@ -452,7 +444,7 @@ def main():
                     SignatureScheme.rsa_pss_pss_sha256]
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256]
         ext = {}
-        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
             .create(groups)
         ext[ExtensionType.signature_algorithms] = \
             SignatureAlgorithmsExtension().create(sig_algs)
@@ -466,12 +458,12 @@ def main():
             ciphers.extend([CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                             CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV])
         ext[ExtensionType.key_share] = key_share_ext_gen(groups)
-        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
             .create([(127, l_ver), (3, 3)])
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         # verify that there is no supported versions in server hello
         node = node.add_child(ExpectServerHello(version=(3, 3),
-                              extensions={ExtensionType.renegotiation_info:None}))
+                                                extensions={ExtensionType.renegotiation_info: None}))
         node = node.add_child(ExpectCertificate())
         if dhe:
             node = node.add_child(ExpectServerKeyExchange())
@@ -490,7 +482,7 @@ def main():
                                           AlertDescription.close_notify))
         node.next_sibling = ExpectClose()
         conversations["fallback from TLS 1.3-draft{0} to 1.2"
-                      .format(l_ver)] = conversation
+            .format(l_ver)] = conversation
 
     # run the conversation
     good = 0
@@ -509,7 +501,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -539,12 +531,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -563,14 +555,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -579,6 +571,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-zero-content-type.py
+++ b/scripts/test-tls13-zero-content-type.py
@@ -11,25 +11,24 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        split_message, PopMessageFromList, SetPaddingCallback, \
-        RawMessageGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    split_message, PopMessageFromList, SetPaddingCallback, \
+    RawMessageGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, SIG_ALL
-
 
 version = 1
 
@@ -103,16 +102,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -132,7 +131,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -150,16 +149,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -193,16 +192,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -236,16 +235,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -278,16 +277,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -320,16 +319,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -364,16 +363,16 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256,
                 SignatureScheme.ecdsa_secp256r1_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -437,12 +436,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS: expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -462,14 +461,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -478,6 +477,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-tls13-zero-length-data.py
+++ b/scripts/test-tls13-zero-length-data.py
@@ -10,24 +10,23 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        split_message, PopMessageFromList, SetPaddingCallback
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    split_message, PopMessageFromList, SetPaddingCallback
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectEncryptedExtensions, ExpectCertificateVerify, \
-        ExpectNewSessionTicket
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
-        SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
-
 
 version = 4
 
@@ -101,15 +100,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -129,7 +128,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -146,15 +145,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -181,7 +180,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -198,15 +197,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -235,7 +234,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -252,15 +251,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -289,7 +288,7 @@ def main():
 
     node.next_sibling = ExpectApplicationData()
     node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
-                                       AlertDescription.close_notify))
+                                                      AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -306,15 +305,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -347,15 +346,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -377,7 +376,7 @@ def main():
                                     AlertDescription.unexpected_message)
     node.next_sibling.add_child(ExpectClose())
 
-    conversations["zero-length app data with padding during handshake"] =\
+    conversations["zero-length app data with padding during handshake"] = \
         conversation
 
     # Send zero-length application data while handshaking with large padding
@@ -391,15 +390,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
@@ -421,7 +420,7 @@ def main():
     node.next_sibling = ExpectAlert(AlertLevel.fatal,
                                     AlertDescription.unexpected_message)
     node.next_sibling.add_child(ExpectClose())
-    conversations["zero-len app data with large padding during handshake"] =\
+    conversations["zero-len app data with large padding during handshake"] = \
         conversation
 
     # Send a zero-length application data interleaved in handshake
@@ -436,15 +435,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     hello_gen = ClientHelloGenerator(ciphers, extensions=ext)
     node = node.add_child(split_message(hello_gen, fragment_list, 2))
@@ -453,7 +452,7 @@ def main():
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.unexpected_message))
     node.add_child(ExpectClose())
-    conversations["zero-length app data interleaved in handshake"] =\
+    conversations["zero-length app data interleaved in handshake"] = \
         conversation
 
     # Send zero-len app data with padding interleaved in handshaking
@@ -468,15 +467,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     hello_gen = ClientHelloGenerator(ciphers, extensions=ext)
     node = node.add_child(split_message(hello_gen, fragment_list, 2))
@@ -502,15 +501,15 @@ def main():
     for group in groups:
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
-    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension() \
         .create([TLS_1_3_DRAFT, (3, 3)])
-    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                 SignatureScheme.rsa_pss_pss_sha256]
-    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension() \
         .create(sig_algs)
-    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension() \
         .create(RSA_SIG_ALL)
     hello_gen = ClientHelloGenerator(ciphers, extensions=ext)
     node = node.add_child(split_message(hello_gen, fragment_list, 2))
@@ -541,7 +540,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -571,12 +570,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -596,14 +595,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -612,6 +611,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-truncating-of-client-hello.py
+++ b/scripts/test-truncating-of-client-hello.py
@@ -10,18 +10,17 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        pad_handshake, split_message, FlushMessageList, \
-        TCPBufferingEnable, TCPBufferingDisable, TCPBufferingFlush
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    pad_handshake, split_message, FlushMessageList, \
+    TCPBufferingEnable, TCPBufferingDisable, TCPBufferingFlush
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, ExpectNoMessage
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, ExpectNoMessage
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
-
+    ExtensionType
 
 version = 4
 
@@ -47,7 +46,6 @@ def help_msg():
 
 
 def main():
-
     #
     # Test if client hello with garbage at the end gets rejected
     #
@@ -118,7 +116,7 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(pad_handshake(ClientHelloGenerator(ciphers,
-                                               extensions={}),
+                                                             extensions={}),
                                         # empty renegotiation info
                                         pad=bytearray(b'\xff\x01\x00\x01\x00')))
     # responding to a malformed client hello is not correct, but tested below
@@ -129,41 +127,40 @@ def main():
 
     conversations["extension past extensions"] = conversation
 
-
     for name, pad_len, pad_byte in [
-                                ("small pad", 1, 0),
-                                ("small pad", 2, 0),
-                                ("small pad", 3, 0),
-                                ("small pad", 1, 0xff),
-                                ("small pad", 2, 0xff),
-                                ("small pad", 3, 0xff),
-                                ("medium pad", 256, 0),
-                                ("large pad", 4096, 0),
-                                ("big pad", 2**16, 0),
-                                ("huge pad", 2**17+512, 0),
-                                ("max pad", 2**24-1-48, 0),
-                                ("small truncate", -1, 0),
-                                ("small truncate", -2, 0),
-                                ("small truncate", -3, 0),
-                                ("small truncate", -4, 0),
-                                ("small truncate", -5, 0),
-                                ("small truncate", -6, 0),
-                                # 7 bytes truncates whole 'extensions' creating
-                                # a valid message
-                                #("small truncate", -7, 0),
-                                ("hello truncate", -8, 0),
-                                ("hello truncate", -9, 0),
-                                ("hello truncate", -10, 0),
-                                ("hello truncate", -11, 0),
-                                ("hello truncate", -12, 0),
-                                ("hello truncate", -13, 0),
-                                ("hello truncate", -32, 0),
-                                ("hello truncate", -39, 0),
-                                # truncate so that only one byte...
-                                ("hello truncate", -47, 0),
-                                # ...or no message remains
-                                ("full message truncate", -48, 0)
-                                ]:
+        ("small pad", 1, 0),
+        ("small pad", 2, 0),
+        ("small pad", 3, 0),
+        ("small pad", 1, 0xff),
+        ("small pad", 2, 0xff),
+        ("small pad", 3, 0xff),
+        ("medium pad", 256, 0),
+        ("large pad", 4096, 0),
+        ("big pad", 2 ** 16, 0),
+        ("huge pad", 2 ** 17 + 512, 0),
+        ("max pad", 2 ** 24 - 1 - 48, 0),
+        ("small truncate", -1, 0),
+        ("small truncate", -2, 0),
+        ("small truncate", -3, 0),
+        ("small truncate", -4, 0),
+        ("small truncate", -5, 0),
+        ("small truncate", -6, 0),
+        # 7 bytes truncates whole 'extensions' creating
+        # a valid message
+        # ("small truncate", -7, 0),
+        ("hello truncate", -8, 0),
+        ("hello truncate", -9, 0),
+        ("hello truncate", -10, 0),
+        ("hello truncate", -11, 0),
+        ("hello truncate", -12, 0),
+        ("hello truncate", -13, 0),
+        ("hello truncate", -32, 0),
+        ("hello truncate", -39, 0),
+        # truncate so that only one byte...
+        ("hello truncate", -47, 0),
+        # ...or no message remains
+        ("full message truncate", -48, 0)
+    ]:
 
         conversation = Connect(host, port)
         node = conversation
@@ -173,10 +170,10 @@ def main():
                                                  extensions={ExtensionType.renegotiation_info: None}),
                             pad_len, pad_byte)
         fragments = []
-        node = node.add_child(split_message(msg, fragments, 2**14))
+        node = node.add_child(split_message(msg, fragments, 2 ** 14))
         node = node.add_child(ExpectNoMessage())
         node.next_sibling = ExpectAlert(AlertLevel.fatal,
-                                         AlertDescription.decode_error)
+                                        AlertDescription.decode_error)
         node.next_sibling.add_child(ExpectClose())
         node = node.add_child(TCPBufferingEnable())
         node = node.add_child(FlushMessageList(fragments))
@@ -210,7 +207,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -240,12 +237,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -263,14 +260,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -279,6 +276,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-truncating-of-finished.py
+++ b/scripts/test-truncating-of-finished.py
@@ -10,18 +10,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, pad_handshake, truncate_handshake
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, pad_handshake, truncate_handshake
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -44,7 +45,6 @@ def help_msg():
 
 
 def main():
-
     #
     # Test sending invalid (too short or too long) Finished messages
     #
@@ -110,21 +110,21 @@ def main():
 
     conver = Connect(host, port)
     node = conver
-    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    # ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
     #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
     node = node.add_child(ChangeCipherSpecGenerator())
     node = node.add_child(pad_handshake(FinishedGenerator(), pad=bytearray(b'\xfa')))
-    #node = node.add_child(ExpectChangeCipherSpec())
-    #node = node.add_child(ExpectFinished())
+    # node = node.add_child(ExpectChangeCipherSpec())
+    # node = node.add_child(ExpectFinished())
 
-    #node = node.add_child(AlertGenerator(AlertLevel.warning,
+    # node = node.add_child(AlertGenerator(AlertLevel.warning,
     #                                     AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -133,21 +133,21 @@ def main():
 
     conver = Connect(host, port)
     node = conver
-    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    # ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
     #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
     node = node.add_child(ChangeCipherSpecGenerator())
     node = node.add_child(truncate_handshake(FinishedGenerator(), 1))
-    #node = node.add_child(ExpectChangeCipherSpec())
-    #node = node.add_child(ExpectFinished())
+    # node = node.add_child(ExpectChangeCipherSpec())
+    # node = node.add_child(ExpectFinished())
 
-    #node = node.add_child(AlertGenerator(AlertLevel.warning,
+    # node = node.add_child(AlertGenerator(AlertLevel.warning,
     #                                     AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
@@ -171,7 +171,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -201,12 +201,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -222,14 +222,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -238,6 +238,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-truncating-of-kRSA-client-key-exchange.py
+++ b/scripts/test-truncating-of-kRSA-client-key-exchange.py
@@ -10,18 +10,19 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        ResetHandshakeHashes, pad_handshake, truncate_handshake
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    ResetHandshakeHashes, pad_handshake, truncate_handshake
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -110,20 +111,20 @@ def main():
 
     conver = Connect(host, port)
     node = conver
-    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    # ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
     #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(pad_handshake(ClientKeyExchangeGenerator(), 1))
-    #node = node.add_child(ChangeCipherSpecGenerator())
-    #node = node.add_child(FinishedGenerator())
-    #node = node.add_child(ExpectChangeCipherSpec())
-    #node = node.add_child(ExpectFinished())
-    #node = node.add_child(AlertGenerator(AlertLevel.warning, AlertDescription.close_notify))
+    # node = node.add_child(ChangeCipherSpecGenerator())
+    # node = node.add_child(FinishedGenerator())
+    # node = node.add_child(ExpectChangeCipherSpec())
+    # node = node.add_child(ExpectFinished())
+    # node = node.add_child(AlertGenerator(AlertLevel.warning, AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
 
@@ -131,20 +132,20 @@ def main():
 
     conver = Connect(host, port)
     node = conver
-    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    # ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
     #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None}))
-    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+                                               extensions={ExtensionType.renegotiation_info: None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(truncate_handshake(ClientKeyExchangeGenerator(), 1))
-    #node = node.add_child(ChangeCipherSpecGenerator())
-    #node = node.add_child(FinishedGenerator())
-    #node = node.add_child(ExpectChangeCipherSpec())
-    #node = node.add_child(ExpectFinished())
-    #node = node.add_child(AlertGenerator(AlertLevel.warning, AlertDescription.close_notify))
+    # node = node.add_child(ChangeCipherSpecGenerator())
+    # node = node.add_child(FinishedGenerator())
+    # node = node.add_child(ExpectChangeCipherSpec())
+    # node = node.add_child(ExpectFinished())
+    # node = node.add_child(AlertGenerator(AlertLevel.warning, AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
 
@@ -167,7 +168,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -197,12 +198,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -218,14 +219,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -234,6 +235,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-unsupported-curve-fallback.py
+++ b/scripts/test-unsupported-curve-fallback.py
@@ -12,19 +12,20 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
-        ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+    ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, GroupName
+    ExtensionType, GroupName
 from tlslite.extensions import SupportedGroupsExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -90,15 +91,15 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
                CipherSuite.TLS_DHE_RSA_WITH_AES_256_GCM_SHA384]
-    ext = {ExtensionType.renegotiation_info:None,
-           ExtensionType.supported_groups:SupportedGroupsExtension()
-                .create([GroupName.secp160k1])}
+    ext = {ExtensionType.renegotiation_info: None,
+           ExtensionType.supported_groups: SupportedGroupsExtension()
+               .create([GroupName.secp160k1])}
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     node = node.add_child(ExpectServerHello(cipher=CipherSuite.
                                             TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
                                             , extensions={ExtensionType.
-                                                     renegotiation_info:None}))
+                                            renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerKeyExchange())
     node = node.add_child(ExpectServerHelloDone())
@@ -158,7 +159,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -188,12 +189,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -209,14 +210,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -224,6 +225,7 @@ def main():
         print("FAILED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-version-numbers.py
+++ b/scripts/test-version-numbers.py
@@ -11,17 +11,18 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType
+    ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -109,10 +110,10 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None},
+                                               extensions={ExtensionType.renegotiation_info: None},
                                                version=(254, 254)))
     node = node.add_child(ExpectServerHello(version=(3, 3),
-                                            extensions={ExtensionType.renegotiation_info:None}))
+                                            extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -133,7 +134,7 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None},
+                                               extensions={ExtensionType.renegotiation_info: None},
                                                version=(0, 0)))
     node = node.add_child(ExpectAlert(description=AlertDescription.protocol_version))
     node = node.add_child(ExpectClose())
@@ -144,10 +145,10 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None},
+                                               extensions={ExtensionType.renegotiation_info: None},
                                                version=(3, 3)))
     node = node.add_child(ExpectServerHello(version=(3, 3),
-                                            extensions={ExtensionType.renegotiation_info:None}))
+                                            extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -168,10 +169,10 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None},
+                                               extensions={ExtensionType.renegotiation_info: None},
                                                version=(3, 3)))
     node = node.add_child(ExpectServerHello(version=(3, 3),
-                                            extensions={ExtensionType.renegotiation_info:None}))
+                                            extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -192,10 +193,10 @@ def main():
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.renegotiation_info:None},
+                                               extensions={ExtensionType.renegotiation_info: None},
                                                version=(254, 254)))
     node = node.add_child(ExpectServerHello(version=(3, 3),
-                                            extensions={ExtensionType.renegotiation_info:None}))
+                                            extensions={ExtensionType.renegotiation_info: None}))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())
     node = node.add_child(ClientKeyExchangeGenerator())
@@ -229,7 +230,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -259,12 +260,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -280,14 +281,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -296,6 +297,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-x25519.py
+++ b/scripts/test-x25519.py
@@ -11,22 +11,22 @@ from random import sample
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
-        TCPBufferingEnable, TCPBufferingFlush, \
-        TCPBufferingDisable
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    TCPBufferingEnable, TCPBufferingFlush, \
+    TCPBufferingDisable
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectApplicationData, ExpectClose, \
-        ExpectServerKeyExchange
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        ExtensionType, HashAlgorithm, SignatureAlgorithm, GroupName, \
-        ECPointFormat
+    ExtensionType, HashAlgorithm, SignatureAlgorithm, GroupName, \
+    ECPointFormat
 from tlslite.utils.x25519 import X25519_ORDER_SIZE, X448_ORDER_SIZE
 from tlslite.extensions import SignatureAlgorithmsExtension, TLSExtension, \
-        SupportedGroupsExtension, ECPointFormatsExtension, \
-        SignatureAlgorithmsCertExtension
+    SupportedGroupsExtension, ECPointFormatsExtension, \
+    SignatureAlgorithmsCertExtension
 from tlslite.utils.cryptomath import numberToByteArray
 from tlsfuzzer.helpers import RSA_SIG_ALL
 from tlsfuzzer.utils.lists import natural_sort_keys
@@ -108,14 +108,14 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.secp256r1,
               GroupName.secp384r1,
               GroupName.secp521r1]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -151,9 +151,9 @@ def main():
                 (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
                 (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
         ext = {ExtensionType.signature_algorithms:
-                SignatureAlgorithmsExtension().create(sigs),
+                   SignatureAlgorithmsExtension().create(sigs),
                ExtensionType.signature_algorithms_cert:
-                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -222,9 +222,9 @@ def main():
                 (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
                 (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
         ext = {ExtensionType.signature_algorithms:
-                SignatureAlgorithmsExtension().create(sigs),
+                   SignatureAlgorithmsExtension().create(sigs),
                ExtensionType.signature_algorithms_cert:
-                SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+                   SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -288,12 +288,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.sect163k1]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -329,12 +329,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [11200]  # unknown ECDHE group
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -370,12 +370,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [11200]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -393,13 +393,13 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x25519,
               GroupName.x448]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -432,13 +432,13 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x25519,
               GroupName.x448]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -470,16 +470,16 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.ec_point_formats] = \
-            ECPointFormatsExtension().create([ECPointFormat.ansiX962_compressed_prime,
-                                              ECPointFormat.ansiX962_compressed_char2,
-                                              ECPointFormat.uncompressed])
+        ECPointFormatsExtension().create([ECPointFormat.ansiX962_compressed_prime,
+                                          ECPointFormat.ansiX962_compressed_char2,
+                                          ECPointFormat.uncompressed])
     groups = [GroupName.x25519]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -511,14 +511,14 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.ec_point_formats] = \
-            ECPointFormatsExtension().create([ECPointFormat.uncompressed])
+        ECPointFormatsExtension().create([ECPointFormat.uncompressed])
     groups = [GroupName.x25519]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -550,12 +550,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x25519]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -587,12 +587,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x448]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -625,12 +625,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x25519]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -659,12 +659,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x25519]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -695,12 +695,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x25519]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -735,12 +735,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x25519]  # ecdh_x25519
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -772,12 +772,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x448]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -807,12 +807,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x448]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -841,12 +841,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x448]  # ecdh_x448
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -876,12 +876,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x25519]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -911,12 +911,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x448]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -946,12 +946,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x25519]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -981,12 +981,12 @@ def main():
             (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
             (HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
     ext = {ExtensionType.signature_algorithms:
-            SignatureAlgorithmsExtension().create(sigs),
+               SignatureAlgorithmsExtension().create(sigs),
            ExtensionType.signature_algorithms_cert:
-            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
+               SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     groups = [GroupName.x448]
     ext[ExtensionType.supported_groups] = \
-            SupportedGroupsExtension().create(groups)
+        SupportedGroupsExtension().create(groups)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     node = node.add_child(ClientHelloGenerator(ciphers,
@@ -1007,7 +1007,6 @@ def main():
     node = node.add_child(ExpectClose())
     conversations["x448 key share of \"1\""] = conversation
 
-
     # run the conversation
     good = 0
     bad = 0
@@ -1025,7 +1024,7 @@ def main():
         if num_limit > len(run_only):
             num_limit = len(run_only)
         regular_tests = [(k, v) for k, v in conversations.items() if
-                          k in run_only]
+                         k in run_only]
     else:
         regular_tests = [(k, v) for k, v in conversations.items() if
                          (k != 'sanity') and k not in run_exclude]
@@ -1055,12 +1054,12 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
@@ -1079,14 +1078,14 @@ def main():
     print(20 * '=')
     print("version: {0}".format(version))
     print(20 * '=')
-    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("TOTAL: {0}".format(len(sampled_tests) + 2 * len(sanity_tests)))
     print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
     print("PASS: {0}".format(good))
     print("XFAIL: {0}".format(xfail))
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -1094,6 +1093,7 @@ def main():
         print("FAILED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test-zero-length-data.py
+++ b/scripts/test-zero-length-data.py
@@ -11,16 +11,18 @@ import getopt
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
-        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
-        FinishedGenerator, ApplicationDataGenerator, \
-        AlertGenerator
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, \
+    AlertGenerator
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
-        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectClose, ExpectApplicationData
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription
 from tlsfuzzer.utils.lists import natural_sort_keys
+
 version = 2
+
 
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
@@ -102,7 +104,7 @@ def main():
     node = node.add_child(ExpectClose())
 
     conversations["zero-length app data"] = \
-            conversation
+        conversation
 
     # run the conversation
     good = 0
@@ -126,9 +128,9 @@ def main():
 
         res = True
         exception = None
-        #because we don't want to abort the testing and we are reporting
-        #the errors to the user, using a bare except is OK
-        #pylint: disable=bare-except
+        # because we don't want to abort the testing and we are reporting
+        # the errors to the user, using a bare except is OK
+        # pylint: disable=bare-except
         try:
             runner.run()
         except Exception as exp:
@@ -136,7 +138,7 @@ def main():
             print("Error while processing")
             print(traceback.format_exc())
             res = False
-        #pylint: enable=bare-except
+        # pylint: enable=bare-except
 
         if c_name in expected_failures:
             if res:
@@ -144,21 +146,21 @@ def main():
                 xpassed.append(c_name)
                 print("XPASS-expected failure but test passed\n")
             else:
-                if expected_failures[c_name] is not None and  \
-                    expected_failures[c_name] not in str(exception):
-                        bad += 1
-                        failed.append(c_name)
-                        print("Expected error message: {0}\n"
-                            .format(expected_failures[c_name]))
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
         else:
             if res:
-                good+=1
+                good += 1
                 print("OK")
             else:
-                bad+=1
+                bad += 1
 
     print("Test end")
     print(20 * '=')
@@ -171,7 +173,7 @@ def main():
     print("FAIL: {0}".format(bad))
     print("XPASS: {0}".format(xpass))
     print(20 * '=')
-    sort = sorted(xpassed ,key=natural_sort_keys)
+    sort = sorted(xpassed, key=natural_sort_keys)
     if len(sort):
         print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
     sort = sorted(failed, key=natural_sort_keys)
@@ -180,6 +182,7 @@ def main():
 
     if bad > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
…definition

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Corrected PEP 8: E305 expected 2 blank lines after class or function

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/757)
<!-- Reviewable:end -->
