### PR TITLE
tlsfuzzer/extract.py: fix for ECDH analysis

### DIFF
--- a/tests/test_tlsfuzzer_extract.py
+++ b/tests/test_tlsfuzzer_extract.py
@@ -269,7 +269,7 @@ class TestCommandLine(unittest.TestCase):
                     key_type=None, frequency=None, hash_func=hashlib.sha256,
                     workers=None, verbose=False, rsa_keys=None,
                     sig_format="DER", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=None)
+                    value_endianness="big", max_bit_size=None)
                 mock_measurements.assert_not_called()
 
     @mock.patch(
@@ -308,7 +308,7 @@ class TestCommandLine(unittest.TestCase):
                     key_type=None, frequency=None, hash_func=hashlib.sha256,
                     workers=None, verbose=False, rsa_keys=None,
                     sig_format="DER", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=None)
+                    value_endianness="big", max_bit_size=None)
                 mock_measurements.assert_not_called()
 
     @mock.patch(
@@ -346,7 +346,7 @@ class TestCommandLine(unittest.TestCase):
                     key_type=None, frequency=None, hash_func=hashlib.sha256,
                     workers=None, verbose=False, rsa_keys=None,
                     sig_format="DER", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=None)
+                    value_endianness="big", max_bit_size=None)
                 mock_measurements.assert_not_called()
 
     @mock.patch(
@@ -381,7 +381,7 @@ class TestCommandLine(unittest.TestCase):
                     key_type=None, frequency=None, hash_func=hashlib.sha256,
                     workers=None, verbose=False, rsa_keys=None,
                     sig_format="DER", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=None)
+                    value_endianness="big", max_bit_size=None)
                 mock_measurements.assert_not_called()
 
     @mock.patch(
@@ -417,7 +417,7 @@ class TestCommandLine(unittest.TestCase):
                     key_type=None, frequency=None, hash_func=hashlib.sha256,
                     workers=None, verbose=False, rsa_keys=None,
                     sig_format="DER", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=None)
+                    value_endianness="big", max_bit_size=None)
                 mock_measurements.assert_not_called()
 
     @mock.patch('tlsfuzzer.extract.Log')
@@ -523,7 +523,7 @@ class TestCommandLine(unittest.TestCase):
                     key_type=None, frequency=None, hash_func=hashlib.sha256,
                     workers=None, verbose=False, rsa_keys=None,
                     sig_format="DER", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=None)
+                    value_endianness="big", max_bit_size=None)
                 mock_measurements.assert_not_called()
 
     @mock.patch('__main__.__builtins__.print')
@@ -596,7 +596,7 @@ class TestCommandLine(unittest.TestCase):
                     priv_key=None, key_type=None, frequency=None,
                     hash_func=hashlib.sha256, workers=None, verbose=False,
                     rsa_keys=priv_key, sig_format="DER", values=None,
-                    value_size=None, value_endianness="little",
+                    value_size=None, value_endianness="big",
                     max_bit_size=None)
                 mock_write.assert_not_called()
                 mock_write_pkt.assert_not_called()
@@ -639,7 +639,7 @@ class TestCommandLine(unittest.TestCase):
                     priv_key=priv_key, key_type="ec", frequency=None,
                     hash_func=hashlib.sha256, workers=None, verbose=False,
                     rsa_keys=None, sig_format="DER", values=None,
-                    value_size=None, value_endianness="little",
+                    value_size=None, value_endianness="big",
                     max_bit_size=None)
                 mock_write.assert_not_called()
                 mock_write_pkt.assert_not_called()
@@ -682,7 +682,7 @@ class TestCommandLine(unittest.TestCase):
                     priv_key=priv_key, key_type="ec", frequency=None,
                     hash_func=hashlib.sha256, workers=None, verbose=True,
                     rsa_keys=None, sig_format="DER", values=None,
-                    value_size=None, value_endianness="little",
+                    value_size=None, value_endianness="big",
                     max_bit_size=None)
                 mock_write.assert_not_called()
                 mock_write_pkt.assert_not_called()
@@ -727,7 +727,7 @@ class TestCommandLine(unittest.TestCase):
                     frequency=frequency * 1e6, hash_func=hashlib.sha256,
                     workers=None, verbose=False, rsa_keys=None,
                     sig_format="DER", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=None)
+                    value_endianness="big", max_bit_size=None)
                 mock_write.assert_not_called()
                 mock_write_pkt.assert_not_called()
                 mock_log.assert_not_called()
@@ -771,7 +771,7 @@ class TestCommandLine(unittest.TestCase):
                     frequency=None, hash_func=hashlib.sha384,
                     workers=None, verbose=False, rsa_keys=None,
                     sig_format="DER", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=None)
+                    value_endianness="big", max_bit_size=None)
                 mock_write.assert_not_called()
                 mock_write_pkt.assert_not_called()
                 mock_log.assert_not_called()
@@ -814,7 +814,7 @@ class TestCommandLine(unittest.TestCase):
                     frequency=None, hash_func=None,
                     workers=None, verbose=False, rsa_keys=None,
                     sig_format="DER", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=None)
+                    value_endianness="big", max_bit_size=None)
                 mock_write.assert_not_called()
                 mock_write_pkt.assert_not_called()
                 mock_log.assert_not_called()
@@ -858,7 +858,7 @@ class TestCommandLine(unittest.TestCase):
                     frequency=None, hash_func=hashlib.sha256,
                     workers=workers, verbose=False, rsa_keys=None,
                     sig_format="DER", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=None)
+                    value_endianness="big", max_bit_size=None)
                 mock_write.assert_not_called()
                 mock_write_pkt.assert_not_called()
                 mock_log.assert_not_called()
@@ -901,7 +901,7 @@ class TestCommandLine(unittest.TestCase):
                     frequency=None, hash_func=hashlib.sha256,
                     workers=None, verbose=False, rsa_keys=None,
                     sig_format="DER", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=None)
+                    value_endianness="big", max_bit_size=None)
                 mock_write.assert_not_called()
                 mock_write_pkt.assert_not_called()
                 mock_log.assert_not_called()
@@ -948,7 +948,7 @@ class TestCommandLine(unittest.TestCase):
                     frequency=None, hash_func=hashlib.sha256,
                     workers=None, verbose=False, rsa_keys=None,
                     sig_format="RAW", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=None)
+                    value_endianness="big", max_bit_size=None)
                 mock_write.assert_not_called()
                 mock_write_pkt.assert_not_called()
                 mock_log.assert_not_called()
@@ -1037,7 +1037,7 @@ class TestCommandLine(unittest.TestCase):
         data_size = 32
         raw_values = "/tmp/values"
         value_size = 64
-        value_endianness = "big"
+        value_endianness = "little"
         raw_times = "/tmp/times"
         priv_key = "/tmp/key"
         args = ["extract.py",
@@ -1107,7 +1107,7 @@ class TestCommandLine(unittest.TestCase):
                     frequency=None, hash_func=hashlib.sha256,
                     workers=None, verbose=False, rsa_keys=None,
                     sig_format="DER", values=None, value_size=None,
-                    value_endianness="little", max_bit_size=max_bit_size)
+                    value_endianness="big", max_bit_size=max_bit_size)
                 mock_write.assert_not_called()
                 mock_write_pkt.assert_not_called()
                 mock_log.assert_not_called()

--- a/tlsfuzzer/extract.py
+++ b/tlsfuzzer/extract.py
@@ -87,7 +87,7 @@ def help_msg():
     print("                script will try to calculate it.")
     print(" --value-endianness endian What endianness to use for the")
     print("                interpretation of the values, 'little' or 'big',")
-    print("                with little being the default")
+    print("                with big being the default")
     print(" --priv-key-ecdsa FILE Read the ecdsa private key from PEM file.")
     print(" --clock-frequency freq Assume that the times in the file are not")
     print("                specified in seconds but rather in clock cycles of")
@@ -148,7 +148,7 @@ def main():
     sig_format = "DER"
     values = None
     value_size = None
-    value_endianness = 'little'
+    value_endianness = 'big'
     priv_key = None
     key_type = None
     freq = None
@@ -1189,13 +1189,16 @@ class Extract:
 
         return secret_wrap_iter
 
-    def ecdh_max_value(self):
+    def ecdh_max_value(self, bits=False):
         """
         Returns the max shared secret size in BYTES depending on the ECDH
         private key.
         """
-        return int(
-            (ecdsa.util.bit_length(self.priv_key.curve.curve.p()) + 7) / 8)
+        if bits:
+            return ecdsa.util.bit_length(self.priv_key.curve.curve.p())
+        else:
+            return int(
+                (ecdsa.util.bit_length(self.priv_key.curve.curve.p()) + 7) / 8)
 
     def _create_and_write_line(self):
         """
@@ -1618,7 +1621,7 @@ class Extract:
                 else:
                     self.process_measurements_and_create_csv_file(
                         self.ecdh_iter(return_type=files[file]),
-                        self.ecdh_max_value() * 8
+                        self.ecdh_max_value(bits=True)
                     )
             return
 


### PR DESCRIPTION
### Description
1) Changed the default for value endianness from little to big 
2) Added argument to return the size in of bits in ecdh_max_value

### Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/964)
<!-- Reviewable:end -->
