### PR TITLE
tlsfuzzer/analysis.py: fix issue with workers

### DIFF
--- a/tlsfuzzer/analysis.py
+++ b/tlsfuzzer/analysis.py
@@ -298,6 +298,7 @@ class Analysis(object):
         self._k_sizes = None
         self._bit_size_data_used = None
         self._total_bit_size_data_used = 0
+        self._sanity_data_points_used = 0
 
         if not bit_size_analysis:
             data = self.load_data()
@@ -1830,6 +1831,7 @@ class Analysis(object):
         all_wilcoxon_values = list(self._bit_size_wilcoxon_test.values())
         total_non_max_data = sum(self._k_sizes[i] for i in self._k_sizes
                                  if i != max(self._k_sizes.keys()))
+        total_non_max_data += self._sanity_data_points_used
         with open(join(self.output, "analysis_results/report.txt"), "w") as fp:
             fp.write(
                 "tlsfuzzer analyse.py version {0} bit size analysis\n\n"
@@ -2199,6 +2201,9 @@ class Analysis(object):
                 tuples_written_in_timing_files = {}
                 for k_size, total in chunks:
                     tuples_written_in_timing_files[k_size] = total
+
+                    if k_size == max_k_size:
+                        self._sanity_data_points_used = total
 
                 if status:
                     status[2].set()


### PR DESCRIPTION
### Description
Bit size analysis fix:
Sometimes the slice that the worker gets might have a chunk of data that will not have any entry of max_k_size in it. Then we are trying to find one and eventually throw an IndexError. Fixed that by checking that i is in range.

### Motivation and Context
failures like
```
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/tmp/tlsfuzzer/tlsfuzzer/analysis.py", line 2322, in _bit_size_smart_analysis_worker
    while k_sizes[i] != max_k_size:
  File "/usr/local/lib64/python3.9/site-packages/numpy/_core/memmap.py", line 348, in __getitem__
    res = super().__getitem__(index)
IndexError: index 1440201 is out of bounds for axis 0 with size 1440201
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tmp/tlsfuzzer/tlsfuzzer/analysis.py", line 3025, in <module>
    main_ret = main()
  File "/tmp/tlsfuzzer/tlsfuzzer/analysis.py", line 243, in main
    ret = analysis.generate_report(
  File "/tmp/tlsfuzzer/tlsfuzzer/analysis.py", line 1984, in generate_report
    ret_val = self.analyze_bit_sizes()
  File "/tmp/tlsfuzzer/tlsfuzzer/analysis.py", line 2481, in analyze_bit_sizes
    self._figure_out_analysis_data_size()
  File "/tmp/tlsfuzzer/tlsfuzzer/analysis.py", line 2393, in _figure_out_analysis_data_size
    for subprocess_progress, subprocess_tuples in chunks:
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 870, in next
    raise value
IndexError: index 1440201 is out of bounds for axis 0 with size 1440201
```

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] The changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/1010)
<!-- Reviewable:end -->
