### PR TITLE
add support for SSLKEYLOGFILE

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -371,6 +371,34 @@ vulnerable behaviour in which the server sometimes sends the correct alert and
 sometimes closes the connection would *not* be detected, reporting a false
 negative to the user.
 
+SSLKEYLOGFILE
+=============
+
+tlsfuzzer supports logging TLS secrets in the [SSLKEYLOGFILE Format](https://www.ietf.org/id/draft-ietf-tls-keylogfile-05.txt),
+which can be used by [Wireshark](https://www.wireshark.org/) to decrypt
+captured TLS traffic.
+
+To enable key logging, pass `sslkeylogfile=True` when creating the `Runner`:
+
+```python
+runner = Runner(conversation, sslkeylogfile=True)
+```
+
+When enabled, the secrets are written to a file called `sslkeylogfile.log`
+in the current working directory (the directory from the test script was run).
+The file is created automatically on the first write and subsequent runs
+append to it.
+
+For TLS 1.2 and earlier, the file will contain `CLIENT_RANDOM` lines with
+the master secret. For TLS 1.3, it will contain
+`CLIENT_HANDSHAKE_TRAFFIC_SECRET`, `SERVER_HANDSHAKE_TRAFFIC_SECRET`,
+`CLIENT_TRAFFIC_SECRET_0`, `SERVER_TRAFFIC_SECRET_0`, and `EXPORTER_SECRET`
+lines.
+
+To use the generated file with Wireshark, go to
+*Edit > Preferences > Protocols > TLS* and set the *(Pre)-Master-Secret log
+filename* to the path of the `sslkeylogfile.log` file.
+
 Test specific notes
 ===================
 

--- a/tests/test_tlsfuzzer_runner.py
+++ b/tests/test_tlsfuzzer_runner.py
@@ -22,12 +22,15 @@ import tlslite.constants as constants
 from tlslite.x509certchain import X509CertChain
 from tlslite.errors import TLSAbruptCloseError
 import socket
+from binascii import hexlify
 
 
 if sys.version_info < (3, 0):
     BUILTIN_PRINT = "__builtin__.print"
+    BUILTIN_OPEN = "__builtin__.open"
 else:
     BUILTIN_PRINT = "builtins.print"
+    BUILTIN_OPEN = "builtins.open"
 
 
 class TestConnectionState(unittest.TestCase):
@@ -107,12 +110,72 @@ class TestConnectionState(unittest.TestCase):
 
         self.assertEqual(state.prf_size, 48)
 
+    def test_sslkeylogfile_default_is_false(self):
+        state = ConnectionState()
+
+        self.assertFalse(state.sslkeylogfile)
+
+    @mock.patch(BUILTIN_OPEN)
+    def test_log_ssl_key_disabled(self, mock_file):
+        state = ConnectionState()
+        state.client_random = bytearray(b'\x00' * 32)
+
+        state.log_ssl_key('CLIENT_RANDOM', bytearray(b'\x01' * 48))
+
+        mock_file.assert_not_called()
+
+    @mock.patch(BUILTIN_OPEN, new_callable=mock.mock_open)
+    def test_log_ssl_key_enabled(self, mock_file):
+        state = ConnectionState()
+        state.sslkeylogfile = True
+        state.client_random = bytearray(range(32))
+        secret = bytearray(range(48))
+
+        state.log_ssl_key('CLIENT_RANDOM', secret)
+
+        mock_file.assert_called_once_with(
+            file='sslkeylogfile.log', mode='a', encoding='utf-8')
+        handle = mock_file()
+        written = handle.write.call_args[0][0]
+        parts = written.strip().split(' ')
+        self.assertEqual(len(parts), 3)
+        self.assertEqual(parts[0], 'CLIENT_RANDOM')
+        self.assertEqual(parts[1], hexlify(bytes(state.client_random)).decode('ascii'))
+        self.assertEqual(parts[2], hexlify(bytes(secret)).decode('ascii'))
+
+    @mock.patch(BUILTIN_OPEN, new_callable=mock.mock_open)
+    def test_log_ssl_key_appends(self, mock_file):
+        state = ConnectionState()
+        state.sslkeylogfile = True
+        state.client_random = bytearray(b'\xaa' * 32)
+        secret1 = bytearray(b'\xbb' * 48)
+        secret2 = bytearray(b'\xcc' * 32)
+
+        state.log_ssl_key('CLIENT_RANDOM', secret1)
+        state.log_ssl_key('CLIENT_HANDSHAKE_TRAFFIC_SECRET', secret2)
+
+        self.assertEqual(mock_file.call_count, 2)
+        handle = mock_file()
+        writes = handle.write.call_args_list
+        self.assertIn('CLIENT_RANDOM', writes[0][0][0])
+        self.assertIn('CLIENT_HANDSHAKE_TRAFFIC_SECRET', writes[1][0][0])
+
 
 class TestRunner(unittest.TestCase):
     def test___init__(self):
         runner = Runner(None)
 
         self.assertIsNotNone(runner.state)
+
+    def test___init___sslkeylogfile_default(self):
+        runner = Runner(None)
+
+        self.assertFalse(runner.state.sslkeylogfile)
+
+    def test___init___sslkeylogfile_enabled(self):
+        runner = Runner(None, sslkeylogfile=True)
+
+        self.assertTrue(runner.state.sslkeylogfile)
 
     @mock.patch(BUILTIN_PRINT)
     def test_run_with_unknown_type(self, mock_print):

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -853,10 +853,14 @@ class ExpectServerHello(_ExpectExtensionsMessage):
                                          state.handshake_hashes,
                                          prf_name)
         state.key['server handshake traffic secret'] = s_traffic_secret
+        state.log_ssl_key('SERVER_HANDSHAKE_TRAFFIC_SECRET',
+                          s_traffic_secret)
         c_traffic_secret = derive_secret(secret, b'c hs traffic',
                                          state.handshake_hashes,
                                          prf_name)
         state.key['client handshake traffic secret'] = c_traffic_secret
+        state.log_ssl_key('CLIENT_HANDSHAKE_TRAFFIC_SECRET',
+                          c_traffic_secret)
 
         state.msg_sock.calcTLS1_3PendingState(
             state.cipher, c_traffic_secret, s_traffic_secret, None)
@@ -1766,16 +1770,19 @@ class ExpectFinished(ExpectHandshake):
                 secret, b'c ap traffic', state.handshake_hashes,
                 state.prf_name)
             state.key['client application traffic secret'] = c_traff_sec
+            state.log_ssl_key('CLIENT_TRAFFIC_SECRET_0', c_traff_sec)
             s_traff_sec = derive_secret(
                 secret, b's ap traffic', state.handshake_hashes,
                 state.prf_name)
             state.key['server application traffic secret'] = s_traff_sec
+            state.log_ssl_key('SERVER_TRAFFIC_SECRET_0', s_traff_sec)
 
             # derive TLS exporter key
             exp_ms = derive_secret(secret, b'exp master',
                                    state.handshake_hashes,
                                    state.prf_name)
             state.key['exporter master secret'] = exp_ms
+            state.log_ssl_key('EXPORTER_SECRET', exp_ms)
 
             # set up the encryption keys for application data
             state.msg_sock.calcTLS1_3PendingState(

--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -1625,6 +1625,10 @@ class ChangeCipherSpecGenerator(MessageGenerator):
                     output_length=48)
 
             status.key['master_secret'] = master_secret
+            # Implementations of TLS 1.2 [TLS12] (and also earlier versions)
+            # use the label "CLIENT_RANDOM" to identify the "master" secret
+            # for the connection. [RFC 9850]
+            status.log_ssl_key('CLIENT_RANDOM', master_secret)
 
             # in case of resumption, the pending states are generated
             # during receive of server sent CCS

--- a/tlsfuzzer/runner.py
+++ b/tlsfuzzer/runner.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 
 import socket
+from binascii import hexlify
 from tlslite.messages import Message, Certificate, RecordHeader2
 from tlslite.handshakehashes import HandshakeHashes
 from tlslite.errors import TLSAbruptCloseError
@@ -105,6 +106,9 @@ class ConnectionState(object):
         self._peer_record_size_limit = None
         self._our_record_size_limit = None
 
+        # SSLKEYLOGFILE support
+        self.sslkeylogfile = False
+
     @property
     def prf_name(self):
         """Return the name of the PRF used for session.
@@ -124,6 +128,27 @@ class ConnectionState(object):
         if self.cipher in CipherSuite.sha384PrfSuites:
             return 48
         return 32
+
+    def log_ssl_key(self, label, secret):
+        """Log a TLS secret to sslkeylogfile.log in NSS Key Log format.
+
+        Does nothing if sslkeylogfile is False.
+
+        :param label: the key log label (e.g. 'CLIENT_RANDOM')
+        :type label: str
+        :param secret: the secret to log
+        :type secret: bytearray
+        """
+        if not self.sslkeylogfile:
+            return
+        # In Python2 the bytearray.hex() is not available, so the hexlify used.
+        # Additionally, in Python2 hexlify doesn't accept bytearray,
+        # but bytes(bytearray(...))
+        client_random_hex = hexlify(bytes(self.client_random)).decode('ascii')
+        secret_hex = hexlify(bytes(secret)).decode('ascii')
+        line = "{0} {1} {2}\n".format(label, client_random_hex, secret_hex)
+        with open(file='sslkeylogfile.log', mode='a', encoding="utf-8") as f:
+            f.write(line)
 
     def get_server_public_key(self):
         """Extract server public key from server Certificate message"""
@@ -174,10 +199,11 @@ def guess_response(content_type, data, ssl2=False):
 class Runner(object):
     """Test if sending a set of commands returns expected values"""
 
-    def __init__(self, conversation):
+    def __init__(self, conversation, sslkeylogfile=False):
         """Link conversation with runner"""
         self.conversation = conversation
         self.state = ConnectionState()
+        self.state.sslkeylogfile = sslkeylogfile
 
     def run(self):
         """Execute conversation"""


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
The changes introduce the ability to log TLS session secrets in the NSS Key Log format (SSLKEYLOGFILE).  This is done by adding a sslkeylogfile flag (default False) to ConnectionState through the Runner in the testing script. The logging goes into sslkeylogfile.log that will be created (or will be adding to an existing file) in the folder, where the script was started.

The following secrets are being logged:
- in the TLS 1.2 (and earlier) master secret with the CLIENT_RANDOM label during ChangeCipherSpec generation.                                                                  
- in the TLS 1.3 secrets:                     
    - SERVER_HANDSHAKE_TRAFFIC_SECRET                                                                    
    - CLIENT_HANDSHAKE_TRAFFIC_SECRET                                                                    
    - CLIENT_TRAFFIC_SECRET_0                                                                            
    - SERVER_TRAFFIC_SECRET_0                                                                            
    - EXPORTER_SECRET            


### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
fixes #178 

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts - _no new test scripts_
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json` - _no new test scripts_
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [x] NSS
  - [x] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md - _no changes_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/1032)
<!-- Reviewable:end -->
