### PR TITLE
Add -i option to combine.py

### DIFF
--- a/docs/source/timing-analysis.rst
+++ b/docs/source/timing-analysis.rst
@@ -474,6 +474,21 @@ paths to one or more ``timing.csv`` files:
    PYTHONPATH=. python tlsfuzzer/combine.py -o out-dir \
    in_1596892760/timing.csv in_1596892742/timing.csv
 
+Alternatively, you can provide an input filelist containing one input
+file per line:
+
+.. code:: bash
+
+   PYTHONPATH=. python tlsfuzzer/combine.py -o out-dir \
+   -i csv_filelist
+
+Or passing the filelist through STDIN.
+
+.. code:: bash
+
+   find in_* -name 'timing.csv' -print | \
+   PYTHONPATH=. python tlsfuzzer/combine.py -o out-dir \
+   -i -
 
 The ``combine.py`` script also include the ``--long-format`` option for csv
 files that have a long format. The script is expecting a csv file, in which

--- a/tlsfuzzer/combine.py
+++ b/tlsfuzzer/combine.py
@@ -75,6 +75,21 @@ def read_column_based_csv(file_name):
             yield i
 
 
+def read_row_based_textfile(file_name):
+    """
+    Reads a text file, yielding line after line.
+    For file_name being '-' STDIN is processed instead.
+    """
+
+    if file_name == '-':
+        for line in sys.stdin:
+            yield line
+    else:
+        with open(file_name, 'r') as file_r:
+            for line in file_r:
+                yield line
+
+
 def combine(output, inputs):
     """Combine timing.csv or measurements.csv files into a single one."""
     columns = None
@@ -138,14 +153,17 @@ def combine_measurements(output, inputs):
 
 
 def main():
+    input_filelist = None
     output = None
     long_format = False
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "o:", ["help", "long-format"])
+    opts, args = getopt.getopt(argv, "i:o:", ["help", "long-format"])
 
     for opt, arg in opts:
-        if opt == "-o":
+        if opt == "-i":
+            input_filelist = arg
+        elif opt == "-o":
             output = arg
         elif opt == "--long-format":
             long_format = True
@@ -155,6 +173,12 @@ def main():
             sys.exit(0)
 
     inputs = args
+
+    # extend filelist provided as arguments with files from input_filelist
+    if input_filelist:
+        inputs.extend(map(lambda obj: obj.strip(),
+                          read_row_based_textfile(input_filelist)))
+
     if not inputs:
         raise ValueError("No input files provided")
     if not output:


### PR DESCRIPTION
Enable passing input file filelist using -i parameter.

### Description
By specifying input file list using `-i` option one can bypass shell limitations on maximum number of arguments.

### Motivation and Context
When combining thousands or more timing.csv files one will hit maximum limit of command line arguments.
Also, command line log becomes more readable.

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see CI results)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/910)
<!-- Reviewable:end -->
