### PR TITLE
Don't send QUIC transport parameters extension

### DIFF
--- a/scripts/test-tls13-large-number-of-extensions.py
+++ b/scripts/test-tls13-large-number-of-extensions.py
@@ -167,7 +167,8 @@ def main():
     unassigned_ext_id.extend(range(22, 28))
     unassigned_ext_id.extend(range(29, 41))
     unassigned_ext_id.extend([46])
-    unassigned_ext_id.extend(range(52, 65536))
+    unassigned_ext_id.extend(range(52, 57))
+    unassigned_ext_id.extend(range(58, 65536))
 
     # Exclude extensions from a list of unassigned ones
     unassigned_ext_id = [ext for ext in unassigned_ext_id if ext not in ext_exclude]

--- a/scripts/test-tls13-shuffled-extentions.py
+++ b/scripts/test-tls13-shuffled-extentions.py
@@ -191,7 +191,9 @@ def main():
     node.add_child(ExpectClose())
     conversations["HRR reversed order of known extensions"] = conversation
 
-    unassigned_ext_id = list(range(52, 65279))
+    unassigned_ext_id = []
+    unassigned_ext_id.extend(range(52, 57))
+    unassigned_ext_id.extend(range(58, 65279))
 
     # Exclude extensions from a list of unassigned ones
     unassigned_ext_id = [ext for ext in unassigned_ext_id if ext not in ext_exclude]


### PR DESCRIPTION
Extension 57 is now assigned to QUIC transport parameters.
It MUST NOT be sent over a TLS connection and peers supporting
it MUST abort the handshake with an unsupported_extension
alert. This causes test failures in libraries supporting QUIC.


### Motivation and Context
Partial fix for #794. I skipped `test-large-hello.py` since that seems to require changes in tlslite-ng:

https://github.com/tlsfuzzer/tlsfuzzer/blob/6ccf91b2d8eabc9e418c38b26f97d02682e0d91d/scripts/test-large-hello.py#L207-L209 

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see CI results)
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] LibreSSL
  - [x] OpenSSL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/799)
<!-- Reviewable:end -->
