### PR TITLE
ExpectAlert - add __repr__

### DIFF
--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -3104,6 +3104,12 @@ class TestExpectAlert(unittest.TestCase):
                          "not match received "
                          "\"255\"")
 
+    def test___str__(self):
+        exp = ExpectAlert(AlertLevel.warning,
+                          AlertDescription.illegal_parameter)
+
+        self.assertEqual(str(exp), "ExpectAlert(level=1, description=47)")
+
 
 class TestExpectSSL2Alert(unittest.TestCase):
     def test___init__(self):

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -1845,6 +1845,10 @@ class ExpectAlert(Expect):
         if problem_desc:
             raise AssertionError(problem_desc)
 
+    def __repr__(self):
+        """Return human readable representation of object."""
+        return self._repr(["level", "description"])
+
 
 class ExpectSSL2Alert(ExpectHandshake):
     """Processing of SSLv2 Handshake protocol alert messages"""


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Add support for `repr()` and `str()` over ExpectAlert

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
Make debugging scripts that use multiple ExpectAlert  nodes easier

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/777)
<!-- Reviewable:end -->
