### PR TITLE
ffdhe: add option to set default socket timeout

### DIFF
--- a/scripts/test-ffdhe-expected-params.py
+++ b/scripts/test-ffdhe-expected-params.py
@@ -54,6 +54,8 @@ def help_msg():
     print(" --dhparam      File with the expected DH parameters that the server should use")
     print("                can be used together with --named-ffdh to specify multiple")
     print("                acceptable parameters")
+    print(" -t timeout     how long to wait before assuming the server won't")
+    print("                send a message")
     print(" --help         this message")
 
 
@@ -67,9 +69,10 @@ def main():
     last_exp_tmp = None
     group_names = []
     dh_file = None
+    timeout = 5.0
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:x:X:n:", ["help", "named-ffdh=",
+    opts, args = getopt.getopt(argv, "h:p:e:x:X:t:n:", ["help", "named-ffdh=",
                                                       "dhparam="])
     for opt, arg in opts:
         if opt == '-h':
@@ -94,6 +97,8 @@ def main():
             group_names.append(arg)
         elif opt == '--dhparam':
             dh_file = arg
+        elif opt == '-t':
+            timeout = float(arg)
         else:
             raise ValueError("Unknown option: {0}".format(opt))
 
@@ -121,7 +126,7 @@ def main():
 
     conversations = {}
 
-    conversation = Connect(host, port)
+    conversation = Connect(host, port, timeout=timeout)
     node = conversation
     ext = {ExtensionType.renegotiation_info: None}
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
@@ -155,7 +160,7 @@ def main():
 
     conversations["sanity"] = conversation
 
-    conversation = Connect(host, port)
+    conversation = Connect(host, port, timeout=timeout)
     node = conversation
     ext = {ExtensionType.renegotiation_info: None}
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,

--- a/scripts/test-ffdhe-negotiation.py
+++ b/scripts/test-ffdhe-negotiation.py
@@ -52,6 +52,8 @@ def help_msg():
     print("                usage: [-x probe-name] [-X exception], order is compulsory!")
     print(" -n num         run 'num' or all(if 0) tests instead of default(all)")
     print("                (excluding \"sanity\" tests)")
+    print(" -t timeout     how long to wait before assuming the server won't")
+    print("                send a message")
     print(" --help         this message")
 
 
@@ -65,9 +67,10 @@ def main():
     expected_failures = {}
     last_exp_tmp = None
     sig_algs = None  # `sigalgs` w/o underscore is used for client certificates
+    timeout = 5.0
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:S:e:x:X:n:", ["help", "alert="])
+    opts, args = getopt.getopt(argv, "h:p:S:e:x:X:t:n:", ["help", "alert="])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -91,6 +94,8 @@ def main():
         elif opt == '--help':
             help_msg()
             sys.exit(0)
+        elif opt == '-t':
+            timeout = float(arg)
         else:
             raise ValueError("Unknown option: {0}".format(opt))
 
@@ -101,7 +106,7 @@ def main():
 
     conversations = {}
 
-    conversation = Connect(host, port)
+    conversation = Connect(host, port, timeout=timeout)
     node = conversation
     ext = {ExtensionType.renegotiation_info: None}
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
@@ -133,7 +138,7 @@ def main():
 
     conversations["sanity"] = conversation
 
-    conversation = Connect(host, port)
+    conversation = Connect(host, port, timeout=timeout)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
@@ -168,7 +173,7 @@ def main():
     conversations["Check if DHE preferred"] = conversation
 
     for group in GroupName.allFF:
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
         ext = {ExtensionType.renegotiation_info: None}
@@ -203,7 +208,7 @@ def main():
         conversations["{0} negotiation".format(GroupName.toStr(group))] = \
                 conversation
 
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
         ext = {ExtensionType.renegotiation_info: None}
@@ -238,7 +243,7 @@ def main():
         conversations["unassigned tolerance, {0} negotiation".format(GroupName.toStr(group))] = \
                 conversation
 
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
         ext = {ExtensionType.renegotiation_info: None}
@@ -277,7 +282,7 @@ def main():
         for group2 in GroupName.allFF:
             if group == group2:
                 continue
-            conversation = Connect(host, port)
+            conversation = Connect(host, port, timeout=timeout)
             node = conversation
             ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
             ext = {ExtensionType.renegotiation_info: None}
@@ -314,7 +319,7 @@ def main():
             conversations["{0} or {1} negotiation".format(GroupName.toStr(group),
                     GroupName.toStr(group2))] = conversation
 
-    conversation = Connect(host, port)
+    conversation = Connect(host, port, timeout=timeout)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
@@ -349,7 +354,7 @@ def main():
 
     conversations["fallback to non-ffdhe"] = conversation
 
-    conversation = Connect(host, port)
+    conversation = Connect(host, port, timeout=timeout)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
@@ -385,7 +390,7 @@ def main():
     conversations["fallback to non-ffdhe with secp256r1 advertised"] = conversation
 
     # first paragraph of section 4 in RFC 7919
-    conversation = Connect(host, port)
+    conversation = Connect(host, port, timeout=timeout)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_NULL_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]

--- a/scripts/test-tls13-ffdhe-groups.py
+++ b/scripts/test-tls13-ffdhe-groups.py
@@ -52,6 +52,8 @@ def help_msg():
     print("                usage: [-x probe-name] [-X exception], order is compulsory!")
     print(" -n num         run 'num' or all(if 0) tests instead of default(all)")
     print("                (\"sanity\" tests are always executed)")
+    print(" -t timeout     how long to wait before assuming the server won't")
+    print("                send a message")
     print(" --help         this message")
 
 
@@ -62,9 +64,10 @@ def main():
     run_exclude = set()
     expected_failures = {}
     last_exp_tmp = None
+    timeout = 5.0
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:x:X:n:", ["help"])
+    opts, args = getopt.getopt(argv, "h:p:e:x:X:t:n:", ["help"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -84,6 +87,8 @@ def main():
         elif opt == '--help':
             help_msg()
             sys.exit(0)
+        elif opt == '-t':
+            timeout = float(arg)
         else:
             raise ValueError("Unknown option: {0}".format(opt))
 
@@ -94,7 +99,7 @@ def main():
 
     conversations = {}
 
-    conversation = Connect(host, port)
+    conversation = Connect(host, port, timeout=timeout)
     node = conversation
     ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -137,7 +142,7 @@ def main():
     conversations["sanity"] = conversation
 
     for group in groups:
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -176,7 +181,7 @@ def main():
         conversations["sanity - {0}".format(GroupName.toRepr(group))] = conversation
 
         # duplicated key share entry
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -202,7 +207,7 @@ def main():
                       .format(GroupName.toRepr(group))] = conversation
 
         # padded representation
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -228,7 +233,7 @@ def main():
         # truncated representation (given that all groups use safe primes,
         # any integer between 1 and p-1 is a valid key share, it's just that
         # after truncation we don't know the private key that generates it)
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -252,7 +257,7 @@ def main():
                       .format(GroupName.toRepr(group))] = conversation
 
         # key share from wrong group
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -280,7 +285,7 @@ def main():
                       .format(GroupName.toRepr(group))] = conversation
 
         # just 0
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -303,7 +308,7 @@ def main():
                       .format(GroupName.toRepr(group))] = conversation
 
         # 0 key share
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -327,7 +332,7 @@ def main():
                       .format(GroupName.toRepr(group))] = conversation
 
         # 1 key share
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -352,7 +357,7 @@ def main():
                       .format(GroupName.toRepr(group))] = conversation
 
         # all bits set key share
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -388,7 +393,7 @@ def main():
             params = FFDHE8192
 
         # p-1 key share
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -412,7 +417,7 @@ def main():
                       .format(GroupName.toRepr(group))] = conversation
 
         # p key share
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -436,7 +441,7 @@ def main():
                       .format(GroupName.toRepr(group))] = conversation
 
         # empty key share entry
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]

--- a/scripts/test-tls13-ffdhe-sanity.py
+++ b/scripts/test-tls13-ffdhe-sanity.py
@@ -48,6 +48,8 @@ def help_msg():
     print("                usage: [-x probe-name] [-X exception], order is compulsory!")
     print(" -n num         run 'num' or all(if 0) tests instead of default(all)")
     print("                (excluding \"sanity\" tests)")
+    print(" -t timeout     how long to wait before assuming the server won't")
+    print("                send a message")
     print(" --help         this message")
 
 
@@ -59,9 +61,10 @@ def main():
     expected_failures = {}
     last_exp_tmp = None
     groups = GroupName.allFF
+    timeout = 5.0
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:x:X:n:", ["help"])
+    opts, args = getopt.getopt(argv, "h:p:e:x:X:t:n:", ["help"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -81,6 +84,8 @@ def main():
         elif opt == '--help':
             help_msg()
             sys.exit(0)
+        elif opt == '-t':
+            timeout = float(arg)
         else:
             raise ValueError("Unknown option: {0}".format(opt))
 
@@ -91,7 +96,7 @@ def main():
 
     conversations = {}
 
-    conversation = Connect(host, port)
+    conversation = Connect(host, port, timeout=timeout)
     node = conversation
     ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -136,7 +141,7 @@ def main():
 
     # test specific ones
     for key_share_group in groups:
-        conversation = Connect(host, port)
+        conversation = Connect(host, port, timeout=timeout)
         node = conversation
         ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]


### PR DESCRIPTION
The tests using ffdhe8192 take long time on some CI setup (e.g., with
software emulated GMP) and cause intermittent timeout.  This adds -t
option to control the timeout value from the test invocation.

Signed-off-by: Daiki Ueno <dueno@redhat.com>

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [x] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

Confirmed at:
https://gitlab.com/dueno/gnutls/-/jobs/1903136178

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/782)
<!-- Reviewable:end -->
