### PR TITLE
lucky13: make test work with (EC)DHE ciphers

### DIFF
--- a/scripts/test-lucky13.py
+++ b/scripts/test-lucky13.py
@@ -167,10 +167,10 @@ def main():
     ext[ExtensionType.signature_algorithms_cert] = \
         SignatureAlgorithmsCertExtension().create(SIG_ALL)
     if dhe:
-        groups = [GroupName.secp256r1,
+        sup_groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
         ext[ExtensionType.supported_groups] = SupportedGroupsExtension() \
-            .create(groups)
+            .create(sup_groups)
 
     # first run sanity test and verify that server supports this ciphersuite
     conversation = Connect(host, port)

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -188,6 +188,8 @@
           "exp_pass" : false},
          {"name":  "test-lucky13.py",
           "arguments" :  ["--quick"]},
+         {"name":  "test-lucky13.py",
+          "arguments" :  ["--quick", "-C", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"]},
          {"name" : "test-message-duplication.py"},
          {"name" : "test-message-skipping.py"},
          {"name" : "test-message-skipping.py",

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -189,6 +189,8 @@
           "exp_pass" : false},
          {"name":  "test-lucky13.py",
           "arguments" :  ["--quick"]},
+         {"name":  "test-lucky13.py",
+          "arguments" :  ["--quick", "-C", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"]},
          {"name" : "test-message-duplication.py"},
          {"name" : "test-message-skipping.py"},
          {"name" : "test-message-skipping.py",


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
fix the -C option in test-lucky13.py to work with DHE and ECDHE ciphers

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
the only ciphers that use PKI authentication with AES_256 and SHA_384 use DH or ECDH key exchange

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/774)
<!-- Reviewable:end -->
