### PR TITLE
Drop the key share extension when we drop supported groups.

### DIFF
--- a/scripts/test-renegotiation-changed-clienthello.py
+++ b/scripts/test-renegotiation-changed-clienthello.py
@@ -346,6 +346,8 @@ def main():
         node = node.add_child(ResetHandshakeHashes())
         renego_exts = OrderedDict(ext)
         del renego_exts[drop_ext]
+        if drop_ext == ExtensionType.supported_groups:
+            del renego_exts[ExtensionType.key_share]
         # use None for autogeneration of the renegotiation_info with correct
         # payload
         renego_exts[ExtensionType.renegotiation_info] = None


### PR DESCRIPTION
RFC 8446 Section 4.2.8 specifies:

"Clients MUST NOT offer any KeyShareEntry values for groups not listed in the client's supported_groups extension"

As such sending key share when supported groups is dropped out is a violation of the RFC, causing unexpected failures in conforming implementations.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/916)
<!-- Reviewable:end -->
