### PR TITLE
rsa-sigs-on-certificate-verify: fix recognition of -n option

### DIFF
--- a/scripts/test-certificate-request.py
+++ b/scripts/test-certificate-request.py
@@ -100,7 +100,7 @@ def main():
                   ClientCertificateType.ecdsa_sign]
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:x:X:s:k:c:T:dM", ["help", "ems"])
+    opts, args = getopt.getopt(argv, "h:p:e:x:X:s:k:c:T:dMn:", ["help", "ems"])
     for opt, arg in opts:
         if opt == '-h':
             hostname = arg

--- a/scripts/test-rsa-sigs-on-certificate-verify.py
+++ b/scripts/test-rsa-sigs-on-certificate-verify.py
@@ -74,7 +74,7 @@ def main():
     ems = False
 
     argv = sys.argv[1:]
-    opts, argv = getopt.getopt(argv, "h:p:e:x:X:k:c:dM", ["help", "ems"])
+    opts, argv = getopt.getopt(argv, "h:p:e:x:X:k:c:dMn:", ["help", "ems"])
 
     for opt, arg in opts:
         if opt == '-k':


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Missing declaration that `-n` is a valid option

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
support making sure that all tests (`-n 0`) are being executed

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/978)
<!-- Reviewable:end -->
