### PR TITLE
Integrating code that combines multiple minerva measurements

### DIFF
--- a/docs/source/timing-analysis.rst
+++ b/docs/source/timing-analysis.rst
@@ -392,11 +392,38 @@ paths to one or more ``timing.csv`` files:
    PYTHONPATH=. python tlsfuzzer/combine.py -o out-dir \
    in_1596892760/timing.csv in_1596892742/timing.csv
 
+
+The ``combine.py`` script also include the ``--long-format`` option for csv
+files that have a long format. The script is expecting a csv file, in which
+each row will have 3 values in the format "row id,column id,value".
+
+For example if we have the data:
+
+================ ======== ======== ========
+rows / cols      Col1     Col2     Col3
+================ ======== ======== ========
+Row1             1        2        3
+Row2             4        5        6
+================ ======== ======== ========
+
+The csv file should be formated as:
+
+.. code::
+
+   Row1,Col1,1
+   Row1,Col2,2
+   Row1,Col3,3
+   Row2,Col1,4
+   Row2,Col2,5
+   Row2,Col3,6
+
 .. warning::
 
-   The script overwrites the ``timing.csv`` in the output directory!
+   The script overwrites the ``timing.csv`` and the ``measurements.csv`` in
+   the output directory!
 
-After combining the ``timing.csv`` files, execute analysis as usual.
+After combining the ``timing.csv`` or ``measurements.csv`` files, execute
+analysis as usual.
 
 .. tip::
 

--- a/tests/test_tlsfuzzer_combine.py
+++ b/tests/test_tlsfuzzer_combine.py
@@ -16,7 +16,7 @@ except ImportError:
 import sys
 
 from tlsfuzzer.combine import help_msg, get_format, read_row_based_csv, \
-    read_column_based_csv, main, combine
+    read_column_based_csv, main, combine, combine_measurements
 
 if sys.version_info < (3, 0):
     BUILTIN_PRINT = "__builtin__.print"
@@ -184,6 +184,66 @@ class TestCombine(unittest.TestCase):
             self.assertIn("don't match column", str(err.exception))
 
 
+class TestMeasurementsCombine(unittest.TestCase):
+
+    @staticmethod
+    def _mock_open(*args, **kwargs):
+        """Fix mock not supporting iterators in all Python versions."""
+        mock_open = mock.mock_open(*args, **kwargs)
+        mock_open.return_value.__iter__ = lambda s: iter(s.readline, '')
+        return mock_open
+
+    def test_combine_measurements(self):
+        open_write = self._mock_open()
+        def file_selector(file_name, mode):
+            if file_name[:4] == "/tmp":
+                return open_write(file_name, mode)
+            elif file_name == "file1":
+                return self._mock_open(
+                    read_data="0,256,1\n0,255,100\n1,256,2\n1,254,101"
+                )(file_name, mode)
+            assert file_name == "file2", file_name
+            return self._mock_open(
+                read_data="0,256,3\n0,255,102\n0,254,103\n1,256,4\n1,254,104"
+            )(file_name, mode)
+
+        open_mock = mock.MagicMock()
+        open_mock.side_effect = file_selector
+
+        with mock.patch("__main__.__builtins__.open", open_mock):
+            combine_measurements("/tmp", ["file1", "file2"])
+
+        calls = open_write().write.call_args_list
+
+        exp = [mock.call("{0}\n".format(i)) for i in
+               ("0,256,1", "0,255,100", "1,256,2", "1,254,101", "2,256,3",
+                "2,255,102", "2,254,103", "3,256,4", "3,254,104")]
+        self.assertEqual(calls[:-1], exp)
+
+    def test_combine_measurements_wrong_format(self):
+        open_write = self._mock_open()
+        def file_selector(file_name, mode):
+            if file_name[:4] == "/tmp":
+                return open_write(file_name, mode)
+            elif file_name == "file1":
+                return self._mock_open(
+                    read_data="0,256,1\n0,255,100\n1,256,2\n1,254,101"
+                )(file_name, mode)
+            assert file_name == "file2", file_name
+            return self._mock_open(
+                read_data="0,256,3\n0,255,102\n0,254,103\n1,256\n1,254,104"
+            )(file_name, mode)
+
+        open_mock = mock.MagicMock()
+        open_mock.side_effect = file_selector
+
+        with mock.patch("__main__.__builtins__.open", open_mock):
+            with self.assertRaises(ValueError) as e:
+                combine_measurements("/tmp", ["file1", "file2"])
+
+        self.assertIn("File does not have correct format",str(e.exception))
+
+
 class TestMain(unittest.TestCase):
     @mock.patch(BUILTIN_PRINT)
     def test_help(self, mock_print):
@@ -213,13 +273,28 @@ class TestMain(unittest.TestCase):
 
         self.assertIn("No output", str(err.exception))
 
-    def test_correct_call(self):
+    @mock.patch('tlsfuzzer.combine.combine_measurements')
+    @mock.patch('tlsfuzzer.combine.combine')
+    def test_correct_call(self, mock_combine, mock_combine_measurements):
         args = ["combine.py", "-o", "/tmp/output",
                 "./input1.csv", "./input2.csv"]
 
         with mock.patch("sys.argv", args):
-            with mock.patch("tlsfuzzer.combine.combine") as mock_combine:
-                main()
+            main()
 
         mock_combine.assert_called_once_with(
             "/tmp/output", ["./input1.csv", "./input2.csv"])
+        mock_combine_measurements.assert_not_called()
+
+    @mock.patch('tlsfuzzer.combine.combine_measurements')
+    @mock.patch('tlsfuzzer.combine.combine')
+    def test_measurements_call(self, mock_combine, mock_combine_measurements):
+        args = ["combine.py", "--long-format", "-o", "/tmp/output",
+                "./input1.csv", "./input2.csv"]
+
+        with mock.patch("sys.argv", args):
+            main()
+
+        mock_combine_measurements.assert_called_once_with(
+            "/tmp/output", ["./input1.csv", "./input2.csv"])
+        mock_combine.assert_not_called()


### PR DESCRIPTION
This commit integrates the code for Minerva's combination of multiple measurements into the tlsfuzzer/combine.py. It expands the command with the flag "--long-format" which defines that the combining files are in long format (measurements up until now).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/835)
<!-- Reviewable:end -->
