### PR TITLE
Don't print pairwise test results

### DIFF
--- a/scripts/test-bleichenbacher-timing-pregenerate.py
+++ b/scripts/test-bleichenbacher-timing-pregenerate.py
@@ -96,6 +96,7 @@ def help_msg():
     print(" --verbose-analysis Enable verbose progress of analysis.")
     print(" --status-delay num How often to print the status line. Default: 2.0 seconds")
     print(" --status-newline Use a newline for line end instead of carriage return.")
+    print(" --summary-only Print summary result only, don't print pairwise results")
     print(" --no-alert     Don't expect the server to send an alert before closing connection.")
     print(" --help         this message")
 
@@ -156,6 +157,7 @@ def main():
     delay = None
     carriage_return = None
     no_alert = False
+    summary_only = False
 
     argv = sys.argv[1:]
     opts, args = getopt.getopt(argv,
@@ -174,6 +176,7 @@ def main():
                                 "verbose-analysis",
                                 "status-delay=",
                                 "status-newline",
+                                "summary-only",
                                 "no-alert"])
     for opt, arg in opts:
         if opt == '-h':
@@ -240,6 +243,8 @@ def main():
             verbose_analysis = True
         elif opt == "--status-delay":
             delay = float(arg)
+        elif opt == "--summary-only":
+            summary_only = True
         elif opt == "--status-newline":
             carriage_return = '\n'
         elif opt == "--no-alert":
@@ -1049,7 +1054,8 @@ place where the timing leak happens:
                                          no_quickack=no_quickack,
                                          verbose_analysis=verbose_analysis,
                                          delay=delay,
-                                         carriage_return=carriage_return)
+                                         carriage_return=carriage_return,
+                                         summary_only=summary_only)
             print("Pre-generating pre-master secret values...")
 
             with open(

--- a/tests/test_tlsfuzzer_analysis.py
+++ b/tests/test_tlsfuzzer_analysis.py
@@ -926,7 +926,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         None, None, None, False, True, 1e-09,
                         'measurements.csv', False, True, True, True, True,
-                        True, True, True)
+                        True, True, True, False)
 
     def test_call_with_no_sample_stats(self):
         output = "/tmp"
@@ -942,7 +942,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         None, None, None, False, True, 1e-09,
                         'measurements.csv', False, True, True, True, True,
-                        True, True, False)
+                        True, True, False, False)
 
     def test_minimal_analysis(self):
         output = "/tmp"
@@ -958,7 +958,7 @@ class TestCommandLine(unittest.TestCase):
                         output, False, False, False, False, False, None, None,
                         None, None, None, False, True, 1e-09,
                         'measurements.csv', False, False, False, True, False,
-                        False, False, False)
+                        False, False, False, False)
 
     def test_call_with_no_box_test(self):
         output = "/tmp"
@@ -974,7 +974,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         None, None, None, False, True, 1e-09,
                         'measurements.csv', False, True, True, True, True,
-                        False, True, True)
+                        False, True, True, False)
 
     def test_call_with_no_le_sign_test(self):
         output = "/tmp"
@@ -990,7 +990,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         None, None, None, False, True, 1e-09,
                         'measurements.csv', False, True, True, True, True,
-                        True, False, True)
+                        True, False, True, False)
 
     def test_call_with_delay_and_CR(self):
         output = "/tmp"
@@ -1007,7 +1007,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         None, 3.5, '\n', False, True, 1e-09,
                         'measurements.csv', False, True, True, True,
-                        True, True, True, True)
+                        True, True, True, True, False)
 
     def test_call_with_workers(self):
         output = "/tmp"
@@ -1023,7 +1023,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         200, None, None, False, True, 1e-09,
                         'measurements.csv', False, True, True, True,
-                        True, True, True, True)
+                        True, True, True, True, False)
 
     def test_call_with_verbose(self):
         output = "/tmp"
@@ -1039,7 +1039,23 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, True, None, None,
                         None, None, None, False, True, 1e-09,
                         'measurements.csv', False, True, True, True,
-                        True, True, True, True)
+                        True, True, True, True, False)
+
+    def test_call_with_summary_only(self):
+        output = "/tmp"
+        args = ["analysis.py", "-o", output, "--summary-only"]
+        mock_init = mock.Mock()
+        mock_init.return_value = None
+        with mock.patch('tlsfuzzer.analysis.Analysis.generate_report') as mock_report:
+            with mock.patch('tlsfuzzer.analysis.Analysis.__init__', mock_init):
+                with mock.patch("sys.argv", args):
+                    main()
+                    mock_report.assert_called_once()
+                    mock_init.assert_called_once_with(
+                        output, True, True, True, False, False, None, None,
+                        None, None, None, False, True, 1e-09,
+                        'measurements.csv', False, True, True, True,
+                        True, True, True, True, True)
 
     def test_call_with_multithreaded_plots(self):
         output = "/tmp"
@@ -1055,7 +1071,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, True, False, None, None,
                         None, None, None, False, True, 1e-09,
                         'measurements.csv', False, True, True, True,
-                        True, True, True, True)
+                        True, True, True, True, False)
 
     def test_call_with_no_plots(self):
         output = "/tmp"
@@ -1073,7 +1089,7 @@ class TestCommandLine(unittest.TestCase):
                         output, False, False, False, False, False, None, None,
                         None, None, None, False, True, 1e-09,
                         'measurements.csv', False, True, True, True,
-                        False, True, True, True)
+                        False, True, True, True, False)
 
     def test_call_with_frequency(self):
         output = "/tmp"
@@ -1089,7 +1105,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, 10*1e6, None,
                         None, None, None, False, True, 1e-09,
                         'measurements.csv', False, True, True, True,
-                        True, True, True, True)
+                        True, True, True, True, False)
 
     def test_call_with_alpha(self):
         output = "/tmp"
@@ -1105,7 +1121,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, 1e-3,
                         None, None, None, False, True, 1e-09,
                         'measurements.csv', False, True, True, True,
-                        True, True, True, True)
+                        True, True, True, True, False)
 
     def test_call_with_bit_size_measurements(self):
         output = "/tmp"
@@ -1123,7 +1139,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         None, None, None, True, True, 1e-09,
                         'measurements.csv', False, True, True, True,
-                        True, True, True, True)
+                        True, True, True, True, False)
 
     def test_call_with_skip_sanity(self):
         output = "/tmp"
@@ -1141,7 +1157,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         None, None, None, True, True, 1e-09,
                         'measurements.csv', True, True, True, True,
-                        True, True, True, True)
+                        True, True, True, True, False)
 
     def test_call_with_custom_measurements_filename(self):
         output = "/tmp"
@@ -1161,7 +1177,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         None, None, None, True, True, 1e-09,
                         measurements_filename, False, True, True, True,
-                        True, True, True, True)
+                        True, True, True, True, False)
 
     def test_call_with_no_smart_analysis(self):
         output = "/tmp"
@@ -1180,7 +1196,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         None, None, None, True, False, 1e-09,
                         'measurements.csv', False, True, True, True,
-                        True, True, True, True)
+                        True, True, True, True, False)
 
     def test_call_with_parametrized_smart_analysis(self):
         output = "/tmp"
@@ -1200,7 +1216,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         None, None, None, True, True,
                         bit_size_desire_ci * 1e-9, 'measurements.csv', False,
-                        True, True, True, True, True, True, True)
+                        True, True, True, True, True, True, True, False)
 
     def test_call_with_Hamming_weight(self):
         output = "/tmp"
@@ -1217,7 +1233,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         None, None, None, True, True, 1e-9,
                         'measurements.csv', False, True, True, True,
-                        True, True, True, True)
+                        True, True, True, True, False)
                     mock_report.assert_called_once_with(
                         bit_size=False, hamming_weight=True)
 
@@ -1237,7 +1253,7 @@ class TestCommandLine(unittest.TestCase):
                         output, True, True, True, False, False, None, None,
                         None, None, None, True, True, 1e-9,
                         'measurements.csv', False, False, False, False,
-                        True, True, True, True)
+                        True, True, True, True, False)
                     mock_report.assert_called_once_with(
                         bit_size=False, hamming_weight=True)
 

--- a/tlsfuzzer/timing_runner.py
+++ b/tlsfuzzer/timing_runner.py
@@ -25,7 +25,7 @@ class TimingRunner:
     def __init__(self, name, tests, out_dir, ip_address, port, interface,
                  affinity=None, skip_extract=False, skip_analysis=False,
                  alpha=None, no_quickack=False, verbose_analysis=False,
-                 delay=None, carriage_return=None):
+                 delay=None, carriage_return=None, summary_only=False):
         """
         Check if tcpdump is present and setup instance parameters.
 
@@ -65,6 +65,7 @@ class TimingRunner:
         self.verbose_analysis = verbose_analysis
         self.delay = delay
         self.carriage_return = carriage_return
+        self.summary_only = summary_only
 
         self.tcpdump_running = True
         self.tcpdump_output = None
@@ -203,7 +204,8 @@ class TimingRunner:
             analysis = Analysis(self.out_dir, alpha=self.alpha,
                                 verbose=self.verbose_analysis,
                                 delay=self.delay,
-                                carriage_return=self.carriage_return)
+                                carriage_return=self.carriage_return,
+                                summary_only=self.summary_only)
             return analysis.generate_report()
 
         print("Analysis is not available. "


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
when analysing larger data sets, the pairwise results do take a lot of space but don't provide much information, allow to silence them irrespective of `--verbose` setting

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
cleaner output, better user experience

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/891)
<!-- Reviewable:end -->
