### PR TITLE
fix called_once_with() asserts

### DIFF
--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -3988,7 +3988,7 @@ class TestExpectKeyUpdate(unittest.TestCase):
 
         exp.process(state, ku)
 
-        state.msg_sock.calcTLS1_3PendingState.called_once_with(
+        state.msg_sock.calcTLS1_3KeyUpdate_sender.assert_called_once_with(
             cipher, cats, sats)
         self.assertIs(state.key['server application traffic secret'], ret)
 

--- a/tests/test_tlsfuzzer_messages.py
+++ b/tests/test_tlsfuzzer_messages.py
@@ -116,7 +116,7 @@ class TestClose(unittest.TestCase):
         close = Close()
         close.process(state)
 
-        state.msg_sock.sock.close.called_once_with()
+        state.msg_sock.sock.close.assert_called_once_with()
 
 class TestTCPBufferingEnable(unittest.TestCase):
     def test___init__(self):
@@ -458,9 +458,8 @@ class TestRawSocketWriteGenerator(unittest.TestCase):
 
         msg_gen.process(state)
 
-        self.assertTrue(
-            state.msg_sock._recordSocket.
-            sock.send.called_once_with(b'some data'))
+        state.msg_sock._recordSocket.sock.send.assert_called_once_with(
+            b'some data')
 
 
 class TestPlaintextMessageGenerator(unittest.TestCase):

--- a/tests/test_tlsfuzzer_runner.py
+++ b/tests/test_tlsfuzzer_runner.py
@@ -190,10 +190,11 @@ class TestRunner(unittest.TestCase):
 
         runner.run()
 
-        internal_message = messages.Message(msg[0].type, msg[1].bytes)
-
-        node.is_match.called_once_with(internal_message)
-        node.process.called_once_with(runner.state, internal_message)
+        # as the message they're called with is generated inside the runner
+        # it will be a different object every time, so just assert that
+        # the methods were called
+        node.is_match.assert_called_once()
+        node.process.assert_called_once()
 
     def test_run_with_expect_and_closed_socket(self):
         node = ExpectClose()
@@ -279,7 +280,7 @@ class TestRunner(unittest.TestCase):
         with self.assertRaises(AssertionError):
             runner.run()
 
-        runner.state.msg_sock.sock.close.called_once_with()
+        runner.state.msg_sock.sock.close.assert_called_once_with()
 
     def test_run_with_generate_and_unexpected_closed_socket(self):
         node = mock.MagicMock()

--- a/tlsfuzzer/runner.py
+++ b/tlsfuzzer/runner.py
@@ -229,8 +229,6 @@ class Runner(object):
                     node = next((proc for proc in node.get_all_siblings()
                                  if proc.is_match(msg)), None)
                     if node is None:
-                        # since we're aborting, the user can't clean up
-                        self.state.msg_sock.sock.close()
                         raise AssertionError("Unexpected message from peer: " +
                                              guess_response(\
                                                  msg.contentType,


### PR DESCRIPTION

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
fix assert calls to actually be assets,
the code removed in runner() is a duplicate of code in except: handling block, so close() was actually called twice before

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
new mock raises exceptions when `called_once_with` is used without spec, expecting `assert_called_once_with` instead.

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/806)
<!-- Reviewable:end -->
