### PR TITLE
Update PSK test to advertise PSK_DHE_KE mode

### DIFF
--- a/tlsfuzzer/_apps/test_tls13_count_tickets.py
+++ b/tlsfuzzer/_apps/test_tls13_count_tickets.py
@@ -19,16 +19,18 @@ from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
         ExpectNewSessionTicket
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+        PskKeyExchangeMode
 from tlslite.keyexchange import ECDHKeyExchange
 from tlsfuzzer.utils.lists import natural_sort_keys
 from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
         SupportedVersionsExtension, SupportedGroupsExtension, \
-        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension, \
+        PskKeyExchangeModesExtension
 from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
 
 
-version = 5
+version = 6
 
 
 def help_msg():
@@ -114,6 +116,8 @@ def main():
         .create(sig_algs)
     ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
         .create(RSA_SIG_ALL)
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+        .create([PskKeyExchangeMode.psk_dhe_ke])
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
     node = node.add_child(ExpectChangeCipherSpec())
@@ -160,6 +164,8 @@ def main():
         .create(sig_algs)
     ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
         .create(RSA_SIG_ALL)
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+        .create([PskKeyExchangeMode.psk_dhe_ke])
     node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
     node = node.add_child(ExpectServerHello())
     node = node.add_child(ExpectChangeCipherSpec())


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Advertise the `psk_key_exchange_modes` extension (offering `psk_dhe_ke` we will need later) in the
ClientHello in `test-tls13-count-tickets`, and thus bump the
script `version` to 6.

### Motivation and Context

A TLS 1.3 client that wants to use a session ticket must
advertise the key-exchange modes it supports via the `psk_key_exchange_modes`
extension (See: RFC 8446 §4.2.9: *"if the client wishes to use PSKs in a subsequent
connection, it MUST send a `psk_key_exchange_modes` extension in this
ClientHello"*). The code previously sent a ClientHellow without the extension/mode. 

It was brought to our attention during this discussion: https://mailarchive.ietf.org/arch/msg/tls/VuvBgc_21bIZAbxEW-mgJMlsidM

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [X] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [X] the changes are also reflected in documentation and code comments
- [X] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts - the tests are not new, so skip I believe
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json` - the tests are not new, so skip I believe
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ X] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/1036)
<!-- Reviewable:end -->
