### PR TITLE
Modified pcap parsing code parse connections ended with RST

### DIFF
--- a/tlsfuzzer/extract.py
+++ b/tlsfuzzer/extract.py
@@ -290,6 +290,7 @@ class Extract:
         self.initial_syn_ack = None
         self.initial_ack = None
         self.warm_up_messages_left = WARM_UP
+        self.last_warmup_fin = None
         self.raw_times = raw_times
         self.binary = binary
         self.endian = endian
@@ -587,10 +588,13 @@ class Extract:
             else:
                 self.warm_up_messages_left -= 1
                 if self.warm_up_messages_left == 0:
-                    if self.srv_fin > self.clnt_fin:
-                        self.last_warmup_fin = self.srv_fin
+                    if self.srv_fin is None and self.clnt_fin is None:
+                        self.last_warmup_fin = 0
                     else:
-                        self.last_warmup_fin = self.clnt_fin
+                        if self.srv_fin > self.clnt_fin:
+                            self.last_warmup_fin = self.srv_fin
+                        else:
+                            self.last_warmup_fin = self.clnt_fin
 
     def _flush_to_files(self):
         # we can write only complete lines
@@ -692,20 +696,31 @@ class Extract:
                     row.append(s_msg_ack - s_msg)
 
                 # lst_srv_to_srv_fin
-                row.append(srv_fin - s_msgs[-1])
+                if srv_fin is None:
+                    row.append(0)
+                else:
+                    row.append(srv_fin - s_msgs[-1])
+
                 # lst_srv_to_clnt_fin
-                row.append(clnt_fin - s_msgs[-1])
-                if srv_fin > clnt_fin:
-                    last_fin = srv_fin
+                if clnt_fin is None:
+                    row.append(0)
                 else:
-                    last_fin = clnt_fin
-                # second_fin_to_ack
-                if ack_for_fin:
-                    row.append(ack_for_fin - last_fin)
-                    self._previous_lst_msg = ack_for_fin
+                    row.append(clnt_fin - s_msgs[-1])
+
+                if srv_fin is None or clnt_fin is None:
+                    row.append(0)
                 else:
-                    row.append(0.0)
-                    self._previous_lst_msg = last_fin
+                    if srv_fin > clnt_fin:
+                        last_fin = srv_fin
+                    else:
+                        last_fin = clnt_fin
+                    # second_fin_to_ack
+                    if ack_for_fin:
+                        row.append(ack_for_fin - last_fin)
+                        self._previous_lst_msg = ack_for_fin
+                    else:
+                        row.append(0.0)
+                        self._previous_lst_msg = last_fin
 
                 writer.writerow(row)
 

--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -4,6 +4,7 @@
 """Objects for generating TLS messages to send."""
 
 import random
+import struct
 from tlslite.messages import ClientHello, ClientKeyExchange, ChangeCipherSpec,\
         Finished, Alert, ApplicationData, Message, Certificate, \
         CertificateVerify, CertificateRequest, ClientMasterKey, \
@@ -120,6 +121,22 @@ class Close(Command):
 
     def process(self, state):
         """Close currently open connection."""
+        state.msg_sock.sock.close()
+
+
+class CloseRST(Command):
+    """Object used to close a TCP connection with a RST packet."""
+
+    def __init__(self):
+        """CloseRST connection object."""
+        super(CloseRST, self).__init__()
+
+    def process(self, state):
+        """Close currently open connection by sending a RST packet."""
+        l_onoff = 1
+        l_linger = 0
+        state.msg_sock.sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER,
+                                       struct.pack('ii', l_onoff, l_linger))
         state.msg_sock.sock.close()
 
 


### PR DESCRIPTION
The code has been modified so the parser will not only expect a FIN packet to be in the end but it tolerates if a connection is finished with a RST packet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/875)
<!-- Reviewable:end -->
