### PR TITLE
lucky13 - run a group only if there are actual tests to execute

### DIFF
--- a/scripts/test-lucky13.py
+++ b/scripts/test-lucky13.py
@@ -29,7 +29,7 @@ from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import SIG_ALL
 
 
-version = 6
+version = 7
 
 
 def help_msg():
@@ -413,15 +413,21 @@ def main():
         # make sure that sanity test is run first and last
         # to verify that server was running and kept running throughout
         sanity_tests = [('sanity', conversations['sanity'])]
-        regular_tests = [(k, v) for k, v in conversations.items() if k != 'sanity']
+        if run_only:
+            if num_limit > len(run_only):
+                num_limit = len(run_only)
+            regular_tests = [(k, v) for k, v in conversations.items() if k in run_only]
+        else:
+            regular_tests = [(k, v) for k, v in conversations.items() if
+                             (k != 'sanity') and k not in run_exclude]
         sampled_tests = sample(regular_tests, min(num_limit, len(regular_tests)))
         ordered_tests = chain(sanity_tests, sampled_tests, sanity_tests)
+        if not sampled_tests:
+            continue
 
         print("Running tests for {0}".format(CipherSuite.ietfNames[cipher]))
 
         for c_name, c_test in ordered_tests:
-            if run_only and c_name not in run_only or c_name in run_exclude:
-                continue
             print("{0} ...".format(c_name))
 
             runner = Runner(c_test)


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
there are two groups of scripts that are executed without the `--quick` option, when the specific conversation names are
specified the script tries to execute two groups, giving confusing result

this fixes it, executing the group only when there are conversations other than `sanity` to execute

this also fixes the handling of running specific conversations to be in line with `test-conversation.py` (i.e. when a name is provided, it's always executed, not when it happens to be selected in the sample)

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
usability/consistency with other scripts

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/771)
<!-- Reviewable:end -->
