### PR TITLE
fix a few crashes in the test-tls13-minerva.py script

### DIFF
--- a/tlsfuzzer/_apps/test_tls13_minerva.py
+++ b/tlsfuzzer/_apps/test_tls13_minerva.py
@@ -435,7 +435,7 @@ size and the timing that was needed to sign the data.""")
                     data_size=data_size,
                     sigs=join(timing_outdir, sigs_file),
                     priv_key=priv_key_file,
-                    key_type="ecdsa",
+                    key_type="ec",
                     verbose=verbose,
                     hash_func=None  # The data are already hashed.
                 )

--- a/tlsfuzzer/analysis.py
+++ b/tlsfuzzer/analysis.py
@@ -2001,7 +2001,7 @@ class Analysis(object):
             self._k_sizes_totals(name_bin)
 
             skillings_mack_pvalue = self.skillings_mack_test(name_bin)
-            ret_val = self.analyze_bit_sizes()
+            ret_val = self._analyze_bit_sizes()
             difference, verdict = self._bit_size_come_to_verdict(
                 ret_val, skillings_mack_pvalue
             )
@@ -2478,6 +2478,14 @@ class Analysis(object):
             )
 
     def analyze_bit_sizes(self):
+        name = join(self.output, self.measurements_filename)
+        name_bin = self._remove_suffix(name, '.csv') + '.bin'
+        self._long_format_to_binary(name, name_bin)
+        self._k_sizes_totals(name_bin)
+
+        return self._analyze_bit_sizes()
+
+    def _analyze_bit_sizes(self):
         """
         Analyses K bit-sizes and creates the plots and the test result files
         which are placed in an analysis_results directory in the output folder.


### PR DESCRIPTION

### Description
I was tinkering with the minerva analysis script and encountered two crashes:

1) ValueError: NoneType has no value curve when computing ecdsa-k-time-map.csv in ecdsa_iter
2) ValueError: self._k_sizes is None when running analyze_bit_sizes in test-tls13-minerva.py


### Motivation and Context
1) Is root caused to the fact that the minerva script instantiates an Extract instance, passing a key type of "ecdsa" rather than "ec" to the construtor.  The Extract class expects only "ec" to be passed, and when its not the right value, there is no private key instance created in the extractor.  As a result when the extractor interrogates the keys curve type in ecdsa_iter->ecsa_message_to_int , we attempt to get self.priv_key.curve.baselen, but self.priv_key is None, and so the script crashes

This is fixed by the first commit, which corrects  the minerva script to pass "ec" rather than "ecdsa" to the Extract class

2) Is root caused to the fact that, when running analysis.analyze_bit_sizes, it is assumed that self.k_sizes is already computed, but that only happens when running analysis.generate_report, and so we get a crash.

This is fixed by the second commit, which bifurcates analyze_bit_sizes into a public function and a private function, the former of which computes self._k_sizes in the same way that generate_report does.


### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tlsfuzzer/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see CI results)
- [ ] [test script checklist](https://github.com/tlsfuzzer/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/1037)
<!-- Reviewable:end -->
