### PR TITLE
Resume with wrong ciphers: enable for DH ciphers

### DIFF
--- a/scripts/test-resumption-with-wrong-ciphers.py
+++ b/scripts/test-resumption-with-wrong-ciphers.py
@@ -47,6 +47,8 @@ def help_msg():
     print("                (excluding \"sanity\" tests)")
     print(" -d             negotiate (EC)DHE instead of RSA key exchange")
     print(" --swap-ciphers expect the server to pick AES-128 over AES-256")
+    print(" --n/n-1        expect n/n-1 record splitting (should be used")
+    print("                for TLS 1.0 and earlier only)")
     print(" --help         this message")
 
 
@@ -60,9 +62,11 @@ def main():
     last_exp_tmp = None
     swap_ciphers = False
     dhe = False
+    splitting = False
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:x:X:n:d", ["help", "swap-ciphers"])
+    opts, args = getopt.getopt(argv, "h:p:e:x:X:n:d", ["help", "swap-ciphers",
+                                                       "n/n-1"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -83,6 +87,8 @@ def main():
             swap_ciphers = True
         elif opt == '-d':
             dhe = True
+        elif opt == "--n/n-1":
+            splitting = True
         elif opt == '--help':
             help_msg()
             sys.exit(0)
@@ -130,6 +136,8 @@ def main():
     node = node.add_child(ApplicationDataGenerator(
         bytearray(b"GET / HTTP/1.0\r\n\r\n")))
     node = node.add_child(ExpectApplicationData())
+    if splitting:
+        node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
@@ -170,6 +178,8 @@ def main():
     node = node.add_child(ApplicationDataGenerator(
         bytearray(b"GET / HTTP/1.0\r\n\r\n")))
     node = node.add_child(ExpectApplicationData())
+    if splitting:
+        node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
@@ -249,6 +259,8 @@ def main():
     node = node.add_child(ApplicationDataGenerator(
         bytearray(b"GET / HTTP/1.0\n\n")))
     node = node.add_child(ExpectApplicationData())
+    if splitting:
+        node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())

--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -231,6 +231,42 @@ class TestExpectHandshake(unittest.TestCase):
 
         self.assertFalse(ret)
 
+    def test__cmp_eq_or_in(self):
+        ret = ExpectHandshake._cmp_eq_or_in([2, 3, 4], 3)
+
+        self.assertIsNone(ret)
+
+    def test__cmp_eq_or_in_with_None(self):
+        ret = ExpectHandshake._cmp_eq_or_in(None, 3)
+
+        self.assertIsNone(ret)
+
+    def test__cmp_eq_or_in_not_matching(self):
+        with self.assertRaises(AssertionError) as e:
+            ExpectHandshake._cmp_eq_or_in([2, 3, 4], 1)
+
+        self.assertIn("[2, 3, 4]", str(e.exception))
+        self.assertIn("not in expected", str(e.exception))
+        self.assertIn("1", str(e.exception))
+
+    def test__cmp_eq_or_in_mismatch_with_type(self):
+        with self.assertRaises(AssertionError) as e:
+            ExpectHandshake._cmp_eq_or_in(
+                [HandshakeType.client_hello,
+                 HandshakeType.server_hello],
+                HandshakeType.server_key_exchange,
+                field_type=HandshakeType)
+
+        self.assertIn("client_hello, server_hello", str(e.exception))
+        self.assertIn("server_key_exchange", str(e.exception))
+
+    def test__cmp_eq_or_in_mismatch_with_format_string(self):
+        with self.assertRaises(AssertionError) as e:
+            ExpectHandshake._cmp_eq_or_in([2, 3], 1,
+                f_str="our: {0}, ext: {1}")
+
+        self.assertIn("our: [2, 3], ext: 1", str(e.exception))
+
     def test__cmp_eq_list_no_type(self):
         ret = ExpectHandshake._cmp_eq_list((1, 2), (1, 2))
 

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -229,6 +229,8 @@
                          "-k", "tests/serverX509Key.pem",
                          "-c", "tests/serverX509Cert.pem"]},
          {"name" : "test-resumption-with-wrong-ciphers.py"},
+         {"name" : "test-resumption-with-wrong-ciphers.py",
+          "arguments" : ["-d"]},
          {"name" : "test-serverhello-random.py",
           "arguments" : ["-x", "Protocol (3, 0)", "-X", "protocol_version",
                          "-x", "Protocol (3, 0) in SSLv2 compatible ClientHello",

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -230,6 +230,8 @@
                          "-k", "tests/serverX509Key.pem",
                          "-c", "tests/serverX509Cert.pem"]},
          {"name" : "test-resumption-with-wrong-ciphers.py"},
+         {"name" : "test-resumption-with-wrong-ciphers.py",
+          "arguments" : ["-d"]},
          {"name" : "test-serverhello-random.py",
           "arguments" : ["-x", "Protocol (3, 0)", "-X", "protocol_version",
                          "-x", "Protocol (3, 0) in SSLv2 compatible ClientHello",


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Allow execution of `test-resumption-with-wrong-ciphers.py` against servers that don't support RSA key exchange.

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
work towards #563

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/759)
<!-- Reviewable:end -->
