### PR TITLE
📦 Compute dist version with `setuptools-scm`

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Needed for setuptools-scm-git-archive
+.git_archival.txt  export-subst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,10 @@
 requires = [
   # Essentials:
   "setuptools >= 64",
+
+  # Plugins:
+  "setuptools-scm [toml] >= 8",
 ]
 build-backend = "setuptools.build_meta"  # must be set always
+
+[tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ except ImportError:
     from distutils.core import setup
 
 setup(name="tlsfuzzer",
-      version="0.0.1",
       author="Hubert Kario",
       author_email="hkario@redhat.com",
       url="https://github.com/tlsfuzzer/tlsfuzzer",


### PR DESCRIPTION
This patch integrates `setuptools-scm` into the packaging configuration. It will only be used when PEP 517 is in play and no other cases are affected by the change.

Additionally, the feature of building from Git archives produced from untagged commits has been enabled.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
$sbj. This is a bit of configuration that will get picked up by modern envs, while not influencing the currently existing ways of using it from Git checkout in ancient runtimes.

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
This is an attempt to demonstrate packaging possibilities for #903.

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md
