### PR TITLE
Fix bare except in runner.py: use except Exception

### DIFF
--- a/tlsfuzzer/runner.py
+++ b/tlsfuzzer/runner.py
@@ -277,7 +277,7 @@ class Runner(object):
                     continue
                 else:
                     raise AssertionError("Unknown decision tree node")
-        except:
+        except Exception:
             if self.state.msg_sock:
                 self.state.msg_sock.sock.close()
             # TODO put into a log


### PR DESCRIPTION
The bare `except:` clause in `runner.py` line 280 catches `BaseException`, including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`. This can suppress signals and interpreter shutdown attempts unexpectedly.

Change `except:` to `except Exception:` to only catch actual exceptions while letting system-level signals propagate normally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlsfuzzer/tlsfuzzer/1039)
<!-- Reviewable:end -->
