### PR TITLE
docs: install just gmpy2

### DIFF
--- a/docs/source/timing-analysis.rst
+++ b/docs/source/timing-analysis.rst
@@ -85,7 +85,7 @@ Then you can install tlsfuzzer dependencies to speed-up the test execution:
    dnf install python3 python3-devel tcpdump gmp-devel swig mpfr-devel \
    libmpc openssl-devel make gcc gcc-c++ git libmpc-devel python3-six
 
-   pip3 install m2crypto gmpy gmpy2
+   pip3 install m2crypto gmpy2
    pip3 install --pre tlslite-ng
 
 And the general requirements to collect and analyse timing results:
@@ -98,7 +98,7 @@ And the general requirements to collect and analyse timing results:
 
    Because the tests use packet capture to collect timing information and
    they buffer the messages until all of them have been created, the use
-   of ``m2crypto``, ``gmpy`` and ``gmpy2`` does not have an effect on collected
+   of ``m2crypto`` and ``gmpy2`` does not have an effect on collected
    data points, using them will only make tlsfuzzer run the tests at a higher
    frequency.
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
gmpy2 is slightly faster and now both tlslite-ng and python-ecdsa use
it in preference to gmpy, so there's no point in installing gmpy

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
easier/faster environment setup for timing tests

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/770)
<!-- Reviewable:end -->
