### PR TITLE
don't use warmup connections

### DIFF
--- a/tlsfuzzer/extract.py
+++ b/tlsfuzzer/extract.py
@@ -290,7 +290,7 @@ class Extract:
         self.initial_syn_ack = None
         self.initial_ack = None
         self.warm_up_messages_left = WARM_UP
-        self.last_warmup_fin = None
+        self.last_warmup_fin = 0
         self.raw_times = raw_times
         self.binary = binary
         self.endian = endian

--- a/tlsfuzzer/utils/statics.py
+++ b/tlsfuzzer/utils/statics.py
@@ -3,4 +3,4 @@
 
 """Static variables shared between multiple modules."""
 
-WARM_UP = 250
+WARM_UP = 0


### PR DESCRIPTION
since initial noise has little to no effect on pairwise tests, there's no need to actually use them

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
don't use WARM_UP connection during timing testing

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
faster test case execution from small samples

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md
