### PR TITLE
gracefully handle ml-dsa in TLS 1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,9 +366,9 @@ jobs:
       - name: Install dependencies (2.6)
         if: ${{ matrix.python-version == '2.6' }}
         run: |
-          wget https://files.pythonhosted.org/packages/ff/d1/f6572100f6d6ddb31d7356d7c670599bf404b744ce9bb3c6728bde3665f3/tlslite_ng-0.8.2.tar.gz
+          wget https://files.pythonhosted.org/packages/fa/ee/4480c1978a383cd4ba0dac6af7a27531071393cd624101a26e4aa3dee892/tlslite_ng-0.9.0b2.tar.gz
           wget https://files.pythonhosted.org/packages/00/e7/ed3243b30d1bec41675b6394a1daae46349dc2b855cb83be846a5a918238/ecdsa-0.19.0-py2.py3-none-any.whl
-          pip install tlslite_ng-0.8.2.tar.gz ecdsa-0.19.0-py2.py3-none-any.whl
+          pip install tlslite_ng-0.9.0b2.tar.gz ecdsa-0.19.0-py2.py3-none-any.whl
       - name: Install dependencies
         if: ${{ matrix.python-version != '2.6' }}
         run: pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tlslite-ng==0.8.2
+tlslite-ng==0.9.0b2

--- a/tests/tlslite-ng-py3.8.json
+++ b/tests/tlslite-ng-py3.8.json
@@ -314,6 +314,7 @@
                          "--exc", "12",
                          "--exc", "23",
                          "--exc", "27",
+                         "--exc", "34",
                          "--exc", "13172"],
           "comment" : "several tls12 extensions must be excluded, tlslite-ng issue #314"},
          {"name" : "test-tls13-large-number-of-extensions.py",

--- a/tests/tlslite-ng-random-subset-py3.8.json
+++ b/tests/tlslite-ng-random-subset-py3.8.json
@@ -313,6 +313,7 @@
                          "--exc", "12",
                          "--exc", "23",
                          "--exc", "27",
+                         "--exc", "34",
                          "--exc", "13172"],
           "comment" : "several tls12 extensions must be excluded, tlslite-ng issue #314"},
          {"name" : "test-tls13-large-number-of-extensions.py",

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -313,6 +313,7 @@
                          "--exc", "12",
                          "--exc", "23",
                          "--exc", "27",
+                         "--exc", "34",
                          "--exc", "13172"],
           "comment" : "several tls12 extensions must be excluded, tlslite-ng issue #314"},
          {"name" : "test-tls13-large-number-of-extensions.py",

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -314,6 +314,7 @@
                          "--exc", "12",
                          "--exc", "23",
                          "--exc", "27",
+                         "--exc", "34",
                          "--exc", "13172"],
           "comment" : "several tls12 extensions must be excluded, tlslite-ng issue #314"},
          {"name" : "test-tls13-large-number-of-extensions.py",

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -1449,7 +1449,10 @@ class ExpectCertificateRequest(_ExpectExtensionsMessage):
         for sig_alg in cert_request.supported_signature_algs:
             if sig_alg in (SignatureScheme.ecdsa_brainpoolP256r1tls13_sha256,
                            SignatureScheme.ecdsa_brainpoolP384r1tls13_sha384,
-                           SignatureScheme.ecdsa_brainpoolP512r1tls13_sha512):
+                           SignatureScheme.ecdsa_brainpoolP512r1tls13_sha512,
+                           SignatureScheme.mldsa44,
+                           SignatureScheme.mldsa65,
+                           SignatureScheme.mldsa87):
                 raise AssertionError(
                     "TLS 1.3 specific signature scheme in an earlier protocol "
                     "version: {0}".format(sig_alg))


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
When server sends ML-DSA signature algorithms in TLS 1.2 we should handle that.

depends on https://github.com/tlsfuzzer/tlslite-ng/pull/546

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
Better user experience.


### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

### Other

We probably should reverse the check though, so that any unrecognised sigalgs in TLS 1.2 cause aborts

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/1000)
<!-- Reviewable:end -->
