### PR TITLE
Fixed the support of the legacy scipy.stats.binom_test function

### DIFF
--- a/tlsfuzzer/analysis.py
+++ b/tlsfuzzer/analysis.py
@@ -1679,21 +1679,23 @@ class Analysis(object):
                             passed += 1
                         total += 1
 
+            statistic = None
+            pvalue = None
             try:
                 results = stats.binomtest(
                     passed, total, p=0.5, alternative="two-sided"
                 )
+                statistic = results.statistic
+                pvalue = results.pvalue
             except AttributeError:
                 results = stats.binom_test(
                     passed, total, p=0.5, alternative="two-sided"
                 )
+                pvalue = results
 
             output_files['sign_test'].write(
                 "K size of {0}: successes={1}, n={2}, stats={3}, pvalue={4}\n"\
-                    .format(
-                        k_size, passed, total,
-                        results.statistic, results.pvalue
-                    )
+                    .format(k_size, passed, total, statistic, pvalue)
             )
 
             # Paired t-test


### PR DESCRIPTION
The legacy binom_test function returns just the float p-value and in the code so far, we assumed it returns a BinomTestResult object as the newer scipy.stats.binomtest function. This commit is to fix compat with old scipy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/886)
<!-- Reviewable:end -->
