### PR TITLE
Add .tlslite-ng, .ecdsa directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ epydoc/
 
 # PyBuilder
 target/
+
+# Project specific ignores (dependencies)
+.tlslite-ng/
+.ecdsa/


### PR DESCRIPTION
### Description

These directories are mentioned in the contributing doc and other
guides; it makes sense to ignore it rather than leaving them for
accidental check-in.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/798)
<!-- Reviewable:end -->
