### PR TITLE
DHE key share sizes

### DIFF
--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -337,6 +337,7 @@ class CopyVariables(Command):
     ``master_secret``, ``ServerHello.extensions.key_share.key_exchange``,
     ``server handshake traffic secret``, ``exporter master secret``,
     ``ServerKeyExchange.key_share``, ``ServerKeyExchange.dh_p``,
+    ``ClientKeyExchange.dh_Yc``, ``ClientKeyExchange.ecdh_Yc``,
     ``DH shared secret``, ``PSK secret``, ``client_verify_data``,
     ``server_verify_data``, ``client application traffic secret``,
     ``server application traffic secret``,
@@ -809,12 +810,14 @@ class ClientKeyExchangeGenerator(HandshakeProtocolMessageGenerator):
                                             self.version).createDH(ske.dh_p-1)
             else:
                 cke = status.key_exchange.makeClientKeyExchange()
+            status.key['ClientKeyExchange.dh_Yc'] = cke.dh_Yc
         elif self.cipher in CipherSuite.ecdhAllSuites:
             if self.ecdh_Yc is not None:
                 cke = ClientKeyExchange(self.cipher,
                                         self.version).createECDH(self.ecdh_Yc)
             else:
                 cke = status.key_exchange.makeClientKeyExchange()
+            status.key['ClientKeyExchange.ecdh_Yc'] = cke.ecdh_Yc
         else:
             raise AssertionError("Unknown cipher/key exchange type")
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
Test to verify if server will accept a client key share that's not zero-padded

### Description
<!-- Describe your changes in detail below -->
Extend the DHE test case to verify that key shares encoded in smaller number of bytes than needed to encode the used prime are accepted by server

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
https://github.com/openssl/openssl/issues/17834
https://bugzilla.redhat.com/show_bug.cgi?id=2004915

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/789)
<!-- Reviewable:end -->
