### PR TITLE
test-tls13-client-certificate-compression: send multiple CCM

### DIFF
--- a/scripts/test-tls13-client-certificate-compression.py
+++ b/scripts/test-tls13-client-certificate-compression.py
@@ -41,7 +41,7 @@ from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 
 
-version = 2
+version = 3
 
 KNOWN_ALGORITHMS = ('zlib', 'brotli', 'zstd')
 KNOWN_ALGORITHM_CODES = set([
@@ -765,6 +765,61 @@ def main():
         node = node.add_child(ExpectClose())
         conversations["unsupported algorithm, {0}".format(algo)] = \
             conversation
+
+    # Check that several Compressed Certificate Message are rejected
+    conversation = Connect(host, port)
+    algorithm=list(compression_algorithms.values())[0]
+    node = conversation
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = \
+        ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256,
+                SignatureScheme.ecdsa_secp256r1_sha256,
+                SignatureScheme.ed25519,
+                SignatureScheme.ed448]
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(SIG_ALL)
+    compression_algs = [algorithm]
+    ext[ExtensionType.compress_certificate] = \
+        CompressedCertificateExtension().create(compression_algs)
+    ext = dict_update_non_present(ext, ext_spec['CH'])
+    cr_ext = {
+        ExtensionType.compress_certificate:
+            CompressedCertificateExtension().create(
+                server_supported_compression_algorithms),
+        ExtensionType.signature_algorithms: None
+    }
+    cr_ext = dict_update_non_present(cr_ext, ext_spec['CR'])
+    node = node.add_child(ClientHelloGenerator(
+        ciphers + [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV],
+        extensions=ext))
+    ext = dict_update_non_present(None, ext_spec['SH'])
+    node = node.add_child(ExpectServerHello(extensions=ext))
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificateRequest(extensions=cr_ext))
+    node = node.add_child(ExpectCompressedCertificate(
+        compression_algo=algorithm))
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    cert_chain = X509CertChain([cert])
+    node = node.add_child(CompressedCertificateGenerator(cert_chain))
+    node = node.add_child(CompressedCertificateGenerator(cert_chain))  # again
+    node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                      AlertDescription.unexpected_message))
+    node.next_sibling = ExpectClose()
+    conversations["Multiple Compressed Certificate Messages"] = conversation
 
     # Send compression bombs
     if run_bombs:


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Add a test for sending two Certificate Compressed Messages back-to-back
to test-tls13-client-certificate-compression.py

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [x] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/982)
<!-- Reviewable:end -->
