### PR TITLE
fuzzed-ciphertext: actually use the ciphersuites selected by default or by -C

### DIFF
--- a/scripts/test-fuzzed-ciphertext.py
+++ b/scripts/test-fuzzed-ciphertext.py
@@ -28,7 +28,7 @@ from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
 
 
-version = 5
+version = 6
 
 
 def help_msg():
@@ -117,11 +117,12 @@ def main():
                     ciphers[0] in CipherSuite.dhAllSuites
     else:
         if dhe:
-            ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-                       CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-                       CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
+            ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                       CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                       CipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256]
         else:
-            ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
+            ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256]
+    ciphers += [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
 
     conversations = {}
 
@@ -139,13 +140,6 @@ def main():
             SignatureAlgorithmsExtension().create(SIG_ALL)
         ext[ExtensionType.signature_algorithms_cert] = \
             SignatureAlgorithmsCertExtension().create(SIG_ALL)
-        ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-                   CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-                   CipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
-                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-    else:
-        ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
-            CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
     if not ext:
         ext = None
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
@@ -177,27 +171,6 @@ def main():
     for pos, val in fuzzes:
         conversation = Connect(host, port)
         node = conversation
-        ext = {}
-        if ems:
-            ext[ExtensionType.extended_master_secret] = AutoEmptyExtension()
-        if dhe:
-            groups = [GroupName.secp256r1,
-                      GroupName.ffdhe2048]
-            ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
-                .create(groups)
-            ext[ExtensionType.signature_algorithms] = \
-                SignatureAlgorithmsExtension().create(SIG_ALL)
-            ext[ExtensionType.signature_algorithms_cert] = \
-                SignatureAlgorithmsCertExtension().create(SIG_ALL)
-            ciphers = [CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-                       CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-                       CipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
-                       CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        else:
-            ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
-                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
-        if not ext:
-            ext = None
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectCertificate())


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
in the previous PR for it (https://github.com/tlsfuzzer/tlsfuzzer/pull/941) we didn't make `-C` work correctly

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
make command line options do what they say in help message

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/953)
<!-- Reviewable:end -->
