### PR TITLE
dhe-no-shared-secret-padding: correct expected extensions for SSLv2 compat hello

### DIFF
--- a/scripts/test-dhe-no-shared-secret-padding.py
+++ b/scripts/test-dhe-no-shared-secret-padding.py
@@ -29,7 +29,7 @@ from tlslite.utils.cryptomath import numBytes
 from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
 
 
-version = 7
+version = 8
 
 
 def help_msg():
@@ -181,7 +181,7 @@ def main():
                                                        ssl2=ssl2))
             if prot > (3, 0):
                 ext = {ExtensionType.renegotiation_info: None}
-                if ems:
+                if ems and not ssl2:
                     ext[ExtensionType.extended_master_secret] = None
             else:
                 ext = None


### PR DESCRIPTION

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Make test cases with SSLv2 work even with `-M` option set

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/902)
<!-- Reviewable:end -->
