### PR TITLE
Skillings-Mack test

### DIFF
--- a/docs/source/tlsfuzzer.utils.rst
+++ b/docs/source/tlsfuzzer.utils.rst
@@ -14,4 +14,5 @@ Submodules
    tlsfuzzer.utils.lists
    tlsfuzzer.utils.ordered_dict
    tlsfuzzer.utils.progress_report
+   tlsfuzzer.utils.stats
 

--- a/docs/source/tlsfuzzer.utils.stats.rst
+++ b/docs/source/tlsfuzzer.utils.stats.rst
@@ -1,0 +1,7 @@
+tlsfuzzer.utils.stats module
+============================
+
+.. automodule:: tlsfuzzer.utils.stats
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/tests/test_tlsfuzzer_utils_stats.py
+++ b/tests/test_tlsfuzzer_utils_stats.py
@@ -7,7 +7,9 @@ import random
 failed_import = False
 try:
     from tlsfuzzer.utils.stats import skillings_mack_result, \
-        skillings_mack_test
+        skillings_mack_test, _block_slices, _slices, _summarise_chunk, \
+        _set_unique
+    import tlsfuzzer.utils.stats
     import numpy as np
 except ImportError:
     failed_import = True
@@ -15,11 +17,160 @@ except ImportError:
 
 @unittest.skipIf(failed_import,
                  "Numpy missing")
-class TestSkillingsMackTest(unittest.TestCase):
+class TestSummariseChunk(unittest.TestCase):
     def assertEqualApprox(self, a, b, eta=1e-6):
-        if a > b * (1 + eta) or a < b * (1 - eta):
+        if abs(a - b) > eta:
             raise AssertionError("{0} is not approximately equal {1}"
                                  .format(a, b))
+
+    def test_summarise_chunk(self):
+        tlsfuzzer.utils.stats._values = \
+            [3, 5, 15, 1, 3, 18, 5, 4, 21, 2, 6, 0, 2, 17, 0, 2, 10, 0,
+             3, 8, 0, 2, 13]
+        tlsfuzzer.utils.stats._groups = \
+            ['1', '2', '3', '1', '2', '3', '1', '2', '3', '1', '3', '1',
+             '2', '3', '1', '2', '3', '1', '2', '3', '1', '2', '3']
+        all_groups = set(tlsfuzzer.utils.stats._groups)
+        len_groups = len(tlsfuzzer.utils.stats._groups)
+        tlsfuzzer.utils.stats._blocks = \
+            [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7,
+             8, 8, 8]
+
+        ret = _summarise_chunk((all_groups, None, (0, len_groups)))
+
+        adjusted_ranks, block_counts, pair_counts = ret
+
+        self.assertEqual(len(adjusted_ranks), 3)
+        self.assertEqualApprox(adjusted_ranks['3'], 13.124355652982139)
+        self.assertEqualApprox(adjusted_ranks['1'], -11.392304845413262)
+        self.assertEqualApprox(adjusted_ranks['2'], -1.7320508075688772)
+        self.assertEqual(block_counts, {'2': 14, '1': 15, '3': 15})
+        self.assertEqual(pair_counts,
+            {frozenset(['2', '1']): 7, frozenset(['3', '1']): 8,
+             frozenset(['3', '2']): 7})
+
+    def test_summarise_chunk_duplicate_use_last(self):
+        # check if it produces the same values as the example from PMCMRplus
+        # R module documentation
+        tlsfuzzer.utils.stats._values = \
+                [3, 5, 15, 1, 3, 18, 5, 4, 21, 2, 6, 0, 2, 17, 0, 2, 10, 0,
+                  3, 8, 0, 2, 0, 13]
+        tlsfuzzer.utils.stats._groups = \
+                ['1', '2', '3', '1', '2', '3', '1', '2', '3', '1', '3', '1',
+                  '2', '3', '1', '2', '3', '1', '2', '3', '1', '2', '3', '3']
+        all_groups = set(tlsfuzzer.utils.stats._groups)
+        len_groups = len(tlsfuzzer.utils.stats._groups)
+        tlsfuzzer.utils.stats._blocks = \
+                [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7,
+                  8, 8, 8, 8]
+
+        ret = _summarise_chunk((all_groups, 'last', (0, len_groups)))
+
+        adjusted_ranks, block_counts, pair_counts = ret
+
+        self.assertEqual(len(adjusted_ranks), 3)
+        self.assertEqualApprox(adjusted_ranks['3'], 13.124355652982139)
+        self.assertEqualApprox(adjusted_ranks['1'], -11.392304845413262)
+        self.assertEqualApprox(adjusted_ranks['2'], -1.7320508075688772)
+        self.assertEqual(block_counts, {'2': 14, '1': 15, '3': 15})
+        self.assertEqual(pair_counts,
+            {frozenset(['2', '1']): 7, frozenset(['3', '1']): 8,
+             frozenset(['3', '2']): 7})
+
+    def test_summarise_chunk_duplicates(self):
+        # check if it produces the same values as the example from PMCMRplus
+        # R module documentation
+        tlsfuzzer.utils.stats._values = \
+                [3, 5, 15, 1, 3, 18, 5, 4, 21, 2, 6, 0, 2, 17, 0, 2, 10, 0,
+                  3, 8, 0, 2, 0, 13]
+        tlsfuzzer.utils.stats._groups = \
+                ['1', '2', '3', '1', '2', '3', '1', '2', '3', '1', '3', '1',
+                  '2', '3', '1', '2', '3', '1', '2', '3', '1', '2', '3', '3']
+        all_groups = set(tlsfuzzer.utils.stats._groups)
+        len_groups = len(tlsfuzzer.utils.stats._groups)
+        tlsfuzzer.utils.stats._blocks = \
+                [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7,
+                  8, 8, 8, 8]
+
+        with self.assertRaises(ValueError) as e:
+            ret = _summarise_chunk((all_groups, None, (0, len_groups)))
+
+        self.assertIn("Duplicate group (3) in block (8)", str(e.exception))
+
+    def test_summarise_chunk_duplicate_use_first(self):
+        # check if it produces the same values as the example from PMCMRplus
+        # R module documentation
+        tlsfuzzer.utils.stats._values = \
+                [3, 5, 15, 1, 3, 18, 5, 4, 21, 2, 6, 0, 2, 17, 0, 2, 10, 0,
+                  3, 8, 0, 2, 13, 0]
+        tlsfuzzer.utils.stats._groups = \
+                ['1', '2', '3', '1', '2', '3', '1', '2', '3', '1', '3', '1',
+                  '2', '3', '1', '2', '3', '1', '2', '3', '1', '2', '3', '3']
+        all_groups = set(tlsfuzzer.utils.stats._groups)
+        len_groups = len(tlsfuzzer.utils.stats._groups)
+        tlsfuzzer.utils.stats._blocks = \
+                [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7,
+                  8, 8, 8, 8]
+
+        ret = _summarise_chunk((all_groups, 'first', (0, len_groups)))
+
+        adjusted_ranks, block_counts, pair_counts = ret
+
+        self.assertEqual(len(adjusted_ranks), 3)
+        self.assertEqualApprox(adjusted_ranks['3'], 13.124355652982139)
+        self.assertEqualApprox(adjusted_ranks['1'], -11.392304845413262)
+        self.assertEqualApprox(adjusted_ranks['2'], -1.7320508075688772)
+        self.assertEqual(block_counts, {'2': 14, '1': 15, '3': 15})
+        self.assertEqual(pair_counts,
+            {frozenset(['2', '1']): 7, frozenset(['3', '1']): 8,
+             frozenset(['3', '2']): 7})
+
+    def test_summarise_not_sorted(self):
+        tlsfuzzer.utils.stats._values = [10, 20, 30, 40, 50]
+        tlsfuzzer.utils.stats._groups = [0, 1, 2, 0, 2]
+        tlsfuzzer.utils.stats._blocks = [0, 0, 1, 1, 0]
+        all_groups = set(tlsfuzzer.utils.stats._groups)
+        len_groups = len(tlsfuzzer.utils.stats._groups)
+        with self.assertRaises(ValueError) as e:
+            ret = _summarise_chunk((all_groups, None, (0, len_groups)))
+
+        self.assertIn("blocks are not sorted", str(e.exception))
+
+    def test_summarise_empty(self):
+        tlsfuzzer.utils.stats._values = []
+        tlsfuzzer.utils.stats._groups = []
+        tlsfuzzer.utils.stats._blocks = []
+        all_groups = set(tlsfuzzer.utils.stats._groups)
+        len_groups = len(tlsfuzzer.utils.stats._groups)
+        with self.assertRaises(ValueError) as e:
+            ret = _summarise_chunk((all_groups, None, (0, len_groups)))
+
+        self.assertIn("Empty data set", str(e.exception))
+
+    def test_set_unique(self):
+        tlsfuzzer.utils.stats._groups = \
+            ['1', '2', '3', '1', '2', '3', '1', '2', '3', '1', '3', '1',
+             '2', '3', '1', '2', '3', '1', '2', '3', '1', '2', '3']
+
+        self.assertEqual(_set_unique((0, 24)), set(['1', '2', '3']))
+
+
+@unittest.skipIf(failed_import,
+                 "Numpy missing")
+class TestSkillingsMackTest(unittest.TestCase):
+    def assertEqualApprox(self, a, b, eta=1e-5):
+        if abs(a - b) > eta:
+            raise AssertionError("{0} is not approximately equal {1}"
+                                 .format(a, b))
+
+    def test_with_different_lengths(self):
+        vals = [0, 0]
+        groups = [0, 1, 2]
+        blocks = [0, 0, 0]
+        with self.assertRaises(ValueError) as e:
+            skillings_mack_test(vals, groups, blocks)
+
+        self.assertIn("must be the same length", str(e.exception))
 
     def test_with_duplcate_group_block_pairs(self):
         vals = [0, 0, 0]
@@ -163,3 +314,62 @@ class TestSkillingsMackTest(unittest.TestCase):
         res = skillings_mack_test(vals, groups, blocks)
 
         self.assertGreater(res.p_value, 1e-6)
+
+
+@unittest.skipIf(failed_import,
+                 "Numpy missing")
+class TestBlockSlices(unittest.TestCase):
+    def test_chunk_larger_than_data(self):
+        blocks = [0, 0, 1, 1]
+        ret = list(_block_slices(blocks, 10))
+        self.assertEqual(ret, [(0, 4)])
+
+    def test_slice_on_chunk_bounary(self):
+        blocks = [0, 0, 0, 1, 1, 1]
+        ret = list(_block_slices(blocks, 3))
+        self.assertEqual(ret, [(0, 3), (3, 6)])
+
+    def test_slice_on_chunk_bounary_multiple_chunks(self):
+        blocks = [0, 0, 1, 1, 2, 2, 3, 3]
+        ret = list(_block_slices(blocks, 2))
+        self.assertEqual(ret, [(0, 2), (2, 4), (4, 6), (6, 8)])
+
+    def test_slice_not_on_chunk_boundary(self):
+        blocks = [0, 0, 0, 1, 1, 1, 2, 2, 2]
+        ret = list(_block_slices(blocks, 4))
+        self.assertEqual(ret, [(0, 6), (6, 9)])
+
+    def test_one_slice(self):
+        blocks = [0, 0, 0, 0, 0, 0, 0, 0]
+        ret = list(_block_slices(blocks, 3))
+        self.assertEqual(ret, [(0, 8)])
+
+    def test_one_slice_at_end(self):
+        blocks = [0, 0, 0, 1, 1, 1, 1, 1, 1]
+        ret = list(_block_slices(blocks, 2))
+        self.assertEqual(ret, [(0, 3), (3, 9)])
+
+
+
+@unittest.skipIf(failed_import,
+                 "Numpy missing")
+class TestSlices(unittest.TestCase):
+    def test_empty(self):
+        ret = list(_slices(0, 10))
+        self.assertEqual(ret, [])
+
+    def test_smaller_than_chunk(self):
+        ret = list(_slices(4, 10))
+        self.assertEqual(ret, [(0, 4)])
+
+    def test_equal_to_chunk_size(self):
+        ret = list(_slices(10, 10))
+        self.assertEqual(ret, [(0, 10)])
+
+    def test_multiple_slices(self):
+        ret = list(_slices(10, 2))
+        self.assertEqual(ret, [(0, 2), (2, 4), (4, 6), (6, 8), (8, 10)])
+
+    def test_length_not_multiple_of_slice_length(self):
+        ret = list(_slices(10, 4))
+        self.assertEqual(ret, [(0, 4), (4, 8), (8, 10)])

--- a/tests/test_tlsfuzzer_utils_stats.py
+++ b/tests/test_tlsfuzzer_utils_stats.py
@@ -1,0 +1,165 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import random
+failed_import = False
+try:
+    from tlsfuzzer.utils.stats import skillings_mack_result, \
+        skillings_mack_test
+    import numpy as np
+except ImportError:
+    failed_import = True
+
+
+@unittest.skipIf(failed_import,
+                 "Numpy missing")
+class TestSkillingsMackTest(unittest.TestCase):
+    def assertEqualApprox(self, a, b, eta=1e-6):
+        if a > b * (1 + eta) or a < b * (1 - eta):
+            raise AssertionError("{0} is not approximately equal {1}"
+                                 .format(a, b))
+
+    def test_with_duplcate_group_block_pairs(self):
+        vals = [0, 0, 0]
+        groups = [0, 1, 1]
+        blocks = [0, 0, 0]
+
+        with self.assertRaises(ValueError) as e:
+            skillings_mack_test(vals, groups, blocks)
+
+        self.assertIn("Duplicate group (1) in block (0)", str(e.exception))
+
+    def test_empty_data(self):
+        vals = []
+        groups = []
+        blocks = []
+        with self.assertRaises(ValueError) as e:
+            skillings_mack_test(vals, groups, blocks)
+
+        self.assertIn("Empty data set", str(e.exception))
+
+    def test_groups_not_compared(self):
+        vals = [10, 20, 30]
+        groups = [0, 1, 2]
+        blocks = [0, 0, 1]
+
+        with self.assertRaises(ValueError) as e:
+            skillings_mack_test(vals, groups, blocks)
+
+        self.assertIn("Groups with no comparisons found", str(e.exception))
+
+    def test_blocks_not_sorted(self):
+        vals = [10, 20, 30, 40, 50]
+        groups = [0, 1, 2, 0, 2]
+        blocks = [0, 0, 1, 1, 0]
+
+        with self.assertRaises(ValueError) as e:
+            skillings_mack_test(vals, groups, blocks)
+
+        self.assertIn("blocks are not sorted", str(e.exception))
+
+    def test_PMCMRplus_example(self):
+        # check if it produces the same values as the example from PMCMRplus
+        # R module documentation
+        vals =   [3, 5, 15, 1, 3, 18, 5, 4, 21, 2, 6, 0, 2, 17, 0, 2, 10, 0,
+                  3, 8, 0, 2, 13]
+        groups = ['1', '2', '3', '1', '2', '3', '1', '2', '3', '1', '3', '1',
+                  '2', '3', '1', '2', '3', '1', '2', '3', '1', '2', '3']
+        blocks = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7,
+                  8, 8, 8]
+
+        res = skillings_mack_test(vals, groups, blocks)
+
+        self.assertIsInstance(res, skillings_mack_result)
+        self.assertEqual(len(res), 3)
+
+        self.assertEqualApprox(res.p_value, 0.001306405)
+        self.assertEqualApprox(res.T, 13.28095)
+        self.assertEqual(res.df, 2)
+
+    def test_PMCMRplus_example_with_duplicate_use_last(self):
+        # check if it produces the same values as the example from PMCMRplus
+        # R module documentation
+        vals =   [3, 5, 15, 1, 3, 18, 5, 4, 21, 2, 6, 0, 2, 17, 0, 2, 10, 0,
+                  3, 8, 0, 2, 0, 13]
+        groups = ['1', '2', '3', '1', '2', '3', '1', '2', '3', '1', '3', '1',
+                  '2', '3', '1', '2', '3', '1', '2', '3', '1', '2', '3', '3']
+        blocks = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7,
+                  8, 8, 8, 8]
+
+        res = skillings_mack_test(vals, groups, blocks, duplicates="last")
+
+        self.assertIsInstance(res, skillings_mack_result)
+        self.assertEqual(len(res), 3)
+
+        self.assertEqualApprox(res.p_value, 0.001306405)
+        self.assertEqualApprox(res.T, 13.28095)
+        self.assertEqual(res.df, 2)
+
+    def test_PMCMRplus_example_with_duplicate_use_first(self):
+        # check if it produces the same values as the example from PMCMRplus
+        # R module documentation
+        vals =   [3, 5, 15, 1, 3, 18, 5, 4, 21, 2, 6, 0, 2, 17, 0, 2, 10, 0,
+                  3, 8, 0, 2, 13, 0]
+        groups = ['1', '2', '3', '1', '2', '3', '1', '2', '3', '1', '3', '1',
+                  '2', '3', '1', '2', '3', '1', '2', '3', '1', '2', '3', '3']
+        blocks = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7,
+                  8, 8, 8, 8]
+
+        res = skillings_mack_test(vals, groups, blocks, duplicates="first")
+
+        self.assertIsInstance(res, skillings_mack_result)
+        self.assertEqual(len(res), 3)
+
+        self.assertEqualApprox(res.p_value, 0.001306405)
+        self.assertEqualApprox(res.T, 13.28095)
+        self.assertEqual(res.df, 2)
+
+    def test_example_with_many_missing_values(self):
+        vals = [3, 5, 15, 4, 1, 3, 5, 4, 21, 5, 2, 6, 0, 2, 17, 0, 2, 10, 0,
+                3, 5, 0, 2, 13]
+        groups = [1, 2, 3, 5, 1, 2, 1, 2, 3, 4, 1, 3, 1, 2, 3, 1, 2, 3, 1, 2,
+                  4, 1, 2, 3]
+        blocks = [1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7,
+                  7, 8, 8, 8]
+
+        res = skillings_mack_test(vals, groups, blocks)
+
+        self.assertEqualApprox(res.p_value, 0.01378318)
+        self.assertEqualApprox(res.T, 12.53551)
+        self.assertEqual(res.df, 4)
+
+    def test_large_sample_with_obvious_difference(self):
+        vals = []
+        groups = []
+        blocks = []
+        for b in range(1000):
+            for g in range(10):
+                if random.uniform(0, 1) < 2**(-g):
+                    if g != 2:
+                        vals.append(random.gauss(0, 1))
+                    else:
+                        vals.append(random.gauss(2, 1))
+                    groups.append(g)
+                    blocks.append(b)
+
+        res = skillings_mack_test(vals, groups, blocks)
+
+        self.assertLess(res.p_value, 1e-6)
+
+    def test_large_sample_with_no_difference(self):
+        vals = []
+        groups = []
+        blocks = []
+        for b in range(1000):
+            for g in range(10):
+                if random.uniform(0, 1) < 2**(-g):
+                    vals.append(random.gauss(0, 1))
+                    groups.append(g)
+                    blocks.append(b)
+
+        res = skillings_mack_test(vals, groups, blocks)
+
+        self.assertGreater(res.p_value, 1e-6)

--- a/tlsfuzzer/utils/stats.py
+++ b/tlsfuzzer/utils/stats.py
@@ -2,9 +2,11 @@
 # Released under Gnu GPL v2.0, see LICENCE for details
 """Various statistical methods missing from scipy and numpy."""
 
+import os
 from math import sqrt
 from itertools import combinations
 from collections import defaultdict, namedtuple
+from multiprocessing import Pool
 from scipy.stats import rankdata, distributions
 import numpy as np
 
@@ -33,42 +35,57 @@ def _summarise_tuple(current_block, all_groups, adjusted_ranks, block_counts,
         else:
             block_counts[g] += (len_current_block - 1)
         adjusted_ranks[g] += sqrt(12/(len_current_block + 1)) * \
-                             (ranks[g] - (len_current_block + 1) / 2.)
+            (ranks[g] - (len_current_block + 1) / 2.)
 
 
-def skillings_mack_test(values, groups, blocks, duplicates=None):
-    """Perform the Skillings-Mack rank sum test.
+def _set_unique(idx):
+    global _groups
+    return set(np.unique(_groups[idx[0]:idx[1]]))
 
-    Skillings-Mack test is a Friedman-like test for unbalanced incomplete
-    block design data. The null hypothesis is that no group stochastically
-    dominates any other group, alternative hypothesis is that in at least
-    one pair of groups one stochastically dominates the other.
 
-    The test requires measurements to be independent within blocks and
-    that the missing values are either partially balanced or random.
+def _slices(length, chunksize):
+    """Return an iterator with tuples that describe the start and end of
+    array of ``length`` where each slice has at most ``chunksize`` elements"""
+    if length == 0:
+        return
+    starts = iter(range(0, length, chunksize))
+    start = next(starts)
+    for i in starts:
+        yield (start, i)
+        start = i
+    yield (start, length)
 
-    ``values``, ``groups``, and ``blocks`` must have equal length.
 
-    Reference: Skillings, J. H., Mack, G.A. (1981) On the use of a
-    Friedman-type statistic in balanced and unbalanced block designs,
-    Technometrics 23, 171-177
+def _block_slices(blocks, chunksize):
+    """Return an iterator with tuples that describe the start and end of
+    array of sorted ids in ``blocks`` where the chunk breaks happen on
+    id change and every chunk is approximately ``chunksize`` elements in
+    size."""
+    start = 0
+    while True:
+        if len(blocks) - start <= chunksize:
+            yield (start, len(blocks))
+            break
+        start_block = blocks[start+chunksize-1]
+        for i, block in enumerate(blocks[start+chunksize:], start + chunksize):
+            if block != start_block:
+                yield (start, i)
+                start = i
+                break
+        else:
+            yield (start, i+1)
+            break
 
-    :param iterable values: an iterable containing values that can be ranked
-      (int, float, etc.)
-    :param list groups: an iterable describing which group the corresponding
-      value belongs to, the elements must be hashable
-    :param iterable blocks: an iterable describing which test block the
-      corresponding value belongs to, the elements must be sorted in the
-      smallest-first order (e.g.: 1, 1, 1, 2, 2, 2, 2, 3,...)
-    :param str duplicates: if set to None (default), will refuse to process
-      duplicate data entries, if set to ``first`` it will use the first
-      value of specific group in the given block, if set to ``last`` it
-      will use the last value in a block
-    :return: named tuple with values of (``p_value``, ``T``, ``df``)
-    """
-    assert duplicates is None or duplicates in ('first', 'last')
 
-    all_groups = set(np.unique(groups))
+def _summarise_chunk(args):
+    global _groups
+    groups = _groups
+    global _values
+    values = _values
+    global _blocks
+    blocks = _blocks
+    all_groups, duplicates, idx = args
+    start, stop = idx
 
     current_block = None
     current_block_id = None
@@ -80,7 +97,9 @@ def skillings_mack_test(values, groups, blocks, duplicates=None):
     # how many times the values are paired with each-other
     pair_counts = defaultdict(int)
 
-    for val, group, block in zip(values, groups, blocks):
+    for val, group, block in zip(values[start:stop],
+                                 groups[start:stop],
+                                 blocks[start:stop]):
         # new block detected, summarise the current block, start a new one
         if block != current_block_id:
             # summarise the tuple only if there is more than one measurement
@@ -111,6 +130,89 @@ def skillings_mack_test(values, groups, blocks, duplicates=None):
     if len(current_block) > 1:
         _summarise_tuple(current_block, all_groups, adjusted_ranks,
                          block_counts, pair_counts)
+
+    return adjusted_ranks, block_counts, pair_counts
+
+
+def skillings_mack_test(values, groups, blocks, duplicates=None):
+    """Perform the Skillings-Mack rank sum test.
+
+    Skillings-Mack test is a Friedman-like test for unbalanced incomplete
+    block design data. The null hypothesis is that no group stochastically
+    dominates any other group, alternative hypothesis is that in at least
+    one pair of groups one stochastically dominates the other.
+
+    The test requires measurements to be independent within blocks and
+    that the missing values are either partially balanced or random.
+
+    ``values``, ``groups``, and ``blocks`` must have equal length.
+
+    Reference: Skillings, J. H., Mack, G.A. (1981) On the use of a
+    Friedman-type statistic in balanced and unbalanced block designs,
+    Technometrics 23, 171-177
+
+    Note: while the arguments have to be list-like, the function accepts
+    memory mapped files and allows processing data sets larger than
+    available system memory.
+
+    Function is not thread-safe.
+
+    :param list-like values: a list containing values that can be ranked
+      (int, float, etc.)
+    :param list-like groups: a list describing which group the corresponding
+      value belongs to, the elements must be hashable
+    :param list-like blocks: a list describing which test block the
+      corresponding value belongs to, the elements must be sorted in the
+      smallest-first order (e.g.: 1, 1, 1, 2, 2, 2, 2, 3,...)
+    :param str duplicates: if set to None (default), will refuse to process
+      duplicate data entries, if set to ``first`` it will use the first
+      value of specific group in the given block, if set to ``last`` it
+      will use the last value in a block
+    :return: named tuple with values of (``p_value``, ``T``, ``df``)
+    """
+    assert duplicates is None or duplicates in ('first', 'last')
+
+    if not (len(groups) == len(values) == len(blocks)):
+        raise ValueError("values, groups, and blocks must be the same length")
+
+    global _groups
+    _groups = groups
+    global _values
+    _values = values
+    global _blocks
+    _blocks = blocks
+
+    all_groups = set()
+    with Pool() as p:
+        # slice the data so that every worker has at least good few
+        # dozen megabytes of data to work with
+        chunks = p.imap_unordered(_set_unique, _slices(len(groups),
+                                                       1024*1024*64))
+
+        for i in chunks:
+            all_groups.update(i)
+
+        adjusted_ranks = defaultdict(float)
+        # how many times a group is present in a block adjusted by individual
+        # block sizes
+        block_counts = defaultdict(int)
+        # how many times the values are paired with each-other
+        pair_counts = defaultdict(int)
+
+        chunk_size = min(1024*1024*64,
+                         max(10, len(blocks) // os.cpu_count()))
+
+        chunks = p.imap_unordered(_summarise_chunk,
+                                  ((all_groups, duplicates, i) for i in
+                                   _block_slices(blocks, chunk_size)))
+
+        for chunk_ranks, chunk_block_counts, chunk_pair_counts in chunks:
+            for k, v in chunk_ranks.items():
+                adjusted_ranks[k] += v
+            for k, v in chunk_block_counts.items():
+                block_counts[k] += v
+            for k, v in chunk_pair_counts.items():
+                pair_counts[k] += v
 
     # check if all the groups present in data were compared with at
     # least one other group

--- a/tlsfuzzer/utils/stats.py
+++ b/tlsfuzzer/utils/stats.py
@@ -1,0 +1,166 @@
+# Author: Hubert Kario
+# Released under Gnu GPL v2.0, see LICENCE for details
+"""Various statistical methods missing from scipy and numpy."""
+
+from math import sqrt
+from itertools import combinations
+from collections import defaultdict, namedtuple
+from scipy.stats import rankdata, distributions
+import numpy as np
+
+
+def _rank_dict(values):
+    """Returns a copy of the dict with values converted to ranks."""
+    keys = values.keys()
+    ranks = rankdata(list(values.values()))
+    return dict(zip(keys, ranks))
+
+
+skillings_mack_result = namedtuple('skillings_mack_result',
+                                   ['p_value', 'T', 'df'])
+
+
+def _summarise_tuple(current_block, all_groups, adjusted_ranks, block_counts,
+                     pair_counts):
+    ranks = _rank_dict(current_block)
+    len_current_block = len(current_block)
+    for pair in (frozenset(x)
+                 for x in combinations(ranks.keys(), 2)):
+        pair_counts[pair] += 1
+    for g in all_groups:
+        if g not in ranks:
+            ranks[g] = (len_current_block + 1) / 2.0
+        else:
+            block_counts[g] += (len_current_block - 1)
+        adjusted_ranks[g] += sqrt(12/(len_current_block + 1)) * \
+                             (ranks[g] - (len_current_block + 1) / 2.)
+
+
+def skillings_mack_test(values, groups, blocks, duplicates=None):
+    """Perform the Skillings-Mack rank sum test.
+
+    Skillings-Mack test is a Friedman-like test for unbalanced incomplete
+    block design data. The null hypothesis is that no group stochastically
+    dominates any other group, alternative hypothesis is that in at least
+    one pair of groups one stochastically dominates the other.
+
+    The test requires measurements to be independent within blocks and
+    that the missing values are either partially balanced or random.
+
+    ``values``, ``groups``, and ``blocks`` must have equal length.
+
+    Reference: Skillings, J. H., Mack, G.A. (1981) On the use of a
+    Friedman-type statistic in balanced and unbalanced block designs,
+    Technometrics 23, 171-177
+
+    :param iterable values: an iterable containing values that can be ranked
+      (int, float, etc.)
+    :param list groups: an iterable describing which group the corresponding
+      value belongs to, the elements must be hashable
+    :param iterable blocks: an iterable describing which test block the
+      corresponding value belongs to, the elements must be sorted in the
+      smallest-first order (e.g.: 1, 1, 1, 2, 2, 2, 2, 3,...)
+    :param str duplicates: if set to None (default), will refuse to process
+      duplicate data entries, if set to ``first`` it will use the first
+      value of specific group in the given block, if set to ``last`` it
+      will use the last value in a block
+    :return: named tuple with values of (``p_value``, ``T``, ``df``)
+    """
+    assert duplicates is None or duplicates in ('first', 'last')
+
+    all_groups = set(np.unique(groups))
+
+    current_block = None
+    current_block_id = None
+
+    adjusted_ranks = defaultdict(float)
+    # how many times a group is present in a block adjusted by individual
+    # block sizes
+    block_counts = defaultdict(int)
+    # how many times the values are paired with each-other
+    pair_counts = defaultdict(int)
+
+    for val, group, block in zip(values, groups, blocks):
+        # new block detected, summarise the current block, start a new one
+        if block != current_block_id:
+            # summarise the tuple only if there is more than one measurement
+            # in the tuple (block)
+            if current_block is not None and len(current_block) > 1:
+                _summarise_tuple(current_block, all_groups, adjusted_ranks,
+                                 block_counts, pair_counts)
+
+            # prepare for new block analysis
+            if current_block_id is not None and block < current_block_id:
+                raise ValueError("blocks are not sorted")
+            current_block_id = block
+            current_block = dict()
+
+        # add new value to the current block if it's consistent with
+        # other values and settings
+        if group not in current_block:
+            current_block[group] = val
+        else:
+            if duplicates == 'last':
+                current_block[group] = val
+            elif duplicates is None:
+                raise ValueError("Duplicate group ({0}) in block ({1})".format(
+                                 group, block))
+
+    if current_block is None:
+        raise ValueError("Empty data set")
+    if len(current_block) > 1:
+        _summarise_tuple(current_block, all_groups, adjusted_ranks,
+                         block_counts, pair_counts)
+
+    # check if all the groups present in data were compared with at
+    # least one other group
+    used_groups = set()
+    for a, b in pair_counts.keys():
+        used_groups.add(a)
+        used_groups.add(b)
+    for i in all_groups:
+        if i not in used_groups:
+            raise ValueError("Groups with no comparisons found")
+
+    # numpy arrays are easier to handle with numerical indexes, so create
+    # a mapping between names and integers
+    mapping = dict((val, i) for i, val in enumerate(sorted(all_groups)))
+
+    #
+    # calculate the covariance matrix to get the test statistic
+    #
+
+    # while the elements are ints, we will be multiplying it by floats
+    # (adjusted_ranks) later, so convert already to floats
+    # missing combinations should be equal 0
+    cov = np.full((len(all_groups), len(all_groups)),
+                  0,
+                  dtype=np.dtype('float64'))
+
+    for k, v in pair_counts.items():
+        x, y = k
+        x = mapping[x]
+        y = mapping[y]
+        cov[x, y] = -v
+        cov[y, x] = -v
+
+    for k, v in block_counts.items():
+        k = mapping[k]
+        cov[k, k] = v
+
+    rank_ar = np.full((len(all_groups), 1),
+                      float('NaN'),
+                      dtype=np.dtype('float64'))
+    for k, v in adjusted_ranks.items():
+        k = mapping[k]
+        rank_ar[k] = v
+
+    # calculate the test statistic (matrix multiply)
+    T = np.matmul(np.matmul(np.transpose(rank_ar), np.linalg.pinv(cov)),
+                  rank_ar)
+    # result is a 1 by 1 matrix so extract that singular value
+    T = T[0, 0]
+
+    p_val = distributions.chi2.sf(T, len(all_groups) - 1)
+
+    return skillings_mack_result(p_val, T, len(all_groups) - 1)


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Implement the Skillings-Mack statistical test

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
When analysing Minerva data, we can't use Friedman test as the data does not follow complete block design.
Implement a test that can handle semi-balanced or random block design (data missing at semi-random)

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] test coverage
- [x] remove debugging statements
- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/905)
<!-- Reviewable:end -->
