### PR TITLE
Change -C in scripts to use the new helper function

### DIFF
--- a/tlsfuzzer/_apps/test_aes_gcm_nonces.py
+++ b/tlsfuzzer/_apps/test_aes_gcm_nonces.py
@@ -24,10 +24,10 @@ from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlslite.utils.cryptomath import bytesToNumber
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -88,13 +88,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_ccs.py
+++ b/tlsfuzzer/_apps/test_ccs.py
@@ -24,10 +24,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 1
+version = 2
 
 
 def help_msg():
@@ -87,13 +87,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_certificate_malformed.py
+++ b/tlsfuzzer/_apps/test_certificate_malformed.py
@@ -30,10 +30,11 @@ from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, RSA_SIG_ALL
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, RSA_SIG_ALL, \
+    cipher_suite_to_id
 
 
-version = 5
+version = 6
 
 
 def help_msg():
@@ -100,13 +101,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_certificate_request.py
+++ b/tlsfuzzer/_apps/test_certificate_request.py
@@ -22,7 +22,8 @@ from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
         ExpectApplicationData, ExpectServerKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlsfuzzer.helpers import sig_algs_to_ids, RSA_SIG_ALL, \
-        client_cert_types_to_ids, AutoEmptyExtension, ECDSA_SIG_ALL
+        client_cert_types_to_ids, AutoEmptyExtension, ECDSA_SIG_ALL, \
+        cipher_suite_to_id
 from tlslite.extensions import SignatureAlgorithmsExtension, \
         SignatureAlgorithmsCertExtension, SupportedGroupsExtension
 from tlslite.constants import CipherSuite, AlertDescription, \
@@ -33,7 +34,7 @@ from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 
 
-version = 13
+version = 14
 
 
 def help_msg():
@@ -123,13 +124,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_certificate_verify.py
+++ b/tlsfuzzer/_apps/test_certificate_verify.py
@@ -27,10 +27,11 @@ from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import RSA_SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import RSA_SIG_ALL, AutoEmptyExtension, \
+    cipher_suite_to_id
 
 
-version = 11
+version = 12
 
 
 def help_msg():
@@ -94,13 +95,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '--help':
             help_msg()
             sys.exit(0)

--- a/tlsfuzzer/_apps/test_certificate_verify_malformed.py
+++ b/tlsfuzzer/_apps/test_certificate_verify_malformed.py
@@ -30,10 +30,11 @@ from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import RSA_SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import RSA_SIG_ALL, AutoEmptyExtension, \
+    cipher_suite_to_id
 
 
-version = 6
+version = 7
 
 
 def help_msg():
@@ -100,13 +101,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_connection_abort.py
+++ b/tlsfuzzer/_apps/test_connection_abort.py
@@ -23,10 +23,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 2
+version = 3
 
 
 def help_msg():
@@ -118,13 +118,7 @@ def main():
         elif opt == "--repeat":
             repeat = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_conversation.py
+++ b/tlsfuzzer/_apps/test_conversation.py
@@ -23,10 +23,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 10
+version = 11
 
 
 def help_msg():
@@ -113,13 +113,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-g':
             vals = arg.split(":")
             groups = [getattr(GroupName, i) for i in vals]

--- a/tlsfuzzer/_apps/test_cve_2004_0079.py
+++ b/tlsfuzzer/_apps/test_cve_2004_0079.py
@@ -26,10 +26,11 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import AutoEmptyExtension, sig_algs_to_ids
+from tlsfuzzer.helpers import AutoEmptyExtension, sig_algs_to_ids, \
+    cipher_suite_to_id
 
 
-version = 1
+version = 2
 
 
 def help_msg():
@@ -111,13 +112,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-g':
             vals = arg.split(":")
             groups = [getattr(GroupName, i) for i in vals]

--- a/tlsfuzzer/_apps/test_cve_2016_2107.py
+++ b/tlsfuzzer/_apps/test_cve_2016_2107.py
@@ -27,10 +27,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -90,13 +90,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_cve_2016_6309.py
+++ b/tlsfuzzer/_apps/test_cve_2016_6309.py
@@ -26,10 +26,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import PaddingExtension, SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -92,13 +92,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_cve_2016_7054.py
+++ b/tlsfuzzer/_apps/test_cve_2016_7054.py
@@ -24,10 +24,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -82,13 +82,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_dsa_in_certificate_verify.py
+++ b/tlsfuzzer/_apps/test_dsa_in_certificate_verify.py
@@ -28,10 +28,10 @@ from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 3
+version = 4
 
 
 def help_msg():
@@ -118,13 +118,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '-k':

--- a/tlsfuzzer/_apps/test_dsa_sig_flexibility.py
+++ b/tlsfuzzer/_apps/test_dsa_sig_flexibility.py
@@ -23,10 +23,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 1
+version = 2
 
 
 def help_msg():
@@ -104,13 +104,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_early_application_data.py
+++ b/tlsfuzzer/_apps/test_early_application_data.py
@@ -23,10 +23,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -90,13 +90,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_ecdhe_rsa_key_exchange_with_bad_messages.py
+++ b/tlsfuzzer/_apps/test_ecdhe_rsa_key_exchange_with_bad_messages.py
@@ -28,10 +28,10 @@ from tlslite.extensions import SupportedGroupsExtension, \
         ECPointFormatsExtension, SignatureAlgorithmsExtension, \
         SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 5
+version = 6
 
 
 def help_msg():
@@ -87,13 +87,7 @@ def main():
                 raise ValueError("-x has to be specified before -X")
             expected_failures[last_exp_tmp] = str(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_ecdsa_sig_flexibility.py
+++ b/tlsfuzzer/_apps/test_ecdsa_sig_flexibility.py
@@ -22,11 +22,11 @@ from tlslite.extensions import SignatureAlgorithmsExtension, \
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
         HashAlgorithm, SignatureAlgorithm, ExtensionType, GroupName, \
         TLS_1_3_BRAINPOOL_SIG_SCHEMES, SignatureScheme
-from tlsfuzzer.helpers import SIG_ALL
+from tlsfuzzer.helpers import SIG_ALL, cipher_suite_to_id
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 
-version = 7
+version = 8
 
 
 def help_msg():
@@ -85,13 +85,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-g':
             vals = arg.split(":")
             groups = [getattr(GroupName, i) for i in vals]

--- a/tlsfuzzer/_apps/test_fuzzed_MAC.py
+++ b/tlsfuzzer/_apps/test_fuzzed_MAC.py
@@ -24,10 +24,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -88,13 +88,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_fuzzed_ciphertext.py
+++ b/tlsfuzzer/_apps/test_fuzzed_ciphertext.py
@@ -25,10 +25,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 6
+version = 7
 
 
 def help_msg():
@@ -89,13 +89,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_hello_request_by_client.py
+++ b/tlsfuzzer/_apps/test_hello_request_by_client.py
@@ -24,10 +24,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -87,13 +87,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_interleaved_CKE_with_CCS.py
+++ b/tlsfuzzer/_apps/test_interleaved_CKE_with_CCS.py
@@ -26,10 +26,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import AutoEmptyExtension, SIG_ALL
+from tlsfuzzer.helpers import AutoEmptyExtension, SIG_ALL, cipher_suite_to_id
 
 
-version = 1
+version = 2
 
 
 def help_msg():
@@ -88,13 +88,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-g':
             vals = arg.split(":")
             groups = [getattr(GroupName, i) for i in vals]

--- a/tlsfuzzer/_apps/test_interleaved_application_data_and_fragmented_handshakes_in_renegotiation.py
+++ b/tlsfuzzer/_apps/test_interleaved_application_data_and_fragmented_handshakes_in_renegotiation.py
@@ -23,10 +23,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -91,13 +91,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_interleaved_application_data_in_renegotiation.py
+++ b/tlsfuzzer/_apps/test_interleaved_application_data_in_renegotiation.py
@@ -24,10 +24,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -92,13 +92,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_invalid_client_hello_w_record_overflow.py
+++ b/tlsfuzzer/_apps/test_invalid_client_hello_w_record_overflow.py
@@ -23,10 +23,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import AutoEmptyExtension
+from tlsfuzzer.helpers import AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -86,13 +86,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_invalid_compression_methods.py
+++ b/tlsfuzzer/_apps/test_invalid_compression_methods.py
@@ -23,10 +23,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import TLSExtension, SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 6
+version = 7
 
 
 def help_msg():
@@ -87,13 +87,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_invalid_content_type.py
+++ b/tlsfuzzer/_apps/test_invalid_content_type.py
@@ -23,10 +23,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -91,13 +91,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_no_mlkem_in_old_tls.py
+++ b/tlsfuzzer/_apps/test_no_mlkem_in_old_tls.py
@@ -23,10 +23,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 1
+version = 2
 
 
 def help_msg():
@@ -110,13 +110,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_point_extension.py
+++ b/tlsfuzzer/_apps/test_point_extension.py
@@ -25,9 +25,9 @@ from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
         ECPointFormatsExtension, RenegotiationInfoExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
-version = 1
+version = 2
 
 
 def help_msg():
@@ -108,13 +108,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '--ec-point-f':
             ecc_point_frmt = [int(item) for item in arg.split(':')]
         elif opt == '-M' or opt == '--ems':

--- a/tlsfuzzer/_apps/test_record_layer_fragmentation.py
+++ b/tlsfuzzer/_apps/test_record_layer_fragmentation.py
@@ -24,10 +24,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import TLSExtension, SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -91,13 +91,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_renegotiation_disabled.py
+++ b/tlsfuzzer/_apps/test_renegotiation_disabled.py
@@ -24,10 +24,10 @@ from tlslite.extensions import ALPNExtension, TLSExtension, \
         SupportedGroupsExtension, SignatureAlgorithmsExtension, \
         SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL
+from tlsfuzzer.helpers import SIG_ALL, cipher_suite_to_id
 
 
-version = 5
+version = 6
 
 
 def help_msg():
@@ -87,13 +87,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '--no-renego-close':
             no_renego_close = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_renegotiation_disabled_client_cert.py
+++ b/tlsfuzzer/_apps/test_renegotiation_disabled_client_cert.py
@@ -28,9 +28,10 @@ from tlslite.utils.keyfactory import parsePEMKey
 from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 from tlsfuzzer.utils.lists import natural_sort_keys
+from tlsfuzzer.helpers import cipher_suite_to_id
 
 
-version = 6
+version = 7
 
 
 def help_msg():
@@ -95,13 +96,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '--no-ins-renego':

--- a/tlsfuzzer/_apps/test_tls13_certificate_compression.py
+++ b/tlsfuzzer/_apps/test_tls13_certificate_compression.py
@@ -31,11 +31,11 @@ from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
     SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
     CompressedCertificateExtension, TLSExtension
 from tlsfuzzer.helpers import key_share_gen, SIG_ALL, RSA_SIG_ALL, \
-    AutoEmptyExtension
+    AutoEmptyExtension, cipher_suite_to_id
 from tlslite.utils.compression import compression_algo_impls
 
 
-version = 1
+version = 2
 
 KNOWN_ALGORITHMS = ('zlib', 'brotli', 'zstd')
 
@@ -117,13 +117,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--algorithms':

--- a/tlsfuzzer/_apps/test_tls13_client_certificate_compression.py
+++ b/tlsfuzzer/_apps/test_tls13_client_certificate_compression.py
@@ -33,7 +33,7 @@ from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
     SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
     CompressedCertificateExtension, TLSExtension
 from tlsfuzzer.helpers import key_share_gen, SIG_ALL, expected_ext_parser, \
-    dict_update_non_present
+    dict_update_non_present, cipher_suite_to_id
 from tlslite.utils.compression import *
 from tlslite.utils.cryptomath import numberToByteArray
 from tlslite.utils.keyfactory import parsePEMKey
@@ -41,7 +41,7 @@ from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 
 
-version = 4
+version = 5
 
 KNOWN_ALGORITHMS = ('zlib', 'brotli', 'zstd')
 KNOWN_ALGORITHM_CODES = set([
@@ -159,13 +159,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-c':
             text_cert = open(arg, 'rb').read()
             if sys.version_info[0] >= 3:

--- a/tlsfuzzer/_apps/test_tls13_connection_abort.py
+++ b/tlsfuzzer/_apps/test_tls13_connection_abort.py
@@ -25,10 +25,10 @@ from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
         SupportedVersionsExtension, SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
-from tlsfuzzer.helpers import key_share_gen, SIG_ALL
+from tlsfuzzer.helpers import key_share_gen, SIG_ALL, cipher_suite_to_id
 
 
-version = 1
+version = 2
 
 
 def help_msg():
@@ -90,13 +90,7 @@ def main():
         elif opt == "--repeat":
             repeat = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '--help':
             help_msg()
             sys.exit(0)

--- a/tlsfuzzer/_apps/test_tls13_conversation.py
+++ b/tlsfuzzer/_apps/test_tls13_conversation.py
@@ -25,10 +25,10 @@ from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
         SupportedVersionsExtension, SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
-from tlsfuzzer.helpers import key_share_gen, SIG_ALL
+from tlsfuzzer.helpers import key_share_gen, SIG_ALL, cipher_suite_to_id
 
 
-version = 7
+version = 8
 
 
 def help_msg():
@@ -85,13 +85,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-g':
             vals = arg.split(":")
             groups = [getattr(GroupName, i) for i in vals]

--- a/tlsfuzzer/_apps/test_tls13_eddsa.py
+++ b/tlsfuzzer/_apps/test_tls13_eddsa.py
@@ -26,10 +26,10 @@ from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
         SupportedVersionsExtension, SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
-from tlsfuzzer.helpers import key_share_gen, SIG_ALL
+from tlsfuzzer.helpers import key_share_gen, SIG_ALL, cipher_suite_to_id
 
 
-version = 1
+version = 2
 
 
 def help_msg():
@@ -82,13 +82,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '--help':
             help_msg()
             sys.exit(0)

--- a/tlsfuzzer/_apps/test_tls13_minerva.py
+++ b/tlsfuzzer/_apps/test_tls13_minerva.py
@@ -30,9 +30,9 @@ from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import ClientKeyShareExtension, \
         SupportedVersionsExtension, SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
-from tlsfuzzer.helpers import key_share_gen, SIG_ALL
+from tlsfuzzer.helpers import key_share_gen, SIG_ALL, cipher_suite_to_id
 
-version = 7
+version = 8
 
 
 def help_msg():
@@ -121,13 +121,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '--curve':
             curve = arg
         elif opt == '--repeat':

--- a/tlsfuzzer/_apps/test_tls13_mlkem.py
+++ b/tlsfuzzer/_apps/test_tls13_mlkem.py
@@ -27,11 +27,11 @@ from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
         SupportedVersionsExtension, SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
-from tlsfuzzer.helpers import key_share_gen, SIG_ALL
+from tlsfuzzer.helpers import key_share_gen, SIG_ALL, cipher_suite_to_id
 from tlslite.utils.compat import ML_KEM_AVAILABLE
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -95,13 +95,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == "--kems":
             kems = [getattr(GroupName, i) for i in arg.split(",")]
         elif opt == "--cookie":

--- a/tlsfuzzer/_apps/test_tls13_no_unknown_groups.py
+++ b/tlsfuzzer/_apps/test_tls13_no_unknown_groups.py
@@ -28,12 +28,12 @@ from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
         SupportedVersionsExtension, SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
         HRRKeyShareExtension
-from tlsfuzzer.helpers import key_share_gen, SIG_ALL
+from tlsfuzzer.helpers import key_share_gen, SIG_ALL, cipher_suite_to_id
 from tlslite.utils.compat import ML_KEM_AVAILABLE
 from tlsfuzzer.utils.ordered_dict import OrderedDict
 
 
-version = 2
+version = 3
 
 
 def help_msg():
@@ -107,13 +107,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == "--groups":
             groups = []
             for i in arg.split(","):

--- a/tlsfuzzer/_apps/test_tls13_session_resumption.py
+++ b/tlsfuzzer/_apps/test_tls13_session_resumption.py
@@ -113,7 +113,7 @@ def main():
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--tls1.2-cipher':
-            ciphers_1_3 = [cipher_suite_to_id(arg)]
+            ciphers_1_2 = [cipher_suite_to_id(arg)]
         elif opt == '--tls1.3-cipher':
             ciphers_1_3 = [cipher_suite_to_id(arg)]
         elif opt == '--client-pke':

--- a/tlsfuzzer/_apps/test_tls13_unencrypted_alert.py
+++ b/tlsfuzzer/_apps/test_tls13_unencrypted_alert.py
@@ -26,10 +26,10 @@ from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
         SupportedVersionsExtension, SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
-from tlsfuzzer.helpers import key_share_gen, SIG_ALL
+from tlsfuzzer.helpers import key_share_gen, SIG_ALL, cipher_suite_to_id
 
 
-version = 1
+version = 2
 
 
 def help_msg():
@@ -82,13 +82,7 @@ def main():
         elif opt == '-n':
             num_limit = int(arg)
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '--help':
             help_msg()
             sys.exit(0)

--- a/tlsfuzzer/_apps/test_tls13_version_negotiation.py
+++ b/tlsfuzzer/_apps/test_tls13_version_negotiation.py
@@ -28,10 +28,10 @@ from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
         SupportedVersionsExtension, SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, key_share_ext_gen, \
-        AutoEmptyExtension
+        AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 7
+version = 8
 
 
 def help_msg():
@@ -90,13 +90,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                tls12_ciphers = [int(arg, 16)]
-            else:
-                try:
-                    tls12_ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    tls12_ciphers = [int(arg)]
+            tls12_ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_truncating_of_client_hello.py
+++ b/tlsfuzzer/_apps/test_truncating_of_client_hello.py
@@ -24,10 +24,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 6
+version = 7
 
 
 def help_msg():
@@ -92,13 +92,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_version_numbers.py
+++ b/tlsfuzzer/_apps/test_version_numbers.py
@@ -23,10 +23,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 5
+version = 6
 
 
 def help_msg():
@@ -87,13 +87,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':

--- a/tlsfuzzer/_apps/test_zero_length_data.py
+++ b/tlsfuzzer/_apps/test_zero_length_data.py
@@ -23,10 +23,10 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension
+from tlsfuzzer.helpers import SIG_ALL, AutoEmptyExtension, cipher_suite_to_id
 
 
-version = 4
+version = 5
 
 
 def help_msg():
@@ -87,13 +87,7 @@ def main():
         elif opt == '-d':
             dhe = True
         elif opt == '-C':
-            if arg[:2] == '0x':
-                ciphers = [int(arg, 16)]
-            else:
-                try:
-                    ciphers = [getattr(CipherSuite, arg)]
-                except AttributeError:
-                    ciphers = [int(arg)]
+            ciphers = [cipher_suite_to_id(arg)]
         elif opt == '-M' or opt == '--ems':
             ems = True
         elif opt == '--help':


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Fixed a typo in TLSv1.2 ciphers variable in test-tls13-session-resumption.py
Change all scripts that use -C for custom cipher to use the new helper function.

### Checklist
- [ ] all new and existing tests pass (see CI results)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/1004)
<!-- Reviewable:end -->
