### PR TITLE
CI: omit the scripts (_apps) from the coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,10 +324,10 @@ jobs:
           ./cc-test-reporter before-build
       - name: Run unit tests (py2.6)
         if: ${{ matrix.python-version == '2.6' }}
-        run: coverage run --branch --source tlsfuzzer -m unittest2 discover
+        run: coverage run --branch --source tlsfuzzer --omit '*/_apps/*' -m unittest2 discover
       - name: Run unit tests (py2.7+)
         if: ${{ matrix.python-version != '2.6' }}
-        run: coverage run --branch --source tlsfuzzer -m unittest discover
+        run: coverage run --branch --source tlsfuzzer --omit '*/_apps/*' -m unittest discover
       - name: Log branch coverage
         run: coverage report -m
       - name: Publish coverage to CodeClimate


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Omit the scripts (_apps) from the coverage report in CI

### Motivation and Context
https://github.com/tlsfuzzer/tlsfuzzer/pull/1011

### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] all new and existing tests pass (see CI results)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/1012)
<!-- Reviewable:end -->
