### PR TITLE
test-tls13-obsolete-curves: don't touch supported_groups around HRR

### DIFF
--- a/scripts/test-tls13-obsolete-curves.py
+++ b/scripts/test-tls13-obsolete-curves.py
@@ -341,7 +341,7 @@ def main():
         ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
             .create([TLS_1_3_DRAFT, (3, 3)])
         ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
-            .create(groups)
+            .create(both_groups)
         sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
                     SignatureScheme.rsa_pss_pss_sha256,
                     SignatureScheme.ecdsa_secp256r1_sha256]


### PR DESCRIPTION
As RFC 8446 section 4.1.2 doesn't modification of supported_groups around HRR, the previous code caused an illegal_parameter alert when testing against Go TLS server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/860)
<!-- Reviewable:end -->
