### PR TITLE
report HelloRetryRequest as such in unexpected message exception

### DIFF
--- a/tests/test_tlsfuzzer_runner.py
+++ b/tests/test_tlsfuzzer_runner.py
@@ -393,6 +393,17 @@ class TestGuessResponse(unittest.TestCase):
 
         self.assertEqual("Handshake(client_hello)",
                          guess_response(content_type, data))
+
+    def test_guess_response_with_hello_retry_request(self):
+        content_type = constants.ContentType.handshake
+        data = bytearray([constants.HandshakeType.server_hello,
+                          0, 0, 34,  # length
+                          3, 3]  # version number
+                          ) + constants.TLS_1_3_HRR
+
+        self.assertEqual("Handshake(server_hello, hello_retry_request)",
+                         guess_response(content_type, data))
+
     def test_guess_response_with_invalid_handshake(self):
         content_type = constants.ContentType.handshake
         data = bytearray()

--- a/tlsfuzzer/runner.py
+++ b/tlsfuzzer/runner.py
@@ -9,7 +9,7 @@ from tlslite.messages import Message, Certificate, RecordHeader2
 from tlslite.handshakehashes import HandshakeHashes
 from tlslite.errors import TLSAbruptCloseError
 from tlslite.constants import ContentType, HandshakeType, AlertLevel, \
-        AlertDescription, SSL2HandshakeType, CipherSuite
+        AlertDescription, SSL2HandshakeType, CipherSuite, TLS_1_3_HRR
 from .expect import ExpectClose, ExpectNoMessage, ExpectAlert
 
 class ConnectionState(object):
@@ -158,6 +158,9 @@ def guess_response(content_type, data, ssl2=False):
         if ssl2:
             return "Handshake({0})".format(SSL2HandshakeType.toStr(data[0]))
         else:
+            if data[0] == HandshakeType.server_hello and \
+                    data[6:6+32] == TLS_1_3_HRR:
+                return "Handshake(server_hello, hello_retry_request)"
             return "Handshake({0})".format(HandshakeType.toStr(data[0]))
     elif content_type == ContentType.application_data:
         return "ApplicationData(len={0})".format(len(data))


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Make it so that when the Runner gets an unexpected message from the server, and that is a HelloRetryRequest, it is identified as such.

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
Usability

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/854)
<!-- Reviewable:end -->
