### PR TITLE
CI: codeclimate is broken, disable it for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,8 @@ jobs:
             os: ubuntu-latest
             python-version: '3.12'
             # note: codeclimate can be specified in only one environment
-            opt-deps: ['extract', 'analysis', 'codeclimate']
+            # note: codeclimate was here but it is broken for now, needs fixing
+            opt-deps: ['extract', 'analysis']
     steps:
       - uses: actions/checkout@v2
         if: ${{ !matrix.container }}


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Since they changed something in CodeClimate and the CI part is broken for now, we are disabling it until we fix it. 

### Motivation and Context
Change because of failures in https://github.com/tlsfuzzer/tlsfuzzer/pull/1008

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/1009)
<!-- Reviewable:end -->
