### PR TITLE
marvin-ciphertext-generator: allow printing status with newlines

### DIFF
--- a/scripts/marvin-ciphertext-generator.py
+++ b/scripts/marvin-ciphertext-generator.py
@@ -44,6 +44,7 @@ def help_msg():
     print("                Default 1")
     print(" --status-delay num How long to wait between status line updates.")
     print("                In seconds. Default: 2.0")
+    print(" --status-newline Use newline for separating lines in the status messages")
     print(" --help         this message")
 
 
@@ -57,6 +58,7 @@ def main():
     pms_tls_version = None
     probe_reuse = 1
     status_delay = 2.0
+    carriage_return = None
 
     argv = sys.argv[1:]
     opts, args = getopt.getopt(argv,
@@ -68,6 +70,7 @@ def main():
                                 "srv-cert=",
                                 "pms-tls-version=",
                                 "probe-reuse=",
+                                "status-newline",
                                 "status-delay="])
     for opt, arg in opts:
         if opt == '-o':
@@ -94,6 +97,8 @@ def main():
             pms_tls_version = divmod(int_ver, 256)
         elif opt == "--probe-reuse":
             probe_reuse = int(arg)
+        elif opt == "--status-newline":
+            carriage_return = '\n'
         elif opt == "--status-delay":
             status_delay = float(arg)
         elif opt == '--help':
@@ -135,6 +140,7 @@ def main():
         status = [0, len(test_classes) * repetitions, Event()]
         kwargs = dict()
         kwargs['delay'] = status_delay
+        kwargs['end'] = carriage_return
         progress = Thread(target=progress_report, args=(status,),
                           kwargs=kwargs)
         progress.start()


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Just like for analysis, allow the marvin-ciphertext-generator output status with newline end, not carriage return

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
better support for redirecting output to a file

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/890)
<!-- Reviewable:end -->
