### PR TITLE
Add coverage for compressed_certificate extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,9 +314,9 @@ jobs:
       - name: Install dependencies (2.6)
         if: ${{ matrix.python-version == '2.6' }}
         run: |
-          wget https://files.pythonhosted.org/packages/a0/da/20dca663a8c6002654ffc3155481b200dc44dd242bc94c9122ad7d68cdcb/tlslite-ng-0.8.0b2.tar.gz
+          wget https://files.pythonhosted.org/packages/f3/3a/6043279b330fd897aa480eafd7f2b92a5a0a2db4f9bfd0b44dc510e17a2b/tlslite-ng-0.8.0b3.tar.gz
           wget https://files.pythonhosted.org/packages/b4/4c/f8b4ed6c61dff52294f98aaf99053dd979c1b4233d953f371afb0a2977a1/ecdsa-0.18.0b2-py2.py3-none-any.whl
-          pip install tlslite-ng-0.8.0b2.tar.gz ecdsa-0.18.0b2-py2.py3-none-any.whl
+          pip install tlslite-ng-0.8.0b3.tar.gz ecdsa-0.18.0b2-py2.py3-none-any.whl
       - name: Install dependencies
         if: ${{ matrix.python-version != '2.6' }}
         run: pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tlslite-ng==0.8.0-beta2
+tlslite-ng==0.8.0-beta3

--- a/scripts/test-tls13-certificate-compression.py
+++ b/scripts/test-tls13-certificate-compression.py
@@ -1,0 +1,791 @@
+# Author: George Pantelakis, (c) 2024
+# Contributor: Alexander Sosedkin
+# Released under Gnu GPL v2.0, see LICENSE file for details
+
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+from itertools import chain
+from random import sample
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    CertificateGenerator, CompressedCertificateGenerator, fuzz_message
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectCompressedCertificate, \
+    ExpectCertificateRequest, ExpectServerKeyExchange
+
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    CertificateCompressionAlgorithm, HashAlgorithm, SignatureAlgorithm
+from tlslite.keyexchange import ECDHKeyExchange
+from tlsfuzzer.utils.lists import natural_sort_keys
+from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+    CompressedCertificateExtension, TLSExtension
+from tlsfuzzer.helpers import key_share_gen, SIG_ALL, RSA_SIG_ALL, \
+    AutoEmptyExtension
+from tlslite.utils.compression import compression_algo_impls
+
+
+version = 1
+
+KNOWN_ALGORITHMS = ('zlib', 'brotli', 'zstd')
+
+
+def help_msg():
+    print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
+    print(" -h hostname              name of the host to run the test against")
+    print("                          localhost by default")
+    print(" -p port                  port number to use for connection,")
+    print("                          4433 by default")
+    print(" probe-name               if present, will run only the probes")
+    print("                          with given names and not all of them,")
+    print("                          e.g \"sanity\"")
+    print(" -e probe-name            exclude the probe from the list of the")
+    print("                          ones run may be specified multiple times")
+    print(" -x probe-name            expect the probe to fail. When such")
+    print("                          probe passes despite being marked like")
+    print("                          this it will be reported in the test")
+    print("                          summary and the whole script will fail.")
+    print("                          May be specified multiple times.")
+    print(" -X message               expect the `message` substring in")
+    print("                          exception raised during execution of")
+    print("                          preceding expected failure probe")
+    print("                          usage: [-x probe-name] [-X exception]")
+    print("                          order is compulsory!")
+    print(" -n num                   run 'num' or all(if 0) tests instead of")
+    print("                          default(all).")
+    print("                          (\"sanity\" tests are always executed)")
+    print(" -d                       negotiate (EC)DHE instead of RSA key")
+    print("                          exchange, send additional extensions,")
+    print("                          usually used for (EC)DHE ciphers")
+    print("                          additional extensions, usually used for")
+    print("                          (EC)DHE ciphers. Only effects TLS v1.2")
+    print("                          tests.")
+    print(" -C ciph                  Use specified ciphersuite. Either")
+    print("                          numerical value or IETF name.")
+    print(" -M | --ems               Advertise support for Extended Master")
+    print("                          Secret. Only effects TLS v1.2 tests.")
+    print(" --algorithms algorithms  comma-separated list of compression")
+    print("                          algorithms that will be used by the")
+    print("                          script to test against the server.")
+    print("                          The algorithms specified here should be")
+    print("                          supported by the server.")
+    print("                          Set to zlib,brotli,zstd by default")
+    print(" --help                   this message")
+
+
+def main():
+    host = "localhost"
+    port = 4433
+    num_limit = None
+    run_exclude = set()
+    expected_failures = {}
+    last_exp_tmp = None
+    dhe = False
+    ciphers = None
+    ems = False
+    compression_algorithms_list = list(KNOWN_ALGORITHMS)
+
+    argv = sys.argv[1:]
+    opts, args = getopt.getopt(argv, "h:p:e:x:X:n:dC:M", ["algorithms=",
+                                                          "ems", "help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '-e':
+            run_exclude.add(arg)
+        elif opt == '-x':
+            expected_failures[arg] = None
+            last_exp_tmp = str(arg)
+        elif opt == '-X':
+            if not last_exp_tmp:
+                raise ValueError("-x has to be specified before -X")
+            expected_failures[last_exp_tmp] = str(arg)
+        elif opt == '-n':
+            num_limit = int(arg)
+        elif opt == '-d':
+            dhe = True
+        elif opt == '-C':
+            if arg[:2] == '0x':
+                ciphers = [int(arg, 16)]
+            else:
+                try:
+                    ciphers = [getattr(CipherSuite, arg)]
+                except AttributeError:
+                    ciphers = [int(arg)]
+        elif opt == '-M' or opt == '--ems':
+            ems = True
+        elif opt == '--algorithms':
+            compression_algorithms_list = arg.split(',')
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+
+    if args:
+        run_only = set(args)
+    else:
+        run_only = None
+
+    if not ciphers:
+        ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256]
+
+    compression_algorithms = {}
+
+    for alg_name in compression_algorithms_list:
+        try:
+            compression_algorithms[alg_name] = \
+                getattr(CertificateCompressionAlgorithm, alg_name)
+        except KeyError:
+            raise RuntimeError("unsupported algorithm `{0}`".format(alg_name))
+
+    server_supported_compression_algorithms = \
+        list(compression_algorithms.values())
+
+    if (
+        'brotli' in compression_algorithms
+        and not compression_algo_impls["brotli_decompress"]
+    ):
+        print(
+            "Warning: Unsupported algorithm `brotli`, skipping algorithm. "
+            "Install Brotli python package if you want to test it."
+        )
+        compression_algorithms.pop('brotli')
+    if (
+        'zstd' in compression_algorithms
+        and not compression_algo_impls["zstd_decompress"]
+    ):
+        print(
+            "Warning: Unsupported algorithm `zstd`, skipping algorithm. "
+            "Install zstandard python package if you want to test it."
+        )
+        compression_algorithms.pop('zstd')
+
+    if not compression_algorithms:
+        raise RuntimeError("No algorithms left to check.")
+
+    conversations = {}
+
+    # Sanity, no certificate compression
+    conversation = Connect(host, port)
+    node = conversation
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256,
+                SignatureScheme.ecdsa_secp256r1_sha256,
+                SignatureScheme.ed25519,
+                SignatureScheme.ed448]
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    node = node.add_child(ClientHelloGenerator(
+        ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+        extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                       AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+    conversations["sanity"] = conversation
+
+    # Sanity, certificate compression
+    for alg_name, algorithm in compression_algorithms.items():
+        conversation = Connect(host, port)
+        node = conversation
+        ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+        ext = {}
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        for group in groups:
+            key_shares.append(key_share_gen(group))
+        ext[ExtensionType.key_share] = \
+                ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = \
+                SupportedVersionsExtension().create([TLS_1_3_DRAFT, (3, 3)])
+        ext[ExtensionType.supported_groups] = \
+                SupportedGroupsExtension().create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256,
+                    SignatureScheme.ecdsa_secp256r1_sha256,
+                    SignatureScheme.ed25519,
+                    SignatureScheme.ed448]
+        ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        compression_algs = [algorithm]
+        ext[ExtensionType.compress_certificate] = \
+            CompressedCertificateExtension().create(compression_algs)
+        node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+        node = node.add_child(ExpectServerHello())
+        node = node.add_child(ExpectChangeCipherSpec())
+        node = node.add_child(ExpectEncryptedExtensions())
+        if algorithm in server_supported_compression_algorithms:
+            node = node.add_child(ExpectCompressedCertificate(
+                compression_algo=algorithm))
+        else:
+            node = node.add_child(ExpectCertificate())
+        node = node.add_child(ExpectCertificateVerify())
+        node = node.add_child(ExpectFinished())
+        node = node.add_child(FinishedGenerator())
+        node = node.add_child(ApplicationDataGenerator(
+            bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+        # This message is optional and may show up 0 to many times
+        cycle = ExpectNewSessionTicket()
+        node = node.add_child(cycle)
+        node.add_child(cycle)
+
+        node.next_sibling = ExpectApplicationData()
+        node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                            AlertDescription.close_notify))
+
+        node = node.add_child(ExpectAlert())
+        node.next_sibling = ExpectClose()
+        conversations["smoke, {0}".format(alg_name)] = conversation
+
+    # Extension is ignored in TLS-1.2
+    conversation = Connect(host, port)
+    node = conversation
+    ext = {}
+    if ems:
+        ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
+    if dhe:
+        ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+                   CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+        groups = [GroupName.secp256r1,
+                  GroupName.ffdhe2048]
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            .create(groups)
+        ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(SIG_ALL)
+        ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    else:
+        ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext[ExtensionType.compress_certificate] = \
+                CompressedCertificateExtension().create(
+                    list(compression_algorithms.values())
+                )
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectCertificate())
+    if dhe:
+        node = node.add_child(ExpectServerKeyExchange())
+    node = node.add_child(ExpectServerHelloDone())
+    node = node.add_child(ClientKeyExchangeGenerator())
+    node = node.add_child(ChangeCipherSpecGenerator())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+    node = node.add_child(ExpectApplicationData())
+    node = node.add_child(AlertGenerator(AlertLevel.warning,
+                                         AlertDescription.close_notify))
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+    conversations["sending extension in TLS-1.2"] = conversation
+
+    # zlib is preferred when first
+    extra_algo = None
+    if 'brotli' in compression_algorithms:
+        extra_algo = compression_algorithms['brotli']
+    elif 'zstd' in compression_algorithms:
+        extra_algo = compression_algorithms['zstd']
+
+    if "zlib" in compression_algorithms and extra_algo:
+        conversation = Connect(host, port)
+        node = conversation
+        ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+        ext = {}
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        for group in groups:
+            key_shares.append(key_share_gen(group))
+        ext[ExtensionType.key_share] = \
+                ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = \
+                SupportedVersionsExtension().create([TLS_1_3_DRAFT, (3, 3)])
+        ext[ExtensionType.supported_groups] = \
+                SupportedGroupsExtension().create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256,
+                    SignatureScheme.ecdsa_secp256r1_sha256,
+                    SignatureScheme.ed25519,
+                    SignatureScheme.ed448]
+        ext[ExtensionType.signature_algorithms] = \
+                SignatureAlgorithmsExtension().create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = \
+                SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        ext[ExtensionType.signature_algorithms_cert] = \
+                SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        algorithms = [compression_algorithms["zlib"], extra_algo]
+        ext[ExtensionType.compress_certificate] = \
+                CompressedCertificateExtension().create(algorithms)
+        node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+        node = node.add_child(ExpectServerHello())
+        node = node.add_child(ExpectChangeCipherSpec())
+        node = node.add_child(ExpectEncryptedExtensions())
+        node = node.add_child(ExpectCompressedCertificate(
+            compression_algo=compression_algorithms["zlib"]))
+        node = node.add_child(ExpectCertificateVerify())
+        node = node.add_child(ExpectFinished())
+        node = node.add_child(FinishedGenerator())
+        node = node.add_child(ApplicationDataGenerator(
+            bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+        # This message is optional and may show up 0 to many times
+        cycle = ExpectNewSessionTicket()
+        node = node.add_child(cycle)
+        node.add_child(cycle)
+
+        node.next_sibling = ExpectApplicationData()
+        node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                            AlertDescription.close_notify))
+
+        node = node.add_child(ExpectAlert())
+        node.next_sibling = ExpectClose()
+        conversations["zlib is preferred"] = conversation
+
+    # bug found: https://github.com/openssl/openssl/pull/19600
+    UNSUPPORTED_ALGORITHMS = set([ # Should not lead to certificate compression
+        0,                         # reserved
+        10,                        # Not supported / unknown algorithm
+        256,                       # 0x0100: valid algorithm, wrong octet
+        770,                       # 0x0302: valid algorithms in all octets
+        16383,                     # not reserved, but unlikely to be used soon
+        16384,                     # reserved
+        16385,                     # reserved
+        65534,                     # reserved
+        65535,                     # reserved
+    ])
+    for unreasonable_compression_algorithm in UNSUPPORTED_ALGORITHMS:
+        conversation = Connect(host, port)
+        node = conversation
+        ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+        ext = {}
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        for group in groups:
+            key_shares.append(key_share_gen(group))
+        ext[ExtensionType.key_share] = \
+                ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = \
+                SupportedVersionsExtension().create([TLS_1_3_DRAFT, (3, 3)])
+        ext[ExtensionType.supported_groups] = \
+                SupportedGroupsExtension().create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256,
+                    SignatureScheme.ecdsa_secp256r1_sha256,
+                    SignatureScheme.ed25519,
+                    SignatureScheme.ed448]
+        ext[ExtensionType.signature_algorithms] = \
+                SignatureAlgorithmsExtension().create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = \
+                SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        ext[ExtensionType.signature_algorithms_cert] = \
+                SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        compression_algs = [unreasonable_compression_algorithm]
+        ext[ExtensionType.compress_certificate] = \
+                CompressedCertificateExtension().create(compression_algs)
+        node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+        node = node.add_child(ExpectServerHello())
+        node = node.add_child(ExpectChangeCipherSpec())
+        node = node.add_child(ExpectEncryptedExtensions())
+        node = node.add_child(ExpectCertificate())
+        node = node.add_child(ExpectCertificateVerify())
+        node = node.add_child(ExpectFinished())
+        node = node.add_child(FinishedGenerator())
+        node = node.add_child(ApplicationDataGenerator(
+            bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+        # This message is optional and may show up 0 to many times
+        cycle = ExpectNewSessionTicket()
+        node = node.add_child(cycle)
+        node.add_child(cycle)
+
+        node.next_sibling = ExpectApplicationData()
+        node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                           AlertDescription.close_notify))
+
+        node = node.add_child(ExpectAlert())
+        node.add_child(ExpectClose())
+        name = "unreasonable algorithm {0} alone"\
+               .format(unreasonable_compression_algorithm)
+        conversations[name] = conversation
+
+        if "zlib" in compression_algorithms:
+            conversation = Connect(host, port)
+            node = conversation
+            ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+                       CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+            ext = {}
+            groups = [GroupName.secp256r1]
+            key_shares = []
+            for group in groups:
+                key_shares.append(key_share_gen(group))
+            ext[ExtensionType.key_share] = \
+                    ClientKeyShareExtension().create(key_shares)
+            ext[ExtensionType.supported_versions] = \
+                    SupportedVersionsExtension().create([TLS_1_3_DRAFT,
+                                                         (3, 3)])
+            ext[ExtensionType.supported_groups] = \
+                    SupportedGroupsExtension().create(groups)
+            sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                        SignatureScheme.rsa_pss_pss_sha256,
+                        SignatureScheme.ecdsa_secp256r1_sha256,
+                        SignatureScheme.ed25519,
+                        SignatureScheme.ed448]
+            ext[ExtensionType.signature_algorithms] = \
+                    SignatureAlgorithmsExtension().create(sig_algs)
+            ext[ExtensionType.signature_algorithms_cert] = \
+                    SignatureAlgorithmsCertExtension().create(SIG_ALL)
+            ext[ExtensionType.signature_algorithms_cert] = \
+                    SignatureAlgorithmsCertExtension().create(SIG_ALL)
+            compression_algs = [unreasonable_compression_algorithm,
+                                CertificateCompressionAlgorithm.zlib]
+            ext[ExtensionType.compress_certificate] = \
+                    CompressedCertificateExtension().create(compression_algs)
+            node = node.add_child(ClientHelloGenerator(ciphers,
+                                                       extensions=ext))
+            node = node.add_child(ExpectServerHello())
+            node = node.add_child(ExpectChangeCipherSpec())
+            node = node.add_child(ExpectEncryptedExtensions())
+            node = node.add_child(ExpectCompressedCertificate(
+                compression_algo=CertificateCompressionAlgorithm.zlib
+            ))
+            node = node.add_child(ExpectCertificateVerify())
+            node = node.add_child(ExpectFinished())
+            node = node.add_child(FinishedGenerator())
+            node = node.add_child(ApplicationDataGenerator(
+                bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+            # This message is optional and may show up 0 to many times
+            cycle = ExpectNewSessionTicket()
+            node = node.add_child(cycle)
+            node.add_child(cycle)
+
+            node.next_sibling = ExpectApplicationData()
+            node = node.next_sibling.add_child(AlertGenerator(
+                AlertLevel.warning, AlertDescription.close_notify
+            ))
+
+            node = node.add_child(ExpectAlert())
+            node.next_sibling = ExpectClose()
+            name = "unreasonable algorithm {0}, fall back to zlib"\
+                   .format(unreasonable_compression_algorithm)
+            conversations[name] = conversation
+
+    # Empty list in extension
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = \
+            ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = \
+            SupportedVersionsExtension().create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = \
+            SupportedGroupsExtension().create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256,
+                SignatureScheme.ecdsa_secp256r1_sha256,
+                SignatureScheme.ed25519,
+                SignatureScheme.ed448]
+    ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    compression_algs = []
+    ext[ExtensionType.compress_certificate] = \
+        CompressedCertificateExtension().create(compression_algs)
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                          AlertDescription.decode_error))
+    node.add_child(ExpectClose())
+    conversations["empty list"] = conversation
+
+    # duplicated values in extension
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = \
+            ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = \
+            SupportedVersionsExtension().create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = \
+            SupportedGroupsExtension().create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256,
+                SignatureScheme.ecdsa_secp256r1_sha256,
+                SignatureScheme.ed25519,
+                SignatureScheme.ed448]
+    ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    compression_algs = [list(compression_algorithms.values())[0]] * 3
+    ext[ExtensionType.compress_certificate] = \
+        CompressedCertificateExtension().create(compression_algs)
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCompressedCertificate(
+        compression_algo=list(compression_algorithms.values())[0]))
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                        AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert())
+    node.add_child(ExpectClose())
+    conversations["duplicated algos"] = conversation
+
+    # modified extension
+    for name, new_len in [
+        ("zero len in extension", 0),
+        ("odd len of list", 5),
+        ("truncated extension", 8),
+        ("padded extension", 4)
+    ]:
+        conversation = Connect(host, port)
+        node = conversation
+        ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+        ext = {}
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        for group in groups:
+            key_shares.append(key_share_gen(group))
+        ext[ExtensionType.key_share] = \
+                ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = \
+                SupportedVersionsExtension().create([TLS_1_3_DRAFT, (3, 3)])
+        ext[ExtensionType.supported_groups] = \
+                SupportedGroupsExtension().create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256,
+                    SignatureScheme.ecdsa_secp256r1_sha256,
+                    SignatureScheme.ed25519,
+                    SignatureScheme.ed448]
+        ext[ExtensionType.signature_algorithms] = \
+                SignatureAlgorithmsExtension().create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = \
+                SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        ext[ExtensionType.signature_algorithms_cert] = \
+                SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        compression_algs = [
+            CertificateCompressionAlgorithm.zlib,
+            CertificateCompressionAlgorithm.brotli,
+            CertificateCompressionAlgorithm.zstd
+        ]
+        ext[ExtensionType.compress_certificate] = \
+            CompressedCertificateExtension().create(compression_algs)
+        msg = ClientHelloGenerator(ciphers, extensions=ext)
+        node = node.add_child(fuzz_message(msg, substitutions={-7: new_len}))
+        node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                          AlertDescription.decode_error))
+        node = node.add_child(ExpectClose())
+        conversations[name] = conversation
+
+    # odd length
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = \
+            ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = \
+            SupportedVersionsExtension().create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = \
+            SupportedGroupsExtension().create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256,
+                SignatureScheme.ecdsa_secp256r1_sha256,
+                SignatureScheme.ed25519,
+                SignatureScheme.ed448]
+    ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    ext[ExtensionType.compress_certificate] = TLSExtension(
+        extType=ExtensionType.compress_certificate).create(
+            bytearray(b'\x00\x07'  # length of array
+                      b'\x00\x01'  # zlib
+                      b'\x00\x02'  # brotli
+                      b'\x00\x03'  # zstd
+                      b'\x04'))    # the odd byte
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                    AlertDescription.decode_error))
+    node = node.add_child(ExpectClose())
+    conversations["odd length of extension"] = conversation
+
+    # run the conversation
+    good = 0
+    bad = 0
+    xfail = 0
+    xpass = 0
+    failed = []
+    xpassed = []
+    if not num_limit:
+        num_limit = len(conversations)
+
+    # make sure that sanity test is run first and last
+    # to verify that server was running and kept running throughout
+    sanity_tests = [('sanity', conversations['sanity'])]
+    if run_only:
+        if num_limit > len(run_only):
+            num_limit = len(run_only)
+        regular_tests = [(k, v) for k, v in conversations.items() if k in run_only]
+    else:
+        regular_tests = [(k, v) for k, v in conversations.items() if
+                         (k != 'sanity') and k not in run_exclude]
+    sampled_tests = sample(regular_tests, min(num_limit, len(regular_tests)))
+    ordered_tests = chain(sanity_tests, sampled_tests, sanity_tests)
+
+    for c_name, c_test in ordered_tests:
+        print("{0} ...".format(c_name))
+
+        runner = Runner(c_test)
+
+        res = True
+        exception = None
+        try:
+            runner.run()
+        except Exception as exp:
+            exception = exp
+            print("Error while processing")
+            print(traceback.format_exc())
+            res = False
+
+        if c_name in expected_failures:
+            if res:
+                xpass += 1
+                xpassed.append(c_name)
+                print("XPASS-expected failure but test passed\n")
+            else:
+                if expected_failures[c_name] is not None and  \
+                    expected_failures[c_name] not in str(exception):
+                        bad += 1
+                        failed.append(c_name)
+                        print("Expected error message: {0}\n"
+                            .format(expected_failures[c_name]))
+                else:
+                    xfail += 1
+                    print("OK-expected failure\n")
+        else:
+            if res:
+                good += 1
+                print("OK\n")
+            else:
+                bad += 1
+                failed.append(c_name)
+
+    print("Basic communications with TLS 1.3 servers to test the")
+    print("compressed_certificate extension. This test does NOT expect the")
+    print("server to sent a RequestCertificate message.\n")
+
+
+    print("Test end")
+    print(20 * '=')
+    print("version: {0}".format(version))
+    print(20 * '=')
+    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
+    print("PASS: {0}".format(good))
+    print("XFAIL: {0}".format(xfail))
+    print("FAIL: {0}".format(bad))
+    print("XPASS: {0}".format(xpass))
+    print(20 * '=')
+    sort = sorted(xpassed ,key=natural_sort_keys)
+    if len(sort):
+        print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
+    sort = sorted(failed, key=natural_sort_keys)
+    if len(sort):
+        print("FAILED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
+
+    if bad or xpass:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-tls13-client-certificate-compression.py
+++ b/scripts/test-tls13-client-certificate-compression.py
@@ -1,0 +1,1040 @@
+# Author: George Pantelakis, (c) 2024
+# Contributor: Alexander Sosedkin
+# Released under Gnu GPL v2.0, see LICENSE file for details
+
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+import zlib
+from itertools import chain, combinations
+from random import sample
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+    ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+    FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+    CertificateGenerator, CompressedCertificateGenerator, \
+    CertificateVerifyGenerator, fuzz_message
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+    ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+    ExpectAlert, ExpectApplicationData, ExpectClose, \
+    ExpectEncryptedExtensions, ExpectCertificateVerify, \
+    ExpectNewSessionTicket, ExpectCompressedCertificate, \
+    ExpectCertificateRequest
+
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
+    TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+    CertificateCompressionAlgorithm
+from tlslite.keyexchange import ECDHKeyExchange
+from tlsfuzzer.utils.lists import natural_sort_keys
+from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
+    SupportedVersionsExtension, SupportedGroupsExtension, \
+    SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+    CompressedCertificateExtension, TLSExtension
+from tlsfuzzer.helpers import key_share_gen, SIG_ALL, expected_ext_parser, \
+    dict_update_non_present
+from tlslite.utils.compression import *
+from tlslite.utils.cryptomath import numberToByteArray
+from tlslite.utils.keyfactory import parsePEMKey
+from tlslite.x509 import X509
+from tlslite.x509certchain import X509CertChain
+
+
+version = 1
+
+KNOWN_ALGORITHMS = ('zlib', 'brotli', 'zstd')
+KNOWN_ALGORITHM_CODES = set([
+    CertificateCompressionAlgorithm.zlib,
+    CertificateCompressionAlgorithm.brotli,
+    CertificateCompressionAlgorithm.zstd])
+
+
+def help_msg():
+    print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
+    print(" -h hostname              name of the host to run the test against")
+    print("                          localhost by default")
+    print(" -p port                  port number to use for connection,")
+    print("                          4433 by default")
+    print(" probe-name               if present, will run only the probes")
+    print("                          with given names and not all of them,")
+    print("                          e.g \"sanity\"")
+    print(" -e probe-name            exclude the probe from the list of the")
+    print("                          ones run may be specified multiple times")
+    print(" -x probe-name            expect the probe to fail. When such")
+    print("                          probe passes despite being marked like")
+    print("                          this it will be reported in the test")
+    print("                          summary and the whole script will fail.")
+    print("                          May be specified multiple times.")
+    print(" -X message               expect the `message` substring in")
+    print("                          exception raised during execution of")
+    print("                          preceding expected failure probe")
+    print("                          usage: [-x probe-name] [-X exception]")
+    print("                          order is compulsory!")
+    print(" -n num                   run 'num' or all(if 0) tests instead of")
+    print("                          default(all).")
+    print("                          (\"sanity\" tests are always executed)")
+    print(" -C ciph                  Use specified ciphersuite. Either")
+    print("                          numerical value or IETF name.")
+    print(" -c certfile              file with the certificate of client")
+    print(" -k keyfile               file with the key of client")
+    print(" -E ext_spec              List of extensions that should be")
+    print("                          advertised by the client (in addition to")
+    print("                          the basic ones required to establish the")
+    print("                          connection). The ids can be specified by")
+    print("                          name (\"status_request\") or by number")
+    print("                          (\"5\"). After the ID specification")
+    print("                          there must be included short names of")
+    print("                          the messages in which the reply to")
+    print("                          extension needs to be included (\"CH\",")
+    print("                          \"SH\", \"EE\", \"CT\", \"CR\", \"NST\",")
+    print("                          \"HRR\"). Extensions are separated by")
+    print("                          spaces, messages are specified by colons,")
+    print("                          e.g.: \"status_request:CH:CT:CR\".")
+    print("                          Note: tlsfuzzer will try to create a")
+    print("                          sensible extension for extensions it")
+    print("                          knows about, but will create extension")
+    print("                          with empty payload for others. ")
+    print("                          Note: in this script, extensions marked")
+    print("                          CR will be verified only in the \"verify")
+    print("                          extensions in CertificateRequest\"")
+    print("                          script.")
+    print(" --algorithms algorithms  comma-separated list of compression")
+    print("                          algorithms: zlib,brotli,zstd by default")
+    print(" --skip-bombs             Skipping tests with compression bombs")
+    print(" --bomb-size num          Size of the bomb in MB, accepts only")
+    print("                          integers. Default value 100.")
+    print(" --full-fuzzing           Will fully fuzz the compression message")
+    print("                          with random bytes from 0 to 2**24.")
+    print("                          Default is disabled and only run a")
+    print("                          random sample is running. Enabling it is")
+    print("                          time and memory expensive.")
+    print(" --random-fuzz-size num   Specify the number of random samples to")
+    print("                          run. Default 20. If 0 is provided,")
+    print("                          fuzzing will be skipped. Overridden by")
+    print("                          --full-fuzzing.")
+    print(" --help                   this message")
+
+
+def main():
+    host = "localhost"
+    port = 4433
+    num_limit = None
+    run_exclude = set()
+    expected_failures = {}
+    last_exp_tmp = None
+    ciphers = None
+    cert = None
+    private_key = None
+    ext_spec = {'CH': None, 'SH': None, 'EE': None, 'CT': None, 'CR': None,
+                'NST': None, 'HRR': None}
+    compression_algorithms_list = list(KNOWN_ALGORITHMS)
+    run_bombs = True
+    bomb_size_MB = 100
+    full_fuzzing = False
+    fuzzing_sample_size = 20
+
+    argv = sys.argv[1:]
+    opts, args = getopt.getopt(argv, "h:p:e:x:X:n:C:k:c:E:", [
+        "algorithms=", "skip-bombs", "bomb-size=", "full-fuzzing",
+        "random-fuzz-size=", "help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '-e':
+            run_exclude.add(arg)
+        elif opt == '-x':
+            expected_failures[arg] = None
+            last_exp_tmp = str(arg)
+        elif opt == '-X':
+            if not last_exp_tmp:
+                raise ValueError("-x has to be specified before -X")
+            expected_failures[last_exp_tmp] = str(arg)
+        elif opt == '-n':
+            num_limit = int(arg)
+        elif opt == '-C':
+            if arg[:2] == '0x':
+                ciphers = [int(arg, 16)]
+            else:
+                try:
+                    ciphers = [getattr(CipherSuite, arg)]
+                except AttributeError:
+                    ciphers = [int(arg)]
+        elif opt == '-c':
+            text_cert = open(arg, 'rb').read()
+            if sys.version_info[0] >= 3:
+                text_cert = str(text_cert, 'utf-8')
+            cert = X509()
+            cert.parse(text_cert)
+        elif opt == '-k':
+            text_key = open(arg, 'rb').read()
+            if sys.version_info[0] >= 3:
+                text_key = str(text_key, 'utf-8')
+            private_key = parsePEMKey(text_key, private=True)
+        elif opt == '-E':
+            ext_spec = expected_ext_parser(arg)
+        elif opt == '--algorithms':
+            compression_algorithms_list = arg.split(',')
+        elif opt == '--skip-bombs':
+            run_bombs = False
+        elif opt == '--bomb-size':
+            bomb_size_MB = int(arg)
+        elif opt == '--full-fuzzing':
+            full_fuzzing = True
+        elif opt == '--random-fuzz-size':
+            fuzzing_sample_size = int(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+
+    if args:
+        run_only = set(args)
+    else:
+        run_only = None
+
+    if not private_key or not cert:
+        raise ValueError(
+            "Client private key and certificate must be specified.")
+
+    if not ciphers:
+        ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256]
+
+    compression_algorithms = {}
+
+    for alg_name in compression_algorithms_list:
+        try:
+            compression_algorithms[alg_name] = \
+                getattr(CertificateCompressionAlgorithm, alg_name)
+        except KeyError:
+            raise RuntimeError("unsupported algorithm `{0}`".format(alg_name))
+
+    server_supported_compression_algorithms = \
+        list(compression_algorithms.values())
+
+    if (
+        'brotli' in compression_algorithms
+        and not compression_algo_impls["brotli_compress"]
+    ):
+        print(
+            "Warning: Unsupported algorithm `brotli`, skipping algorithm. "
+            "Install Brotli python package if you want to test it."
+        )
+        compression_algorithms.pop('brotli')
+    if (
+        'zstd' in compression_algorithms
+        and not compression_algo_impls["zstd_compress"]
+    ):
+        print(
+            "Warning: Unsupported algorithm `zstd`, skipping algorithm. "
+            "Install zstandard python package if you want to test it."
+        )
+        compression_algorithms.pop('zstd')
+
+    if not compression_algorithms:
+        raise RuntimeError("No algorithms left to check.")
+
+    conversations = {}
+
+    # Sanity, no certificate compression
+    conversation = Connect(host, port)
+    node = conversation
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256,
+                SignatureScheme.ecdsa_secp256r1_sha256,
+                SignatureScheme.ed25519,
+                SignatureScheme.ed448]
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    ext = dict_update_non_present(ext, ext_spec['CH'])
+    node = node.add_child(ClientHelloGenerator(
+        ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+        extensions=ext))
+    ext = dict_update_non_present(None, ext_spec['SH'])
+    node = node.add_child(ExpectServerHello(extensions=ext))
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificateRequest())
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(CertificateGenerator(X509CertChain([cert])))
+    node = node.add_child(CertificateVerifyGenerator(private_key))
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                       AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+    conversations["sanity"] = conversation
+
+    # Check that CertificateRequest sends correct extensions
+    conversation = Connect(host, port)
+    algorithm=list(compression_algorithms.values())[0]
+    node = conversation
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = \
+        ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256,
+                SignatureScheme.ecdsa_secp256r1_sha256,
+                SignatureScheme.ed25519,
+                SignatureScheme.ed448]
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    compression_algs = [algorithm]
+    ext[ExtensionType.compress_certificate] = \
+        CompressedCertificateExtension().create(compression_algs)
+    ext = dict_update_non_present(ext, ext_spec['CH'])
+    cr_ext = {
+        ExtensionType.compress_certificate:
+            CompressedCertificateExtension().create(
+                server_supported_compression_algorithms),
+        ExtensionType.signature_algorithms: None
+    }
+    cr_ext = dict_update_non_present(cr_ext, ext_spec['CR'])
+    node = node.add_child(ClientHelloGenerator(
+        ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+        extensions=ext))
+    ext = dict_update_non_present(None, ext_spec['SH'])
+    node = node.add_child(ExpectServerHello(extensions=ext))
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificateRequest(extensions=cr_ext))
+    node = node.add_child(ExpectCompressedCertificate(
+        compression_algo=algorithm))
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(CompressedCertificateGenerator(
+        X509CertChain([cert])))
+    node = node.add_child(CertificateVerifyGenerator(private_key))
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                    AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+    conversations["CertificateRequest has correct extensions"] = conversation
+
+    # Check that CertificateRequest sends correct extensions even without
+    # client having sent the extension
+    conversation = Connect(host, port)
+    algorithm=list(compression_algorithms.values())[0]
+    node = conversation
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = \
+        ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256,
+                SignatureScheme.ecdsa_secp256r1_sha256,
+                SignatureScheme.ed25519,
+                SignatureScheme.ed448]
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    ext = dict_update_non_present(ext, ext_spec['CH'])
+    node = node.add_child(ClientHelloGenerator(
+        ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+        extensions=ext))
+    ext = dict_update_non_present(None, ext_spec['SH'])
+    node = node.add_child(ExpectServerHello(extensions=ext))
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    # cr_ext defined in previous test "CertificateRequest has correct
+    # extensions"
+    node = node.add_child(ExpectCertificateRequest(extensions=cr_ext))
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(CompressedCertificateGenerator(
+        X509CertChain([cert])))
+    node = node.add_child(CertificateVerifyGenerator(private_key))
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                    AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+    test_title="CertificateRequest has extension even if client doesn't"
+    conversations[test_title] = conversation
+
+    # Empty certificate
+    conversation = Connect(host, port)
+    algorithm=list(compression_algorithms.values())[0]
+    node = conversation
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = \
+        ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256,
+                SignatureScheme.ecdsa_secp256r1_sha256,
+                SignatureScheme.ed25519,
+                SignatureScheme.ed448]
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    compression_algs = [algorithm]
+    ext[ExtensionType.compress_certificate] = \
+        CompressedCertificateExtension().create(compression_algs)
+    ext = dict_update_non_present(ext, ext_spec['CH'])
+    node = node.add_child(ClientHelloGenerator(
+        ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+        extensions=ext))
+    ext = dict_update_non_present(None, ext_spec['SH'])
+    node = node.add_child(ExpectServerHello(extensions=ext))
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificateRequest())
+    node = node.add_child(ExpectCompressedCertificate(
+        compression_algo=algorithm))
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(CompressedCertificateGenerator())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                    AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+    conversations["Send empty certificate"] = conversation
+
+    # messing with uncompressed_size
+    for name, size in [
+        ('wrong', 10), ('zero', 0), ('max', 2**24 - 1)
+    ]:
+        conversation = Connect(host, port)
+        node = conversation
+        ext = {}
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        for group in groups:
+            key_shares.append(key_share_gen(group))
+        ext[ExtensionType.key_share] = \
+            ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            .create([TLS_1_3_DRAFT, (3, 3)])
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            .create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256,
+                    SignatureScheme.ecdsa_secp256r1_sha256,
+                    SignatureScheme.ed25519,
+                    SignatureScheme.ed448]
+        ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        compression_algs = [algorithm]
+        ext[ExtensionType.compress_certificate] = \
+            CompressedCertificateExtension().create(compression_algs)
+        ext = dict_update_non_present(ext, ext_spec['CH'])
+        node = node.add_child(ClientHelloGenerator(
+            ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+            extensions=ext))
+        ext = dict_update_non_present(None, ext_spec['SH'])
+        node = node.add_child(ExpectServerHello(extensions=ext))
+        node = node.add_child(ExpectChangeCipherSpec())
+        node = node.add_child(ExpectEncryptedExtensions())
+        node = node.add_child(ExpectCertificateRequest())
+        node = node.add_child(ExpectCompressedCertificate())
+        node.next_sibling = ExpectCertificate()
+        sibling_node = node.next_sibling
+        node = node.add_child(ExpectCertificateVerify())
+        sibling_node.add_child(node)
+        node = node.add_child(ExpectFinished())
+        node = node.add_child(CompressedCertificateGenerator(
+            X509CertChain([cert]),
+            uncompressed_message_size=size))
+        node = node.add_child(CertificateVerifyGenerator(private_key))
+        node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                          AlertDescription.bad_certificate))
+        node = node.add_child(ExpectClose())
+        conversations["{0} uncompressed_size".format(name)] = conversation
+
+    # use non advertized algorithm
+    diff = KNOWN_ALGORITHM_CODES.difference(
+        server_supported_compression_algorithms)
+    for algo in diff:
+        if algo not in compression_algorithms:
+            continue
+
+        conversation = Connect(host, port)
+        node = conversation
+        ext = {}
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        for group in groups:
+            key_shares.append(key_share_gen(group))
+        ext[ExtensionType.key_share] = \
+            ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            .create([TLS_1_3_DRAFT, (3, 3)])
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            .create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256,
+                    SignatureScheme.ecdsa_secp256r1_sha256,
+                    SignatureScheme.ed25519,
+                    SignatureScheme.ed448]
+        ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        compression_algs = [algorithm]
+        ext[ExtensionType.compress_certificate] = \
+            CompressedCertificateExtension().create(compression_algs)
+        ext = dict_update_non_present(ext, ext_spec['CH'])
+        node = node.add_child(ClientHelloGenerator(
+            ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+            extensions=ext))
+        ext = dict_update_non_present(None, ext_spec['SH'])
+        node = node.add_child(ExpectServerHello(extensions=ext))
+        node = node.add_child(ExpectChangeCipherSpec())
+        node = node.add_child(ExpectEncryptedExtensions())
+        node = node.add_child(ExpectCertificateRequest())
+        node = node.add_child(ExpectCompressedCertificate())
+        node.next_sibling = ExpectCertificate()
+        sibling_node = node.next_sibling
+        node = node.add_child(ExpectCertificateVerify())
+        sibling_node.add_child(node)
+        node = node.add_child(ExpectFinished())
+        node = node.add_child(CompressedCertificateGenerator(
+            X509CertChain([cert]), algorithm=algo))
+        node = node.add_child(CertificateVerifyGenerator(private_key))
+        node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                        AlertDescription.illegal_parameter))
+        node = node.add_child(ExpectClose())
+        test_title = "non advertized algorithm - {0}".format(
+            CertificateCompressionAlgorithm.toRepr(algo)
+        )
+        conversations[test_title] = conversation
+
+    # change the compression algorithm used to compress to a different
+    # supported one
+    for pair in combinations(compression_algorithms.items(), 2):
+        conversation = Connect(host, port)
+        node = conversation
+        ext = {}
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        for group in groups:
+            key_shares.append(key_share_gen(group))
+        ext[ExtensionType.key_share] = \
+            ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            .create([TLS_1_3_DRAFT, (3, 3)])
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            .create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256,
+                    SignatureScheme.ecdsa_secp256r1_sha256,
+                    SignatureScheme.ed25519,
+                    SignatureScheme.ed448]
+        ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        compression_algs = [algorithm]
+        ext[ExtensionType.compress_certificate] = \
+            CompressedCertificateExtension().create(compression_algs)
+        ext = dict_update_non_present(ext, ext_spec['CH'])
+        node = node.add_child(ClientHelloGenerator(
+            ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+            extensions=ext))
+        ext = dict_update_non_present(None, ext_spec['SH'])
+        node = node.add_child(ExpectServerHello(extensions=ext))
+        node = node.add_child(ExpectChangeCipherSpec())
+        node = node.add_child(ExpectEncryptedExtensions())
+        node = node.add_child(ExpectCertificateRequest())
+        node = node.add_child(ExpectCompressedCertificate())
+        node.next_sibling = ExpectCertificate()
+        sibling_node = node.next_sibling
+        node = node.add_child(ExpectCertificateVerify())
+        sibling_node.add_child(node)
+        node = node.add_child(ExpectFinished())
+        node = node.add_child(fuzz_message(CompressedCertificateGenerator(
+                X509CertChain([cert]),
+                algorithm=pair[0][1]),
+            substitutions={5: pair[1][1]}
+        ))
+        node = node.add_child(CertificateVerifyGenerator(private_key))
+        node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                        AlertDescription.bad_certificate))
+        node = node.add_child(ExpectClose())
+        test_title = "override actual algorithm used: {0} -> {1}".format(
+            pair[0][0], pair[1][0])
+        conversations[test_title] = conversation
+
+    # compress with zlib but override algorithm used with unsupported one
+    UNSUPPORTED_ALGORITHMS = set([ # Should not lead to certificate compression
+        0,                         # reserved
+        10,                        # Not supported / unknown algorithm
+        256,                       # 0x0100: valid algorithm, wrong octet
+        770,                       # 0x0302: valid algorithms in all octets
+        16383,                     # not reserved, but unlikely to be used soon
+        16384,                     # reserved
+        16385,                     # reserved
+        65534,                     # reserved
+        65535,                     # reserved
+    ])
+    for algo in UNSUPPORTED_ALGORITHMS:
+        algo_bytes = bytes(numberToByteArray(algo, 2))
+        conversation = Connect(host, port)
+        node = conversation
+        ext = {}
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        for group in groups:
+            key_shares.append(key_share_gen(group))
+        ext[ExtensionType.key_share] = \
+            ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            .create([TLS_1_3_DRAFT, (3, 3)])
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            .create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256,
+                    SignatureScheme.ecdsa_secp256r1_sha256,
+                    SignatureScheme.ed25519,
+                    SignatureScheme.ed448]
+        ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        compression_algs = [algorithm]
+        ext[ExtensionType.compress_certificate] = \
+            CompressedCertificateExtension().create(compression_algs)
+        ext = dict_update_non_present(ext, ext_spec['CH'])
+        node = node.add_child(ClientHelloGenerator(
+            ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+            extensions=ext))
+        ext = dict_update_non_present(None, ext_spec['SH'])
+        node = node.add_child(ExpectServerHello(extensions=ext))
+        node = node.add_child(ExpectChangeCipherSpec())
+        node = node.add_child(ExpectEncryptedExtensions())
+        node = node.add_child(ExpectCertificateRequest())
+        node = node.add_child(ExpectCompressedCertificate())
+        node.next_sibling = ExpectCertificate()
+        sibling_node = node.next_sibling
+        node = node.add_child(ExpectCertificateVerify())
+        sibling_node.add_child(node)
+        node = node.add_child(ExpectFinished())
+        node = node.add_child(fuzz_message(CompressedCertificateGenerator(
+                X509CertChain([cert]),
+                algorithm=CertificateCompressionAlgorithm.zlib),
+            substitutions=dict(enumerate(algo_bytes, 4))
+        ))
+        node = node.add_child(CertificateVerifyGenerator(private_key))
+        node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                          AlertDescription.illegal_parameter))
+        node = node.add_child(ExpectClose())
+        conversations["unsupported algorithm, {0}".format(algo)] = \
+            conversation
+
+    # Send compression bombs
+    if run_bombs:
+        print("Log: Preparing compression bombs, this might take a while...")
+        bombs = {}
+        mb_of_zeroes = b'\0' * 2**20
+
+        if 'zlib' in compression_algorithms:
+            zlib_compressor = zlib.compressobj()
+            bombs['zlib'] = b''
+            for _ in range(bomb_size_MB):
+                bombs['zlib'] += zlib_compressor.compress(mb_of_zeroes)
+            bombs['zlib'] += zlib_compressor.flush()
+            assert(len(bombs['zlib']) < 2**24)
+
+        if 'brotli' in compression_algorithms:
+            brotli_compressor = brotli.Compressor()
+            bombs['brotli'] = b''
+            for _ in range(bomb_size_MB):
+                bombs['brotli'] += brotli_compressor.process(mb_of_zeroes)
+            bombs['brotli'] += brotli_compressor.flush()
+            assert(len(bombs['brotli']) < 2**24)
+
+        if 'zstd' in compression_algorithms:
+            import zstd
+            # no streaming interface for the most popular zstd binding,
+            # but not all hope is lost for Python 3
+            if sys.version_info < (3, 0):
+                many_bytes = b'\00' * (2**20 * bomb_size_MB)  # eats up RAM
+            else:
+                many_bytes = bytes(2**20 * bomb_size_MB)  # doesn't eat up RAM
+            assert len(many_bytes) == 2**20 * bomb_size_MB
+            bombs['zstd'] = zstd.ZSTD_compress(many_bytes)
+            assert(len(bombs['zstd']) < 2**24)
+
+        for alg_name, algorithm in compression_algorithms.items():
+            conversation = Connect(host, port)
+            node = conversation
+            ext = {}
+            groups = [GroupName.secp256r1]
+            key_shares = []
+            for group in groups:
+                key_shares.append(key_share_gen(group))
+            ext[ExtensionType.key_share] = \
+                ClientKeyShareExtension().create(key_shares)
+            ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+                .create([TLS_1_3_DRAFT, (3, 3)])
+            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+                .create(groups)
+            sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                        SignatureScheme.rsa_pss_pss_sha256,
+                        SignatureScheme.ecdsa_secp256r1_sha256,
+                        SignatureScheme.ed25519,
+                        SignatureScheme.ed448]
+            ext[ExtensionType.signature_algorithms] = \
+                SignatureAlgorithmsExtension().create(sig_algs)
+            ext[ExtensionType.signature_algorithms_cert] = \
+                SignatureAlgorithmsCertExtension().create(SIG_ALL)
+            compression_algs = [algorithm]
+            ext[ExtensionType.compress_certificate] = \
+                CompressedCertificateExtension().create(compression_algs)
+            ext = dict_update_non_present(ext, ext_spec['CH'])
+            node = node.add_child(ClientHelloGenerator(
+                ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+                extensions=ext))
+            ext = dict_update_non_present(None, ext_spec['SH'])
+            node = node.add_child(ExpectServerHello(extensions=ext))
+            node = node.add_child(ExpectChangeCipherSpec())
+            node = node.add_child(ExpectEncryptedExtensions())
+            node = node.add_child(ExpectCertificateRequest())
+            node = node.add_child(ExpectCompressedCertificate())
+            node.next_sibling = ExpectCertificate()
+            sibling_node = node.next_sibling
+            node = node.add_child(ExpectCertificateVerify())
+            sibling_node.add_child(node)
+            node = node.add_child(ExpectFinished())
+            node = node.add_child(CompressedCertificateGenerator(
+                certs=X509CertChain([cert]),
+                algorithm=algorithm,
+                compressed_certificate_message=bombs[alg_name],
+                # Change the decompressed size to max sp the implementation
+                # will allocate the maximum size possible. If the big data
+                # comes we will see if there will be a leak or it will break.
+                uncompressed_message_size=2**24 - 1))
+            node = node.add_child(CertificateVerifyGenerator(private_key))
+            node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                              AlertDescription.bad_certificate))
+            node.next_sibling = ExpectClose()
+            conversations["{0} bomb".format(alg_name)] = conversation
+
+    for alg_name, algo, after in [
+        (alg_name, algo, after)
+        for alg_name, algo in compression_algorithms.items()
+        for after in [True, False]
+    ]:
+        msg = bytes(b'\x00\x00\x00\x00')
+        if algo == CertificateCompressionAlgorithm.zlib:
+            compressed_msg = zlib.compress(msg)
+        elif algo == CertificateCompressionAlgorithm.brotli:
+            compressed_msg = compression_algo_impls["brotli_compress"](msg)
+        else:
+            assert algo == CertificateCompressionAlgorithm.zstd
+            compressed_msg = compression_algo_impls["zstd_compress"](msg)
+
+        orig_comp_msg_len = len(compressed_msg)
+        if after:
+            # 2 more bytes at the end
+            compressed_msg += b'\x00\x00'
+        else:
+            # 2 more bytes at the beginning
+            compressed_msg = b'\x00\x00' + compressed_msg
+
+        conversation = Connect(host, port)
+        node = conversation
+        ext = {}
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        for group in groups:
+            key_shares.append(key_share_gen(group))
+        ext[ExtensionType.key_share] = \
+            ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            .create([TLS_1_3_DRAFT, (3, 3)])
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            .create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256,
+                    SignatureScheme.ecdsa_secp256r1_sha256,
+                    SignatureScheme.ed25519,
+                    SignatureScheme.ed448]
+        ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        compression_algs = [CertificateCompressionAlgorithm.zlib]
+        ext[ExtensionType.compress_certificate] = \
+            CompressedCertificateExtension().create(compression_algs)
+        ext = dict_update_non_present(ext, ext_spec['CH'])
+        node = node.add_child(ClientHelloGenerator(
+            ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+            extensions=ext))
+        ext = dict_update_non_present(None, ext_spec['SH'])
+        node = node.add_child(ExpectServerHello(extensions=ext))
+        node = node.add_child(ExpectChangeCipherSpec())
+        node = node.add_child(ExpectEncryptedExtensions())
+        node = node.add_child(ExpectCertificateRequest())
+        node = node.add_child(ExpectCompressedCertificate(
+            compression_algo=CertificateCompressionAlgorithm.zlib))
+        node.next_sibling = ExpectCertificate()
+        sibling_node = node.next_sibling
+        node = node.add_child(ExpectCertificateVerify())
+        sibling_node.add_child(node)
+        node = node.add_child(ExpectFinished())
+        node = node.add_child(fuzz_message(CompressedCertificateGenerator(
+            certs=X509CertChain([cert]),
+            algorithm=algo,
+            compressed_certificate_message=compressed_msg,
+        ), substitutions={
+            8: 4, - len(compressed_msg) - 1: orig_comp_msg_len}))
+        node = node.add_child(CertificateVerifyGenerator(private_key))
+        node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                          AlertDescription.decode_error))
+        node.next_sibling = ExpectClose()
+        name = (
+            "Additional bytes, {0}, ".format(alg_name) +
+            ( "after, " if after else "before, " ) + "unreflected in size"
+        )
+        conversations[name] = conversation
+
+    # Fuzzing compressed message
+    algorithm=list(compression_algorithms.values())[0]
+    sizes = []
+    if full_fuzzing:
+        sizes = range(0, 2**24)
+    elif fuzzing_sample_size > 0:
+        # Handshake message can be up to 2**24 - 1 size so due to other
+        # fields in the message we can generate up to the max_size amount
+        max_size = 2**24 - 1 - 2 - 3 - 3
+        if fuzzing_sample_size > 2:
+            sizes = sample(range(1, max_size), fuzzing_sample_size - 2)
+        sizes.append(0)
+        sizes.append(max_size)
+
+    for size in sizes:
+        conversation = Connect(host, port)
+        node = conversation
+        ext = {}
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        for group in groups:
+            key_shares.append(key_share_gen(group))
+        ext[ExtensionType.key_share] = \
+            ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            .create([TLS_1_3_DRAFT, (3, 3)])
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            .create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256,
+                    SignatureScheme.ecdsa_secp256r1_sha256,
+                    SignatureScheme.ed25519,
+                    SignatureScheme.ed448]
+        ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(SIG_ALL)
+        compression_algs = [algorithm]
+        ext[ExtensionType.compress_certificate] = \
+            CompressedCertificateExtension().create(compression_algs)
+        ext = dict_update_non_present(ext, ext_spec['CH'])
+        node = node.add_child(ClientHelloGenerator(
+            ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+            extensions=ext))
+        ext = dict_update_non_present(None, ext_spec['SH'])
+        node = node.add_child(ExpectServerHello(extensions=ext))
+        node = node.add_child(ExpectChangeCipherSpec())
+        node = node.add_child(ExpectEncryptedExtensions())
+        node = node.add_child(ExpectCertificateRequest())
+        node = node.add_child(ExpectCompressedCertificate(
+            compression_algo=algorithm))
+        node.next_sibling = ExpectCertificate()
+        sibling_node = node.next_sibling
+        node = node.add_child(ExpectCertificateVerify())
+        sibling_node.add_child(node)
+        node = node.add_child(ExpectFinished())
+        node = node.add_child(CompressedCertificateGenerator(
+            certs=X509CertChain([cert]),
+            algorithm=CertificateCompressionAlgorithm.zlib,
+            compressed_certificate_message=bytearray(size),
+            # Change the decompressed size to max sp the implementation
+            # will allocate the maximum size possible. If the big data
+            # comes we will see if there will be a leak or it will break.
+            uncompressed_message_size=2**24 - 1))
+        node = node.add_child(CertificateVerifyGenerator(private_key))
+        node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                          AlertDescription.bad_certificate))
+        node.next_sibling = ExpectClose()
+        conversations["fuzzing of {0:,} bytes".format(size)] = \
+            conversation
+
+    # run the conversation
+    good = 0
+    bad = 0
+    xfail = 0
+    xpass = 0
+    failed = []
+    xpassed = []
+    if not num_limit:
+        num_limit = len(conversations)
+
+    # make sure that sanity test is run first and last
+    # to verify that server was running and kept running throughout
+    sanity_tests = [('sanity', conversations['sanity'])]
+    if run_only:
+        if num_limit > len(run_only):
+            num_limit = len(run_only)
+        regular_tests = [(k, v) for k, v in conversations.items() if k in run_only]
+    else:
+        regular_tests = [(k, v) for k, v in conversations.items() if
+                         (k != 'sanity') and k not in run_exclude]
+    sampled_tests = sample(regular_tests, min(num_limit, len(regular_tests)))
+    ordered_tests = chain(sanity_tests, sampled_tests, sanity_tests)
+
+    for c_name, c_test in ordered_tests:
+        print("{0} ...".format(c_name))
+
+        runner = Runner(c_test)
+
+        res = True
+        exception = None
+        try:
+            runner.run()
+        except Exception as exp:
+            exception = exp
+            print("Error while processing")
+            print(traceback.format_exc())
+            res = False
+
+        if c_name in expected_failures:
+            if res:
+                xpass += 1
+                xpassed.append(c_name)
+                print("XPASS-expected failure but test passed\n")
+            else:
+                if expected_failures[c_name] is not None and  \
+                    expected_failures[c_name] not in str(exception):
+                        bad += 1
+                        failed.append(c_name)
+                        print("Expected error message: {0}\n"
+                            .format(expected_failures[c_name]))
+                else:
+                    xfail += 1
+                    print("OK-expected failure\n")
+        else:
+            if res:
+                good += 1
+                print("OK\n")
+            else:
+                bad += 1
+                failed.append(c_name)
+
+    print("Basic communications with TLS 1.3 servers to test the")
+    print("compressed certificate message. This test DOES expect that the")
+    print("server will sent a RequestCertificate message so the clint then")
+    print("can send its certificate.\n")
+
+    print("Test end")
+    print(20 * '=')
+    print("version: {0}".format(version))
+    print(20 * '=')
+    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
+    print("PASS: {0}".format(good))
+    print("XFAIL: {0}".format(xfail))
+    print("FAIL: {0}".format(bad))
+    print("XPASS: {0}".format(xpass))
+    print(20 * '=')
+    sort = sorted(xpassed ,key=natural_sort_keys)
+    if len(sort):
+        print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
+    sort = sorted(failed, key=natural_sort_keys)
+    if len(sort):
+        print("FAILED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
+
+    if bad or xpass:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts_retention.py
+++ b/tests/scripts_retention.py
@@ -157,7 +157,7 @@ def run_clients(tests, common_args, srv, expected_size, run_only=None):
         script = params["name"]
 
         if run_only is not None and script != run_only:
-            # If the test name doesn't match, count it as skipped 
+            # If the test name doesn't match, count it as skipped
             logger.info("{0}:skipped".format(script))
             skipped += 1
             continue

--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -32,7 +32,7 @@ from tlsfuzzer.expect import Expect, ExpectHandshake, ExpectServerHello, \
         srv_ext_handler_heartbeat, gen_srv_ext_handler_record_limit, \
         srv_ext_handler_status_request, ExpectHeartbeat, ExpectHelloRequest, \
         clnt_ext_handler_status_request, clnt_ext_handler_sig_algs, \
-        ExpectKeyUpdate
+        ExpectKeyUpdate, ExpectCompressedCertificate
 
 from tlslite.constants import ContentType, HandshakeType, ExtensionType, \
         AlertLevel, AlertDescription, ClientCertificateType, HashAlgorithm, \
@@ -40,19 +40,22 @@ from tlslite.constants import ContentType, HandshakeType, ExtensionType, \
         SSL2ErrorDescription, GroupName, CertificateStatusType, ECPointFormat,\
         SignatureScheme, TLS_1_3_HRR, HeartbeatMode, \
         TLS_1_1_DOWNGRADE_SENTINEL, TLS_1_2_DOWNGRADE_SENTINEL, \
-        HeartbeatMessageType, KeyUpdateMessageType
+        HeartbeatMessageType, KeyUpdateMessageType, \
+        CertificateCompressionAlgorithm
 from tlslite.messages import Message, ServerHello, CertificateRequest, \
         ClientHello, Certificate, ServerHello2, ServerFinished, \
         ServerKeyExchange, CertificateStatus, CertificateVerify, \
         Finished, EncryptedExtensions, NewSessionTicket, Heartbeat, \
-        KeyUpdate, HelloRequest, ServerHelloDone, NewSessionTicket1_0
+        KeyUpdate, HelloRequest, ServerHelloDone, NewSessionTicket1_0, \
+        CompressedCertificate
 from tlslite.extensions import SNIExtension, TLSExtension, \
         SupportedGroupsExtension, ALPNExtension, ECPointFormatsExtension, \
         NPNExtension, ServerKeyShareExtension, ClientKeyShareExtension, \
         SrvSupportedVersionsExtension, SupportedVersionsExtension, \
         HRRKeyShareExtension, CookieExtension, \
         SrvPreSharedKeyExtension, PskIdentity, PreSharedKeyExtension, \
-        HeartbeatExtension, StatusRequestExtension
+        HeartbeatExtension, StatusRequestExtension, \
+        CompressedCertificateExtension
 from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509certchain import X509CertChain, X509
 from tlslite.extensions import SNIExtension, SignatureAlgorithmsExtension
@@ -398,23 +401,15 @@ class TestServerExtensionProcessors(unittest.TestCase):
             srv_ext_handler_status_request(state, ext)
 
     def test_clnt_ext_handler_status_request(self):
-        ext = StatusRequestExtension().create()
+        ext = StatusRequestExtension()
 
-        clnt_ext_handler_status_request(None, ext)
+        srv_ext_handler_sni(None, ext)
 
-    def test_clnt_ext_handler_status_request_with_empty_extension(self):
+    def test_clnt_ext_handler_status_request_with_non_empty_extension(self):
         ext = StatusRequestExtension().create()
-        ext.responder_id_list = None
 
         with self.assertRaises(AssertionError):
-            clnt_ext_handler_status_request(None, ext)
-
-    def test_clnt_ext_handler_status_request_with_wrong_type(self):
-        ext = StatusRequestExtension().create()
-        ext.status_type = 0
-
-        with self.assertRaises(AssertionError):
-            clnt_ext_handler_status_request(None, ext)
+            srv_ext_handler_sni(None, ext)
 
     def test_srv_ext_handler_renego(self):
         ext = RenegotiationInfoExtension().create(bytearray(b'abba'))
@@ -2666,7 +2661,7 @@ class TestExpectFinished(unittest.TestCase):
         # is called with them
         state = ConnectionState()
         msg = Message(ContentType.handshake,
-                      bytearray([HandshakeType.finished, 0, 0, 12]) + 
+                      bytearray([HandshakeType.finished, 0, 0, 12]) +
                       bytearray(b"\xa3;\x9c\xc9\'E\xbc\xf6\xc7\x96\xaf\x7f"))
 
         exp.process(state, msg)
@@ -4058,3 +4053,137 @@ class TestExpectHelloRequest(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             self.exp.process(None, hd)
+
+class TestExpectCompressedCertificate(unittest.TestCase):
+    def test___init__(self):
+        exp = ExpectCompressedCertificate()
+        self.assertIsNotNone(exp)
+        self.assertIsInstance(exp, ExpectCompressedCertificate)
+        self.assertTrue(exp.is_expect())
+        self.assertFalse(exp.is_generator())
+        self.assertFalse(exp.is_command())
+        self.assertEqual(exp.cert_type, CertificateType.x509)
+        self.assertIsNone(exp._old_cert)
+        self.assertIsNone(exp._old_cert_bytes)
+        self.assertIsNone(exp._compression_algo)
+
+    def test_compression_algo_in_init(self):
+        exp = ExpectCompressedCertificate(
+            compression_algo=CertificateCompressionAlgorithm.zlib)
+
+        self.assertEqual(
+            exp._compression_algo, CertificateCompressionAlgorithm.zlib)
+
+    def test_process_with_defaults(self):
+        exp = ExpectCompressedCertificate()
+
+        state = ConnectionState()
+        state.version = (3, 4)
+        client_hello = ClientHello()
+        client_hello.addExtension(CompressedCertificateExtension().create(
+            [CertificateCompressionAlgorithm.zlib]))
+        state.handshake_messages.append(client_hello)
+
+        cc = CompressedCertificate(CertificateType.x509).create(
+            CertificateCompressionAlgorithm.zlib,
+            X509CertChain([X509().parse(srv_raw_certificate)]))
+
+        exp.process(state, cc)
+
+    def test_process_with_certificate(self):
+        exp = ExpectCompressedCertificate()
+
+        cert = Certificate(CertificateType.x509).create(
+            X509CertChain([X509().parse(srv_raw_certificate)]))
+
+        with self.assertRaises(AssertionError):
+            exp.process(None, cert)
+
+    def test_process_with_wrong_message(self):
+        exp = ExpectCompressedCertificate()
+
+        hd = ServerHelloDone().create()
+
+        with self.assertRaises(AssertionError):
+            exp.process(None, hd)
+
+    def test_process_twice(self):
+        exp = ExpectCompressedCertificate()
+
+        state = ConnectionState()
+        state.version = (3, 4)
+        client_hello = ClientHello()
+        client_hello.addExtension(CompressedCertificateExtension().create(
+            [CertificateCompressionAlgorithm.zlib]))
+        state.handshake_messages.append(client_hello)
+
+        cc = CompressedCertificate(CertificateType.x509).create(
+            CertificateCompressionAlgorithm.zlib,
+            X509CertChain([X509().parse(srv_raw_certificate)]))
+
+        self.assertIsNone(exp._old_cert)
+        self.assertIsNone(exp._old_cert_bytes)
+
+        exp.process(state, cc)
+
+        self.assertIsNotNone(exp._old_cert)
+        self.assertIsNotNone(exp._old_cert_bytes)
+        previous_old_cert_bytes = exp._old_cert_bytes
+
+        exp.process(state, cc)
+
+        self.assertEqual(exp._old_cert_bytes, previous_old_cert_bytes)
+
+    def test_process_not_advertized(self):
+        exp = ExpectCompressedCertificate()
+
+        state = ConnectionState()
+        state.version = (3, 4)
+        client_hello = ClientHello()
+        client_hello.addExtension(CompressedCertificateExtension().create(
+            [CertificateCompressionAlgorithm.brotli]))
+        state.handshake_messages.append(client_hello)
+
+        cc = CompressedCertificate(CertificateType.x509).create(
+            CertificateCompressionAlgorithm.zlib,
+            X509CertChain([X509().parse(srv_raw_certificate)]))
+
+        with self.assertRaises(AssertionError):
+            exp.process(state, cc)
+
+    def test_process_with_compression_algorithm(self):
+        exp = ExpectCompressedCertificate(
+            compression_algo=CertificateCompressionAlgorithm.zlib)
+
+        state = ConnectionState()
+        state.version = (3, 4)
+        client_hello = ClientHello()
+        client_hello.addExtension(CompressedCertificateExtension().create(
+            [CertificateCompressionAlgorithm.zlib]))
+        state.handshake_messages.append(client_hello)
+
+        cc = CompressedCertificate(CertificateType.x509).create(
+            CertificateCompressionAlgorithm.zlib,
+            X509CertChain([X509().parse(srv_raw_certificate)]))
+
+        exp.process(state, cc)
+
+    def test_process_with_wrong_compression_algorithm(self):
+        exp = ExpectCompressedCertificate(
+            compression_algo=CertificateCompressionAlgorithm.brotli)
+
+        state = ConnectionState()
+        state.version = (3, 4)
+        client_hello = ClientHello()
+        client_hello.addExtension(CompressedCertificateExtension().create(
+            [CertificateCompressionAlgorithm.zlib]))
+        state.handshake_messages.append(client_hello)
+
+        cc = CompressedCertificate(CertificateType.x509).create(
+            CertificateCompressionAlgorithm.zlib,
+            X509CertChain([X509().parse(srv_raw_certificate)]))
+
+        with self.assertRaises(AssertionError) as e:
+            exp.process(state, cc)
+
+        self.assertIn("Compression algorithms doesn't much.", str(e.exception))

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -309,6 +309,7 @@
                          "--exc", "11",
                          "--exc", "12",
                          "--exc", "23",
+                         "--exc", "27",
                          "--exc", "13172"],
           "comment" : "several tls12 extensions must be excluded, tlslite-ng issue #314"},
          {"name" : "test-tls13-large-number-of-extensions.py",
@@ -361,7 +362,8 @@
          {"name" : "test-unsupported-curve-fallback.py"},
          {"name" : "test-version-numbers.py"},
          {"name" : "test-x25519.py"},
-         {"name" : "test-zero-length-data.py"}
+         {"name" : "test-zero-length-data.py"},
+         {"name" : "test-tls13-certificate-compression.py"}
      ]
     },
     {"server_command": ["{python}", "-u", "{command}", "server",
@@ -421,10 +423,11 @@
          {"name" : "test-rsa-sigs-on-certificate-verify.py"},
          {"name" : "test-rsa-sigs-on-certificate-verify.py",
           "arguments" : ["-d"]},
-         {"name" : "test-tls13-certificate-request.py"},
+         {"name" : "test-tls13-certificate-request.py",
+          "arguments" : ["-E", "compress_certificate:CR key_share:SH supported_versions:SH"]},
          {"name" : "test-tls13-certificate-request.py",
           "comment": "Test with additional extensions",
-          "arguments" : ["-E", "status_request:CH:CT key_share:SH supported_versions:SH"]
+          "arguments" : ["-E", "compress_certificate:CR status_request:CH:CT key_share:SH supported_versions:SH"]
           },
          {"name" : "test-tls13-certificate-verify.py",
           "arguments" : ["-k", "tests/clientRSAPSSKey.pem",
@@ -442,6 +445,13 @@
          {"name" : "test-tls13-eddsa-in-certificate-verify.py",
           "arguments" : ["-k", "tests/serverEd448Key.pem",
                          "-c", "tests/serverEd448Cert.pem"]
+         },
+         {"name" : "test-tls13-client-certificate-compression.py",
+          "arguments" : ["-k", "tests/clientX509Key.pem",
+                         "-c", "tests/clientX509Cert.pem",
+                         "--skip-bombs",
+                         "--random-fuzz-size", "0",
+                         "--algorithms", "zlib"]
          }
      ]
     },

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -310,6 +310,7 @@
                          "--exc", "11",
                          "--exc", "12",
                          "--exc", "23",
+                         "--exc", "27",
                          "--exc", "13172"],
           "comment" : "several tls12 extensions must be excluded, tlslite-ng issue #314"},
          {"name" : "test-tls13-large-number-of-extensions.py",
@@ -361,7 +362,8 @@
          {"name" : "test-unsupported-curve-fallback.py"},
          {"name" : "test-version-numbers.py"},
          {"name" : "test-x25519.py"},
-         {"name" : "test-zero-length-data.py"}
+         {"name" : "test-zero-length-data.py"},
+         {"name" : "test-tls13-certificate-compression.py"}
      ]
     },
     {"server_command": ["{python}", "-u", "{command}", "server",
@@ -421,10 +423,11 @@
          {"name" : "test-rsa-sigs-on-certificate-verify.py"},
          {"name" : "test-rsa-sigs-on-certificate-verify.py",
           "arguments" : ["-d"]},
-         {"name" : "test-tls13-certificate-request.py"},
+         {"name" : "test-tls13-certificate-request.py",
+          "arguments" : ["-E", "compress_certificate:CR key_share:SH supported_versions:SH"]},
          {"name" : "test-tls13-certificate-request.py",
           "comment": "Test with additional extensions",
-          "arguments" : ["-E", "status_request:CH:CT key_share:SH supported_versions:SH"]
+          "arguments" : ["-E", "compress_certificate:CR status_request:CH:CT key_share:SH supported_versions:SH"]
           },
          {"name" : "test-tls13-certificate-verify.py",
           "arguments" : ["-k", "tests/clientRSAPSSKey.pem",
@@ -442,6 +445,13 @@
          {"name" : "test-tls13-eddsa-in-certificate-verify.py",
           "arguments" : ["-k", "tests/serverEd448Key.pem",
                          "-c", "tests/serverEd448Cert.pem"]
+         },
+         {"name" : "test-tls13-client-certificate-compression.py",
+          "arguments" : ["-k", "tests/clientX509Key.pem",
+                         "-c", "tests/clientX509Cert.pem",
+                         "--skip-bombs",
+                         "--random-fuzz-size", "0",
+                         "--algorithms", "zlib"]
          }
      ]
     },

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -15,12 +15,13 @@ from tlslite.constants import ContentType, HandshakeType, CertificateType,\
         SSL2HandshakeType, CipherSuite, GroupName, AlertDescription, \
         SignatureScheme, TLS_1_3_HRR, HeartbeatMode, \
         TLS_1_1_DOWNGRADE_SENTINEL, TLS_1_2_DOWNGRADE_SENTINEL, \
-        HeartbeatMessageType, ClientCertificateType, CertificateStatusType
+        HeartbeatMessageType, ClientCertificateType, CertificateStatusType, \
+        CertificateCompressionAlgorithm
 from tlslite.messages import ServerHello, Certificate, ServerHelloDone,\
         ChangeCipherSpec, Finished, Alert, CertificateRequest, ServerHello2,\
         ServerKeyExchange, ClientHello, ServerFinished, CertificateStatus, \
         CertificateVerify, EncryptedExtensions, NewSessionTicket, Heartbeat,\
-        KeyUpdate, HelloRequest, NewSessionTicket1_0
+        KeyUpdate, HelloRequest, NewSessionTicket1_0, CompressedCertificate
 from tlslite.extensions import TLSExtension, ALPNExtension
 from tlslite.utils.codec import Parser, Writer
 from tlslite.utils.compat import b2a_hex
@@ -460,17 +461,13 @@ def clnt_ext_handler_status_request(state, extension):
     """
     Check status_request extension from initiating side.
 
-    To be used in ClientHello and CertificateRequest
+    To be used in CertificateRequest
     """
     del state  # kept for compatibility
-    if extension.status_type != CertificateStatusType.ocsp:
+    if extension.extData:
         raise AssertionError(
-            "Unexpected status_type in status_request extension: {0}"
-            .format(CertificateStatusType.toStr(extension.status_type)))
-    if extension.responder_id_list is None \
-            or extension.request_extensions is None:
-        raise AssertionError(
-            "Malformed status_request extension")
+            "Unexpected payload in status_request extension: {0}"
+            .format(extension.extData))
 
 
 def clnt_ext_handler_sig_algs(state, extension):
@@ -1035,6 +1032,55 @@ class ExpectCertificate(ExpectHandshake):
         state.handshake_hashes.update(msg_bytes)
 
 
+class ExpectCompressedCertificate(ExpectHandshake):
+    def __init__(self, cert_type=CertificateType.x509, compression_algo=None):
+        super(ExpectCompressedCertificate, self).__init__(
+            ContentType.handshake,
+            HandshakeType.compressed_certificate
+        )
+        self.cert_type = cert_type
+        self._old_cert = None
+        self._old_cert_bytes = None
+        self._compression_algo = compression_algo
+
+    def process(self, state, msg):
+        """
+        :type state: `~ConnectionState`
+        """
+        assert msg.contentType == ContentType.handshake
+
+        msg_bytes = msg.write()
+        if self._old_cert_bytes is not None and \
+                msg_bytes == self._old_cert_bytes:
+            cert = self._old_cert
+        else:
+            parser = Parser(msg_bytes)
+            hs_type = parser.get(1)
+            assert hs_type == HandshakeType.compressed_certificate
+
+            cert = CompressedCertificate(self.cert_type, state.version)
+            cert.parse(parser)
+            self._old_cert_bytes = msg_bytes
+            self._old_cert = cert
+
+            if self._compression_algo is not None:
+                if cert.compression_algo != self._compression_algo:
+                    raise AssertionError(
+                        "Compression algorithms doesn't much. " +
+                        "Expected: {0}, Got: {1}".format(
+                            self._compression_algo, cert.compression_algo)
+                    )
+            else:
+                ch = state.get_last_message_of_type(ClientHello)
+                assert ch is not None
+                ext = ch.getExtension(ExtensionType.compress_certificate)
+                assert ext is not None
+                assert cert.compression_algo in ext.algorithms
+
+        state.handshake_messages.append(cert)
+        state.handshake_hashes.update(msg_bytes)
+
+
 class ExpectCertificateVerify(ExpectHandshake):
     """
     Processing TLS Handshake protocol Certificate Verify messages.
@@ -1349,7 +1395,8 @@ class ExpectCertificateRequest(_ExpectExtensionsMessage):
             corresponding client certificate type.
         :param extensions: dictionary with extensions that need to be included
             in the message. Set to ``None`` to accept any, set to empty dict to
-            expect no extensions. Usable in TLS 1.3 only.
+            expect no extensions. This has to be an exact match of the
+            extensions included in the message. Usable in TLS 1.3 only.
         """
         msg_type = HandshakeType.certificate_request
         super(ExpectCertificateRequest, self).__init__(ContentType.handshake,

--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -9,11 +9,11 @@ from tlslite.messages import ClientHello, ClientKeyExchange, ChangeCipherSpec,\
         Finished, Alert, ApplicationData, Message, Certificate, \
         CertificateVerify, CertificateRequest, ClientMasterKey, \
         ClientFinished, ServerKeyExchange, ServerHello, Heartbeat, \
-        KeyUpdate
+        KeyUpdate, CompressedCertificate
 from tlslite.constants import AlertLevel, AlertDescription, ContentType, \
         ExtensionType, CertificateType, HashAlgorithm, \
         SignatureAlgorithm, CipherSuite, SignatureScheme, TLS_1_3_HRR, \
-        HeartbeatMessageType
+        HeartbeatMessageType, CertificateCompressionAlgorithm
 import tlslite.utils.tlshashlib as hashlib
 from tlslite.extensions import TLSExtension, RenegotiationInfoExtension, \
         ClientKeyShareExtension, StatusRequestExtension
@@ -26,6 +26,7 @@ from tlslite.utils.codec import Writer
 from tlslite.utils.cryptomath import getRandomBytes, numBytes, \
     numberToByteArray, bytesToNumber, HKDF_expand_label, secureHMAC, \
     derive_secret
+from tlslite.utils.compression import compression_algo_impls
 from tlslite.keyexchange import KeyExchange
 from tlslite.bufferedsocket import BufferedSocket
 from tlslite.recordlayer import ConnectionState
@@ -983,6 +984,103 @@ class CertificateGenerator(HandshakeProtocolMessageGenerator):
             context = context.certificate_request_context
         cert = Certificate(self.cert_type, version=self.version)
         cert.create(self.certs, context=context)
+        if self.context:
+            self.context.append(cert)
+
+        self.msg = cert
+        return cert
+
+
+class CompressedCertificateGenerator(HandshakeProtocolMessageGenerator):
+    """
+    Generator for TLS handshake protocol CompressedCertificate message.
+
+    :vartype certs: X509CertChain
+    :ivar certs: passed in CertificateGenerator class
+
+    :vartype cert_type: ClientCertificateType
+    :ivar cert_type: passed in CertificateGenerator class
+
+    :vartype version: tuple(int,int)
+    :ivar version: passed in CertificateGenerator class
+
+    :vartype context: bytearray
+    :ivar context: passed in CertificateGenerator class
+
+    :vartype algorithm: CertificateCompressionAlgorithm
+    :ivar algorithm: the compression algorithm that will be used to create the
+    compressed certificate message.
+
+    :vartype compressed_certificate_message: bytearray
+    :ivar compressed_certificate_message: The bytearray that will be used as a
+    payload to generate the compressed certificate message.
+    """
+
+    def __init__(self, certs=None, cert_type=None, version=None, context=None,
+                 algorithm=None, compressed_certificate_message=None,
+                 uncompressed_message_size=None):
+        """Set the compressed certificates to send to server."""
+        super(CompressedCertificateGenerator, self).__init__()
+
+        self.certs = certs
+        self.cert_type = cert_type
+        self.version = version
+        self.context = context
+        self.algorithm = algorithm
+        self.compressed_certificate_message = compressed_certificate_message
+        self.uncompressed_message_size = uncompressed_message_size
+
+    def generate(self, state):
+        """Create a Compressed Certificate message."""
+        if self.version is None:
+            self.version = state.version
+
+        if self.cert_type is None:
+            self.cert_type = CertificateType.x509
+
+        if self.algorithm is None:  # pick one from compress_certificate
+            cr = state.get_last_message_of_type(CertificateRequest)
+            assert cr is not None
+            ext = cr.getExtension(ExtensionType.compress_certificate)
+            assert ext is not None
+            algorithms = ext.algorithms
+
+            if CertificateCompressionAlgorithm.zlib in algorithms:
+                self.algorithm = CertificateCompressionAlgorithm.zlib
+            elif (
+                CertificateCompressionAlgorithm.brotli in algorithms
+                and compression_algo_impls["brotli_compress"]
+            ):
+                self.algorithm = CertificateCompressionAlgorithm.brotli
+            elif (
+                CertificateCompressionAlgorithm.zstd in algorithms
+                and compression_algo_impls["zstd_compress"]
+            ):
+                self.algorithm = CertificateCompressionAlgorithm.zstd
+            else:
+                raise ValueError(
+                    "No matching algorithms in compress_certificate. "
+                    "Algorithms: [{0}]".format(", ".join(
+                        CertificateCompressionAlgorithm.toStr(algo)
+                        for algo in algorithms
+                    ))
+                )
+
+        context = b''
+        if self.context:
+            context = self.context[-1]
+            assert isinstance(context, CertificateRequest)
+            context = context.certificate_request_context
+
+        cert = CompressedCertificate(self.cert_type, version=self.version)
+        cert.create(self.algorithm, self.certs, context=context)
+
+        if self.compressed_certificate_message is not None:
+            cert._compressed_msg = self.compressed_certificate_message
+
+        if self.uncompressed_message_size is not None:
+            cert._uncompressed_msg_len = self.uncompressed_message_size
+
         if self.context:
             self.context.append(cert)
 

--- a/tlsfuzzer/runner.py
+++ b/tlsfuzzer/runner.py
@@ -128,7 +128,7 @@ class ConnectionState(object):
     def get_server_public_key(self):
         """Extract server public key from server Certificate message"""
         certificates = (msg for msg in self.handshake_messages if\
-                        isinstance(msg, Certificate))
+                        isinstance(msg, (Certificate)))
         cert_message = next(certificates)
         return cert_message.cert_chain.getEndEntityPublicKey()
 


### PR DESCRIPTION
### Description
Added coverage for compressed_certificate extension and compressed certificate messages as described in https://www.rfc-editor.org/rfc/rfc8879.html

### Motivation and Context
https://github.com/tlsfuzzer/tlsfuzzer/issues/923
https://github.com/tlsfuzzer/tlslite-ng/issues/431
maybe https://github.com/tlsfuzzer/tlsfuzzer/issues/633

### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [x] GnuTLS

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/931)
<!-- Reviewable:end -->
