### PR TITLE
support/test Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
           - name: py3.9
             os: ubuntu-latest
             python-version: 3.9
+          - name: py3.10
+            os: ubuntu-latest
+            python-version: '3.10.0-rc.1'
           # also test with extraction tooling installed
           - name: py2.6 with extract
             os: ubuntu-latest
@@ -78,6 +81,10 @@ jobs:
             os: ubuntu-latest
             python-version: 3.9
             opt-deps: ['extract']
+          - name: py3.10 with extract
+            os: ubuntu-latest
+            python-version: '3.10.0-rc.1'
+            opt-deps: ['extract']
           # also test with just analysis tooling installed
           - name: py3.6 with analysis
             os: ubuntu-18.04
@@ -95,6 +102,10 @@ jobs:
             os: ubuntu-latest
             python-version: 3.9
             opt-deps: ['analysis']
+          - name: py3.10 with analysis
+            os: ubuntu-latest
+            python-version: '3.10.0-rc.1'
+            opt-deps: ['analysis']
           # and with both extract and analysis
           - name: py3.6 with extract and analysis
             os: ubuntu-18.04
@@ -111,6 +122,10 @@ jobs:
           - name: py3.9 with extract and analysis
             os: ubuntu-latest
             python-version: 3.9
+            opt-deps: ['extract', 'analysis']
+          - name: py3.10 with extract and analysis
+            os: ubuntu-latest
+            python-version: '3.10.0-rc.1'
             # note: codeclimate can be specified in only one environment
             opt-deps: ['extract', 'analysis', 'codeclimate']
     steps:
@@ -195,8 +210,11 @@ jobs:
         if: ${{ !matrix.container }}
         run: sudo apt-get install -y libmpfr-dev libmpc-dev libgmp-dev
       - name: Install gmpy2
-        if: ${{ !matrix.container }}
+        if: ${{ !matrix.container && matrix.python-version != '3.10.0-rc.1' }}
         run: pip install gmpy2
+      - name: Install gmpy2 2.1.0b6 (3.10)
+        if: ${{ !matrix.container && matrix.python-version == '3.10.0-rc.1' }}
+        run: pip install git+https://github.com/aleaxit/gmpy@gmpy2-2.1.0b6
       - name: Install M2Crypto dependencies
         if: ${{ !matrix.container }}
         run: sudo apt-get install -y swig libssl-dev
@@ -325,6 +343,8 @@ jobs:
           # https://github.com/python/cpython/blob/2c050e52f1ccf5db03819e4ed70690521d67e9fa/Lib/http/server.py#L253
           if [[ $PYTHON_VERSION == '2.7' || $PYTHON_VERSION == '3.4' || $PYTHON_VERSION == '3.5' || $PYTHON_VERSION == '3.6' || $PYTHON_VERSION == '3.7' || $PYTHON_VERSION == '3.8' ]]; then
             export REPLY_SIZE=1850
+          elif [[ $PYTHON_VERSION == '3.10.0-rc.1' ]]; then
+            export REPLY_SIZE=1853  # Server: SimpleHTTP/0.6 Python/3.10.0rc1
           elif [[ $PYTHON_VERSION == 'nightly' ]]; then
             export REPLY_SIZE=1852  # Server: SimpleHTTP/0.6 Python/3.10.0a0
           else

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -4,7 +4,6 @@
 """Parsing and processing of received TLS messages"""
 from __future__ import print_function
 
-import collections
 import itertools
 from functools import partial
 import sys
@@ -39,6 +38,15 @@ from .handshake_helpers import calc_pending_states, kex_for_group, \
         curve_name_to_hash_tls13
 from .helpers import ECDSA_SIG_TLS1_3_ALL
 from .tree import TreeNode
+
+# pylint: disable=import-error,no-name-in-module
+# pylint: disable=bad-option-value,deprecated-class
+if sys.version_info >= (3, 3):
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
+# pylint: enable=bad-option-value,deprecated-class
+# pylint: enable=import-error,no-name-in-module
 
 
 class Expect(TreeNode):
@@ -1818,7 +1826,7 @@ class ExpectAlert(Expect):
                                                             self.level)
         if self.description is not None:
             # allow for multiple choice for description
-            if not isinstance(self.description, collections.Iterable):
+            if not isinstance(self.description, Iterable):
                 self.description = tuple([self.description])
 
             if alert.description not in self.description:


### PR DESCRIPTION
Python 3.9 has deprecated, Python 3.10 has removed accessing ABCs
directly from collections. Use collections.abc.Iterable on 3.3+.

### Description

Import `Iterable` from `collections.abc` on supported versions.

Enable Python 3.10 in CI.

### Motivation and Context
Resolves: #766

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/773)
<!-- Reviewable:end -->
