### PR TITLE
More ems

### DIFF
--- a/scripts/test-large-number-of-extensions.py
+++ b/scripts/test-large-number-of-extensions.py
@@ -30,7 +30,7 @@ from tlslite.extensions import SupportedGroupsExtension, SignatureAlgorithmsExte
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -51,6 +51,7 @@ def help_msg():
     print(" -X message     expect the `message` substring in exception raised during")
     print("                execution of preceding expected failure probe")
     print("                usage: [-x probe-name] [-X exception], order is compulsory!")
+    print(" -M | --ems     Enable support for Extended Master Secret")
     print(" --help         this message")
 
 
@@ -64,9 +65,10 @@ def main():
     dhe = False
     # max number of extensions
     max_ext = 16382
+    ems = False
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:n:e:x:X:d", ["help"])
+    opts, args = getopt.getopt(argv, "h:p:n:e:x:X:dM", ["help", "ems"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -86,6 +88,8 @@ def main():
             if not last_exp_tmp:
                 raise ValueError("-x has to be specified before -X")
             expected_failures[last_exp_tmp] = str(arg)
+        elif opt == '-M' or opt == '--ems':
+            ems = True
         elif opt == '--help':
             help_msg()
             sys.exit(0)
@@ -105,8 +109,8 @@ def main():
 
     conversation = Connect(host, port)
     node = conversation
+    ext = {}
     if dhe:
-        ext = {}
         groups = [GroupName.secp256r1,
                   GroupName.ffdhe2048]
         ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
@@ -119,12 +123,18 @@ def main():
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     else:
-        ext = None
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
+    if not ext:
+        ext = None
 
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
-    node = node.add_child(ExpectServerHello())
+    ext = {ExtensionType.renegotiation_info: None}
+    if ems:
+        ext[ExtensionType.extended_master_secret] = None
+    node = node.add_child(ExpectServerHello(extensions=ext))
     node = node.add_child(ExpectCertificate())
     if dhe:
         node = node.add_child(ExpectServerKeyExchange())
@@ -161,8 +171,12 @@ def main():
     else:
         ext = {ExtensionType.renegotiation_info: None}
         ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     ext = {ExtensionType.renegotiation_info: None}
+    if ems:
+        ext[ExtensionType.extended_master_secret] = None
     node = node.add_child(ExpectServerHello(extensions=ext))
     node = node.add_child(ExpectCertificate())
     if dhe:
@@ -186,7 +200,7 @@ def main():
               4094, 4095, 4096, 8190, 8191, 8192, max_ext]:
         conversation = Connect(host, port)
         node = conversation
-        ext = OrderedDict((j+64, AutoEmptyExtension()) for j in range(i))
+        ext = OrderedDict((j+64, AutoEmptyExtension()) for j in range(i - ems))
         if ExtensionType.supports_npn in ext:
             del ext[ExtensionType.supports_npn]
             ext[i+64+1] = AutoEmptyExtension()
@@ -204,8 +218,12 @@ def main():
         else:
             ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
         ext[ExtensionType.renegotiation_info] = None
+        if ems:
+            ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         ext = {ExtensionType.renegotiation_info: None}
+        if ems:
+            ext[ExtensionType.extended_master_secret] = None
         node = node.add_child(ExpectServerHello(extensions=ext))
         node = node.add_child(ExpectCertificate())
         if dhe:

--- a/scripts/test-sig-algs.py
+++ b/scripts/test-sig-algs.py
@@ -24,12 +24,12 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
         GroupName
 from tlslite.extensions import SignatureAlgorithmsExtension, TLSExtension, \
         SignatureAlgorithmsCertExtension, SupportedGroupsExtension
-from tlsfuzzer.helpers import RSA_SIG_ALL
+from tlsfuzzer.helpers import RSA_SIG_ALL, AutoEmptyExtension
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 
-version = 7
+version = 8
 
 
 def help_msg():
@@ -49,6 +49,7 @@ def help_msg():
     print(" -X message     expect the `message` substring in exception raised during")
     print("                execution of preceding expected failure probe")
     print("                usage: [-x probe-name] [-X exception], order is compulsory!")
+    print(" -M | --ems     Enable support for Extended Master Secret")
     print(" --help         this message")
 
 
@@ -59,9 +60,10 @@ def main():
     run_exclude = set()
     expected_failures = {}
     last_exp_tmp = None
+    ems = False
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:n:x:X:", ["help"])
+    opts, args = getopt.getopt(argv, "h:p:e:n:x:X:M", ["help", "ems"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -78,6 +80,8 @@ def main():
             if not last_exp_tmp:
                 raise ValueError("-x has to be specified before -X")
             expected_failures[last_exp_tmp] = str(arg)
+        elif opt == '-M' or opt == '--ems':
+            ems = True
         elif opt == '--help':
             help_msg()
             sys.exit(0)
@@ -114,6 +118,8 @@ def main():
               GroupName.secp521r1]
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -153,6 +159,8 @@ def main():
                 SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
         ext[ExtensionType.supported_groups] = \
             SupportedGroupsExtension().create(groups)
+        if ems:
+            ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
         ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -196,6 +204,8 @@ def main():
             SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -236,6 +246,8 @@ def main():
             SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -276,6 +288,8 @@ def main():
             SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -321,6 +335,8 @@ def main():
             SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -359,6 +375,8 @@ def main():
             SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -378,6 +396,8 @@ def main():
             SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -396,6 +416,8 @@ def main():
         SupportedGroupsExtension().create(groups)
     ext[ExtensionType.signature_algorithms_cert] = \
         SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     sigs = [(HashAlgorithm.sha256, SignatureAlgorithm.rsa)]
     ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
         .create(sigs)
@@ -418,6 +440,8 @@ def main():
         SupportedGroupsExtension().create(groups)
     ext[ExtensionType.signature_algorithms_cert] = \
         SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     ext[ExtensionType.signature_algorithms] =  SignatureAlgorithmsExtension()\
         .create(sigs)
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -442,6 +466,8 @@ def main():
            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
@@ -465,6 +491,8 @@ def main():
            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)}
     ext[ExtensionType.supported_groups] = \
         SupportedGroupsExtension().create(groups)
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
This is a follow-up to https://github.com/tlsfuzzer/tlsfuzzer/pull/816 and https://github.com/tlsfuzzer/tlsfuzzer/pull/828, to support EMS in more scripts.

### Motivation and Context
Without this PR, they fail in FIPS mode after the recent enforcement of EMS: https://gitlab.com/gnutls/gnutls/-/merge_requests/1752

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/829)
<!-- Reviewable:end -->
