### PR TITLE
scripts_retention.py: don't override PYTHONPATH if already set

### DIFF
--- a/tests/scripts_retention.py
+++ b/tests/scripts_retention.py
@@ -155,7 +155,8 @@ def run_clients(tests, common_args, srv, expected_size):
                      arg in arguments]
         proc_args.extend(common_args + arguments)
         my_env = os.environ.copy()
-        my_env["PYTHONPATH"]="."
+        path = my_env.get("PYTHONPATH")
+        my_env["PYTHONPATH"] = ".:{0}".format(path) if path else "."
         proc = Popen(proc_args, env=my_env,
                      stdout=PIPE, stderr=PIPE, bufsize=1)
         thr_stdout = Thread(target=process_stdout, args=(script, proc))


### PR DESCRIPTION
To use scripts_retention.py in TLS library test suite, tlslite-ng
needs to be visible to the script; typically this can be done either
by using pip or create a symlink inside tlsfuzzer submodule:
https://gitlab.com/gnutls/gnutls/-/blob/3.7.2/tests/suite/tls-fuzzer/tls-fuzzer-common.sh#L43

While the latter is preferred in CI environment (because it allows a
specific tlslite-ng revision to be pinned), it's still not ideal to
modify the tlsfuzzer submodule checkout.  This patch adds the third
option: the user can adjust PYTHONPATH before running the script,
which was previously not possible because of PYTHONPATH override in
the script itself.

Signed-off-by: Daiki Ueno <dueno@redhat.com>

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/775)
<!-- Reviewable:end -->
