### PR TITLE
tlsfuzzer/expect.py: use collections.abc.Iterable

### DIFF
--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -4,7 +4,6 @@
 """Parsing and processing of received TLS messages"""
 from __future__ import print_function
 
-import collections
 import itertools
 from functools import partial
 import sys
@@ -39,6 +38,14 @@ from .handshake_helpers import calc_pending_states, kex_for_group, \
         curve_name_to_hash_tls13
 from .helpers import ECDSA_SIG_TLS1_3_ALL
 from .tree import TreeNode
+
+if sys.version_info >= (3, 3):
+    # pylint: disable=ungrouped-imports,import-error,no-name-in-module
+    from collections.abc import Iterable
+else:
+    # pylint: disable=ungrouped-imports,import-error,no-name-in-module
+    # pylint: disable=deprecated-class
+    from collections import Iterable
 
 
 class Expect(TreeNode):
@@ -1818,7 +1825,7 @@ class ExpectAlert(Expect):
                                                             self.level)
         if self.description is not None:
             # allow for multiple choice for description
-            if not isinstance(self.description, collections.Iterable):
+            if not isinstance(self.description, Iterable):
                 self.description = tuple([self.description])
 
             if alert.description not in self.description:


### PR DESCRIPTION
`tlsfuzzer/expect.py`: use `collections.abc.Iterable`

### Description
Use `collections.abc.Iterable` on Python 3.3+.

### Motivation and Context
Python 3.9 has deprecated, Python 3.10 has removed accessing ABCs directly from `collections`.

Resolves: #766

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/772)
<!-- Reviewable:end -->
