### PR TITLE
Change bit count to work in all python versions

### DIFF
--- a/tlsfuzzer/extract.py
+++ b/tlsfuzzer/extract.py
@@ -30,6 +30,7 @@ from tlsfuzzer.utils.statics import WARM_UP
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 from tlsfuzzer.utils.progress_report import progress_report
+from tlsfuzzer.utils.compat import bit_count
 from tlslite.utils.cryptomath import bytesToNumber, numberToByteArray
 from tlslite.utils.python_key import Python_Key
 
@@ -1734,7 +1735,7 @@ class Extract:
                 key = self._read_private_key(rsa_keys)
                 if key:
                     # extract Hamming weights of the private key parameters
-                    values.append(dict((i, getattr(key, i).bit_count())
+                    values.append(dict((i, bit_count(getattr(key, i)))
                                        for i in
                                        value_names))
                     times.append(next(times_iterator))

--- a/tlsfuzzer/utils/compat.py
+++ b/tlsfuzzer/utils/compat.py
@@ -1,0 +1,16 @@
+# Author: George Pantelakis, (c) 2024
+# Released under Gnu GPL v2.0, see LICENSE file for details
+
+"""Miscellaneous functions to mask Python version differences."""
+
+import sys
+
+
+if sys.version_info >= (3, 10):
+    def bit_count(number):
+        """Counts the bits of an integer"""
+        return number.bit_count()
+else:
+    def bit_count(number):
+        """Counts the bits of an integer"""
+        return bin(number).count("1")


### PR DESCRIPTION
### Description
int.bit_count function is only available from Python version 3.10, in previous versions we need to follow a different method.

### Motivation and Context
Failures running with previous versions of python

### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] all new and existing tests pass (see CI results)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/966)
<!-- Reviewable:end -->
