### PR TITLE
a bit more strict rejection of fully random ciphertexts

### DIFF
--- a/tlsfuzzer/utils/rsa.py
+++ b/tlsfuzzer/utils/rsa.py
@@ -252,6 +252,12 @@ class MarvinCiphertextGenerator(object):
                     a[0] == self._pub_key_n_bytes[0] and \
                     a[1] >= self._pub_key_n_bytes[1]:
                 continue
+            # don't make it start with a valid type 2 padding
+            # while it's semi-unlikely with modulus bit size that's a
+            # multiple of 8, a modulus size of 2049 bits make it quite
+            # probable, so reject those
+            if a[0] == 0 and a[1] == 2:
+                continue
             break
         subs[0] = a[0]
         subs[1] = a[1]


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
we don't really want the fully random to be somewhat valid, so make sure that the first two bytes of plaintext never are 0x00, 0x02

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
make the CI pass consistently

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/987)
<!-- Reviewable:end -->
